### PR TITLE
Change Contracts namespace from Microsoft.Sbom.Contracts --> Microsoft.Sbom.Api.Contracts

### DIFF
--- a/src/Microsoft.Sbom.Api.Contracts/Checksum.cs
+++ b/src/Microsoft.Sbom.Api.Contracts/Checksum.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Sbom.Api.Contracts.Enums;
 using System;
 using System.Collections.Generic;
-using Microsoft.Sbom.Contracts.Enums;
 
-namespace Microsoft.Sbom.Contracts
+namespace Microsoft.Sbom.Api.Contracts
 {
     /// <summary>
     /// Represents a checksum for a file or package.

--- a/src/Microsoft.Sbom.Api.Contracts/Entities/AlgorithmNames.cs
+++ b/src/Microsoft.Sbom.Api.Contracts/Entities/AlgorithmNames.cs
@@ -1,12 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Sbom.Contracts.Enums;
-using Microsoft.Sbom.Contracts.Interfaces;
-using System;
+using Microsoft.Sbom.Api.Contracts.Enums;
+using Microsoft.Sbom.Api.Contracts.Interfaces;
 using System.Collections.Generic;
 
-namespace Microsoft.Sbom.Contracts.Contracts.Entities
+namespace Microsoft.Sbom.Api.Contracts.Entities
 {
     public class AlgorithmNames : IAlgorithmNames
     {

--- a/src/Microsoft.Sbom.Api.Contracts/Entities/Entity.cs
+++ b/src/Microsoft.Sbom.Api.Contracts/Entities/Entity.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Sbom.Contracts.Enums;
+using Microsoft.Sbom.Api.Contracts.Enums;
 
-namespace Microsoft.Sbom.Contracts.Entities
+namespace Microsoft.Sbom.Api.Contracts.Entities
 {
     /// <summary>
     /// Represents a single entity in a SBOM, such as a file or package.

--- a/src/Microsoft.Sbom.Api.Contracts/Entities/FileEntity.cs
+++ b/src/Microsoft.Sbom.Api.Contracts/Entities/FileEntity.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Sbom.Contracts.Enums;
+using Microsoft.Sbom.Api.Contracts.Enums;
 using System;
 
-namespace Microsoft.Sbom.Contracts.Entities
+namespace Microsoft.Sbom.Api.Contracts.Entities
 {
     /// <summary>
     /// Represents a single file in a SBOM.

--- a/src/Microsoft.Sbom.Api.Contracts/Entities/PackageEntity.cs
+++ b/src/Microsoft.Sbom.Api.Contracts/Entities/PackageEntity.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Sbom.Api.Contracts.Enums;
 using System;
-using Microsoft.Sbom.Contracts.Enums;
 
-namespace Microsoft.Sbom.Contracts.Entities
+namespace Microsoft.Sbom.Api.Contracts.Entities
 {
     /// <summary>
     /// Represents a single package in a SBOM.

--- a/src/Microsoft.Sbom.Api.Contracts/EntityError.cs
+++ b/src/Microsoft.Sbom.Api.Contracts/EntityError.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Sbom.Contracts.Entities;
-using Microsoft.Sbom.Contracts.Enums;
+using Microsoft.Sbom.Api.Contracts.Entities;
+using Microsoft.Sbom.Api.Contracts.Enums;
 
-namespace Microsoft.Sbom.Contracts
+namespace Microsoft.Sbom.Api.Contracts
 {
     /// <summary>
     /// Represents a single error for a given entity. The entity could be a file or package.

--- a/src/Microsoft.Sbom.Api.Contracts/Enums/AlgorithmName.cs
+++ b/src/Microsoft.Sbom.Api.Contracts/Enums/AlgorithmName.cs
@@ -5,7 +5,7 @@ using System;
 using System.IO;
 using System.Security.Cryptography;
 
-namespace Microsoft.Sbom.Contracts.Enums
+namespace Microsoft.Sbom.Api.Contracts.Enums
 {
     /// <summary>
     /// A list of the names of the hash algorithms that are supported by this SBOM api.

--- a/src/Microsoft.Sbom.Api.Contracts/Enums/EntityType.cs
+++ b/src/Microsoft.Sbom.Api.Contracts/Enums/EntityType.cs
@@ -3,7 +3,7 @@
 
 using System.Runtime.Serialization;
 
-namespace Microsoft.Sbom.Contracts.Enums
+namespace Microsoft.Sbom.Api.Contracts.Enums
 {
     /// <summary>
     /// Represents an entity in a SBOM, like a package or file.

--- a/src/Microsoft.Sbom.Api.Contracts/Enums/ErrorType.cs
+++ b/src/Microsoft.Sbom.Api.Contracts/Enums/ErrorType.cs
@@ -3,7 +3,7 @@
 
 using System.Runtime.Serialization;
 
-namespace Microsoft.Sbom.Contracts.Enums
+namespace Microsoft.Sbom.Api.Contracts.Enums
 {
     /// <summary>
     /// The type of <see cref="EntityError"/> for a given entity.

--- a/src/Microsoft.Sbom.Api.Contracts/Enums/FileType.cs
+++ b/src/Microsoft.Sbom.Api.Contracts/Enums/FileType.cs
@@ -3,7 +3,7 @@
 
 using System.Runtime.Serialization;
 
-namespace Microsoft.Sbom.Contracts.Enums
+namespace Microsoft.Sbom.Api.Contracts.Enums
 {
     /// <summary>
     /// Represents the type of a file.

--- a/src/Microsoft.Sbom.Api.Contracts/ISBOMGenerator.cs
+++ b/src/Microsoft.Sbom.Api.Contracts/ISBOMGenerator.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Sbom.Api.Contracts.Enums;
 using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
-using Microsoft.Sbom.Contracts.Enums;
 
-namespace Microsoft.Sbom.Contracts
+namespace Microsoft.Sbom.Api.Contracts
 {
     /// <summary>
     /// Provides an API interface to the SBOM generator workflow.

--- a/src/Microsoft.Sbom.Api.Contracts/Interfaces/IAlgorithmNames.cs
+++ b/src/Microsoft.Sbom.Api.Contracts/Interfaces/IAlgorithmNames.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Sbom.Contracts.Enums;
+using Microsoft.Sbom.Api.Contracts.Enums;
 using System.Collections.Generic;
 
-namespace Microsoft.Sbom.Contracts.Interfaces
+namespace Microsoft.Sbom.Api.Contracts.Interfaces
 {
     /// <summary>
     /// The implemention of this interface should provide a list of hashing algorithms that can be

--- a/src/Microsoft.Sbom.Api.Contracts/LicenseInfo.cs
+++ b/src/Microsoft.Sbom.Api.Contracts/LicenseInfo.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.Sbom.Contracts
+namespace Microsoft.Sbom.Api.Contracts
 {
     /// <summary>
     /// Defines license strings for an entity.

--- a/src/Microsoft.Sbom.Api.Contracts/Microsoft.Sbom.Api.Contracts.csproj
+++ b/src/Microsoft.Sbom.Api.Contracts/Microsoft.Sbom.Api.Contracts.csproj
@@ -1,7 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>Microsoft.Sbom.Api.Contracts</RootNamespace>
   </PropertyGroup>
 
 </Project>

--- a/src/Microsoft.Sbom.Api.Contracts/RuntimeConfiguration.cs
+++ b/src/Microsoft.Sbom.Api.Contracts/RuntimeConfiguration.cs
@@ -3,7 +3,7 @@
 
 using System.Diagnostics.Tracing;
 
-namespace Microsoft.Sbom.Contracts
+namespace Microsoft.Sbom.Api.Contracts
 {
     /// <summary>
     /// Define additional configuration keys here to tweak the execution of the SBOM library.

--- a/src/Microsoft.Sbom.Api.Contracts/SBOMFile.cs
+++ b/src/Microsoft.Sbom.Api.Contracts/SBOMFile.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Sbom.Contracts.Enums;
 using System.Collections.Generic;
 
-namespace Microsoft.Sbom.Contracts
+namespace Microsoft.Sbom.Api.Contracts
 {
     /// <summary>
     /// Customer facing structure that represents a file in a SBOM.

--- a/src/Microsoft.Sbom.Api.Contracts/SBOMGenerationResult.cs
+++ b/src/Microsoft.Sbom.Api.Contracts/SBOMGenerationResult.cs
@@ -3,7 +3,7 @@
 
 using System.Collections.Generic;
 
-namespace Microsoft.Sbom.Contracts
+namespace Microsoft.Sbom.Api.Contracts
 {
     /// <summary>
     /// Represents the result of a SBOM generation action.

--- a/src/Microsoft.Sbom.Api.Contracts/SBOMMetadata.cs
+++ b/src/Microsoft.Sbom.Api.Contracts/SBOMMetadata.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Sbom.Contracts.Enums;
-
-namespace Microsoft.Sbom.Contracts
+namespace Microsoft.Sbom.Api.Contracts
 {
     /// <summary>
     /// Use this class to provide addtional metadata to the SBOM generator 

--- a/src/Microsoft.Sbom.Api.Contracts/SBOMPackage.cs
+++ b/src/Microsoft.Sbom.Api.Contracts/SBOMPackage.cs
@@ -3,7 +3,7 @@
 
 using System.Collections.Generic;
 
-namespace Microsoft.Sbom.Contracts
+namespace Microsoft.Sbom.Api.Contracts
 {
     /// <summary>
     /// A structure that represents a package in a SBOM.

--- a/src/Microsoft.Sbom.Api.Contracts/SBOMSpecification.cs
+++ b/src/Microsoft.Sbom.Api.Contracts/SBOMSpecification.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Microsoft.Sbom.Contracts
+namespace Microsoft.Sbom.Api.Contracts
 {
     /// <summary>
     /// Represents the specification of the SBOM.

--- a/src/Microsoft.Sbom.Extensions/Entities/GenerationData.cs
+++ b/src/Microsoft.Sbom.Extensions/Entities/GenerationData.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Sbom.Contracts;
+using Microsoft.Sbom.Api.Contracts;
 using System.Collections.Generic;
 
 namespace ManifestInterface.Entities


### PR DESCRIPTION
This change is to make namespaces match name of the project. In addition I also flattened contracts structure to make file structure match namespace structure and prevent duplicate wording (Microsoft.Sbom.Api.Contracts.Contracts specifically).