### PR TITLE
Update namespaces

### DIFF
--- a/Microsoft.Sbom.sln
+++ b/Microsoft.Sbom.sln
@@ -15,9 +15,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Sbom.Contracts", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Sbom.Adapters.Tests", "test\Microsoft.Sbom.Adapters.Tests\Microsoft.Sbom.Adapters.Tests.csproj", "{4F5EA400-F98B-4010-A8E1-D55A96428B07}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Sbom.SPDX22SBOMParser", "src\Microsoft.Sbom.SPDX22SBOMParser\Microsoft.Sbom.SPDX22SBOMParser.csproj", "{86EC977D-A785-40FF-AE78-C1EC4254AFF8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Sbom.Parsers.Spdx22SbomParser", "src\Microsoft.Sbom.Parsers.Spdx22SbomParser\Microsoft.Sbom.Parsers.Spdx22SbomParser.csproj", "{86EC977D-A785-40FF-AE78-C1EC4254AFF8}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Sbom.SPDX22SBOMParser.Tests", "test\Microsoft.Sbom.SPDX22SBOMParser.Tests\Microsoft.Sbom.SPDX22SBOMParser.Tests.csproj", "{ADDEE422-40D1-48D9-A5FB-BBE990272B78}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests", "test\Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests\Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests.csproj", "{ADDEE422-40D1-48D9-A5FB-BBE990272B78}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Sbom.Api", "src\Microsoft.Sbom.Api\Microsoft.Sbom.Api.csproj", "{725723C5-DCA4-4BAD-8883-CC94E5F5A5A8}"
 EndProject

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/CargoComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/CargoComponentExtensions.cs
@@ -4,7 +4,7 @@
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.Sbom.Contracts;
 
-namespace Microsoft.Sbom.Adapters.Adapters.ComponentDetection
+namespace Microsoft.Sbom.Adapters.ComponentDetection
 {
     /// <summary>
     /// Extensions methods for <see cref="CargoComponent"/>.

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/CondaComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/CondaComponentExtensions.cs
@@ -6,7 +6,7 @@ using Microsoft.Sbom.Contracts;
 using Microsoft.Sbom.Contracts.Enums;
 using System.Collections.Generic;
 
-namespace Microsoft.Sbom.Adapters.Adapters.ComponentDetection
+namespace Microsoft.Sbom.Adapters.ComponentDetection
 {
     /// <summary>
     /// Extensions methods for <see cref="CondaComponent"/>.

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/DockerImageComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/DockerImageComponentExtensions.cs
@@ -6,7 +6,7 @@ using Microsoft.Sbom.Contracts;
 using Microsoft.Sbom.Contracts.Enums;
 using System.Collections.Generic;
 
-namespace Microsoft.Sbom.Adapters.Adapters.ComponentDetection
+namespace Microsoft.Sbom.Adapters.ComponentDetection
 {
     /// <summary>
     /// Extensions methods for <see cref="DockerImageComponent"/>.

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/GitComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/GitComponentExtensions.cs
@@ -6,7 +6,7 @@ using Microsoft.Sbom.Contracts;
 using Microsoft.Sbom.Contracts.Enums;
 using System.Collections.Generic;
 
-namespace Microsoft.Sbom.Adapters.Adapters.ComponentDetection
+namespace Microsoft.Sbom.Adapters.ComponentDetection
 {
     /// <summary>
     /// Extensions methods for <see cref="GitComponent"/>.

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/GoComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/GoComponentExtensions.cs
@@ -6,7 +6,7 @@ using Microsoft.Sbom.Contracts;
 using Microsoft.Sbom.Contracts.Enums;
 using System.Collections.Generic;
 
-namespace Microsoft.Sbom.Adapters.Adapters.ComponentDetection
+namespace Microsoft.Sbom.Adapters.ComponentDetection
 {
     /// <summary>
     /// Extensions methods for <see cref="GoComponent"/>.

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/LinuxComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/LinuxComponentExtensions.cs
@@ -4,7 +4,7 @@
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.Sbom.Contracts;
 
-namespace Microsoft.Sbom.Adapters.Adapters.ComponentDetection
+namespace Microsoft.Sbom.Adapters.ComponentDetection
 {
     /// <summary>
     /// Extensions methods for <see cref="LinuxComponent"/>.

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/Logging/LoggingHelper.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/Logging/LoggingHelper.cs
@@ -5,7 +5,7 @@ using System;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.Sbom.Adapters.Report;
 
-namespace Microsoft.Sbom.Adapters.Adapters.ComponentDetection.Logging
+namespace Microsoft.Sbom.Adapters.ComponentDetection.Logging
 {
     /// <summary>
     /// A set of static helper methods used by the component detection adapter for logging.

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/MavenComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/MavenComponentExtensions.cs
@@ -4,7 +4,7 @@
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.Sbom.Contracts;
 
-namespace Microsoft.Sbom.Adapters.Adapters.ComponentDetection
+namespace Microsoft.Sbom.Adapters.ComponentDetection
 {
     /// <summary>
     /// Extensions methods for <see cref="MavenComponent"/>.

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/NpmComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/NpmComponentExtensions.cs
@@ -6,7 +6,7 @@ using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.Sbom.Contracts;
 using System.Collections.Generic;
 
-namespace Microsoft.Sbom.Adapters.Adapters.ComponentDetection
+namespace Microsoft.Sbom.Adapters.ComponentDetection
 {
     /// <summary>
     /// Extensions methods for <see cref="NpmComponent"/>.

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/NuGetComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/NuGetComponentExtensions.cs
@@ -5,7 +5,7 @@ using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.Sbom.Contracts;
 using System.Linq;
 
-namespace Microsoft.Sbom.Adapters.Adapters.ComponentDetection
+namespace Microsoft.Sbom.Adapters.ComponentDetection
 {
     /// <summary>
     /// Extensions methods for <see cref="NuGetComponent"/>.

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/OtherComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/OtherComponentExtensions.cs
@@ -5,7 +5,7 @@ using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.Sbom.Contracts;
 using System.Collections.Generic;
 
-namespace Microsoft.Sbom.Adapters.Adapters.ComponentDetection
+namespace Microsoft.Sbom.Adapters.ComponentDetection
 {
     /// <summary>
     /// Extensions methods for <see cref="OtherComponent"/>.

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/PipComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/PipComponentExtensions.cs
@@ -4,7 +4,7 @@
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.Sbom.Contracts;
 
-namespace Microsoft.Sbom.Adapters.Adapters.ComponentDetection
+namespace Microsoft.Sbom.Adapters.ComponentDetection
 {
     /// <summary>
     /// Extensions methods for <see cref="PipComponent"/>.

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/PodComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/PodComponentExtensions.cs
@@ -4,7 +4,7 @@
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.Sbom.Contracts;
 
-namespace Microsoft.Sbom.Adapters.Adapters.ComponentDetection
+namespace Microsoft.Sbom.Adapters.ComponentDetection
 {
     /// <summary>
     /// Extensions methods for <see cref="PodComponent"/>.

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/RubyGemsComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/RubyGemsComponentExtensions.cs
@@ -4,7 +4,7 @@
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.Sbom.Contracts;
 
-namespace Microsoft.Sbom.Adapters.Adapters.ComponentDetection
+namespace Microsoft.Sbom.Adapters.ComponentDetection
 {
     /// <summary>
     /// Extensions methods for <see cref="RubyGemsComponent"/>.

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/ScannedComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/ScannedComponentExtensions.cs
@@ -5,10 +5,10 @@ using System;
 using Microsoft.Sbom.Adapters.Report;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.Sbom.Contracts;
-using Microsoft.Sbom.Adapters.Adapters.ComponentDetection.Logging;
+using Microsoft.Sbom.Adapters.ComponentDetection.Logging;
 using Microsoft.ComponentDetection.Contracts.BcdeModels;
 
-namespace Microsoft.Sbom.Adapters.Adapters.ComponentDetection
+namespace Microsoft.Sbom.Adapters.ComponentDetection
 {
     /// <summary>
     /// Extensions methods for <see cref="ScannedComponent"/>.

--- a/src/Microsoft.Sbom.Adapters/ComponentDetectionToSBOMPackageAdapter.cs
+++ b/src/Microsoft.Sbom.Adapters/ComponentDetectionToSBOMPackageAdapter.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Sbom.Adapters.Adapters.ComponentDetection;
+using Microsoft.Sbom.Adapters.ComponentDetection;
 using Microsoft.Sbom.Adapters.Report;
 using Newtonsoft.Json;
 using System.Collections.Generic;

--- a/src/Microsoft.Sbom.Adapters/Microsoft.Sbom.Adapters.csproj
+++ b/src/Microsoft.Sbom.Adapters/Microsoft.Sbom.Adapters.csproj
@@ -2,13 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <AssemblyName>Microsoft.SBOM.Adapters</AssemblyName>
+    <AssemblyName>Microsoft.Sbom.Adapters</AssemblyName>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Description>Provides a set of adapters from external component formats to a single SBOM format.</Description>
     <Nullable>enable</Nullable>
-    <!--NU5104: Warning thrown because Microsoft.VisualStudio.Services.Governance.ComponentDetection.Contracts is a "prerelease" package.-->
-    <!--Note: due to a bug in dotnet, this needs to be a global nowarn instead of for the specific package it is trying to suppress.-->
-    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Sbom.Api/Executors/ComponentToPackageInfoConverter.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ComponentToPackageInfoConverter.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.ComponentDetection.Contracts.BcdeModels;
-using Microsoft.Sbom.Adapters.Adapters.ComponentDetection;
+using Microsoft.Sbom.Adapters.ComponentDetection;
 using Microsoft.Sbom.Adapters.Report;
 using Microsoft.Sbom.Api.Entities;
 using Microsoft.Sbom.Contracts;

--- a/src/Microsoft.Sbom.Api/Microsoft.Sbom.Api.csproj
+++ b/src/Microsoft.Sbom.Api/Microsoft.Sbom.Api.csproj
@@ -41,7 +41,7 @@
       <ProjectReference Include="..\Microsoft.Sbom.Common\Microsoft.Sbom.Common.csproj" />
       <ProjectReference Include="..\Microsoft.Sbom.Contracts\Microsoft.Sbom.Contracts.csproj" />
       <ProjectReference Include="..\Microsoft.Sbom.Extensions\Microsoft.Sbom.Extensions.csproj" />
-      <ProjectReference Include="..\Microsoft.Sbom.SPDX22SBOMParser\Microsoft.Sbom.SPDX22SBOMParser.csproj" />
+      <ProjectReference Include="..\Microsoft.Sbom.Parsers.Spdx22SbomParser\Microsoft.Sbom.Parsers.Spdx22SbomParser.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Constants.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Constants.cs
@@ -4,7 +4,7 @@
 using Microsoft.Sbom.Extensions.Entities;
 using System.Collections.Generic;
 
-namespace Microsoft.SPDX22SBOMParser
+namespace Microsoft.Sbom.Parsers.Spdx22SbomParser
 {
     internal class Constants
     {

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Checksum.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Checksum.cs
@@ -3,7 +3,7 @@
 
 using System.Text.Json.Serialization;
 
-namespace Microsoft.SPDX22SBOMParser.Entities
+namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities
 {
     /// <summary>
     /// Represents the hash value of the file using the algorithm specified.

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/CreationInfo.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/CreationInfo.cs
@@ -4,7 +4,7 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
-namespace Microsoft.SPDX22SBOMParser.Entities
+namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities
 {
     /// <summary>
     /// Used to define creation information about the SBOM.

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Creator.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Creator.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.SPDX22SBOMParser.Entities
+namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities
 {
     internal class Creator
     {

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Enums/ExternalRepositoryType.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Enums/ExternalRepositoryType.cs
@@ -4,7 +4,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
-namespace Microsoft.SPDX22SBOMParser.Entities.Enums
+namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities.Enums
 {
     /// <summary>
     /// Type of the external reference. These are definined in an appendix in the SPDX specification.

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Enums/ReferenceCategory.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Enums/ReferenceCategory.cs
@@ -3,7 +3,7 @@
 
 using System.Text.Json.Serialization;
 
-namespace Microsoft.SPDX22SBOMParser.Entities.Enums
+namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities.Enums
 {
     /// <summary>
     /// Defines a Category for an external package reference.

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Enums/SPDXFileType.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Enums/SPDXFileType.cs
@@ -3,7 +3,7 @@
 
 using System.Text.Json.Serialization;
 
-namespace Microsoft.SPDX22SBOMParser.Entities.Enums
+namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities.Enums
 {
     /// <summary>
     /// This field provides information about the type of file identified.

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Enums/SPDXRelationshipType.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Enums/SPDXRelationshipType.cs
@@ -3,7 +3,7 @@
 
 using System.Text.Json.Serialization;
 
-namespace Microsoft.SPDX22SBOMParser.Entities.Enums
+namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities.Enums
 {
     /// <summary>
     /// Defines the type of <see cref="SPDXRelationship"/> between the source and the 

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/ExternalReference.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/ExternalReference.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.SPDX22SBOMParser.Entities.Enums;
+using Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities.Enums;
 using System.Text.Json.Serialization;
 
-namespace Microsoft.SPDX22SBOMParser.Entities
+namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities
 {
     /// <summary>
     /// Defines a reference to an external source of additional information, metadata,

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/PackageVerificationCode.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/PackageVerificationCode.cs
@@ -4,7 +4,7 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
-namespace Microsoft.SPDX22SBOMParser.Entities
+namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities
 {
     /// <summary>
     /// Used to specify a hash code that describes all the individual

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SPDX22Document.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SPDX22Document.cs
@@ -4,7 +4,7 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
-namespace Microsoft.SPDX22SBOMParser.Entities
+namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities
 {
     internal class SPDX22Document
     {

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SPDXPackage.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SPDXPackage.cs
@@ -4,7 +4,7 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
-namespace Microsoft.SPDX22SBOMParser.Entities
+namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities
 {
     /// <summary>
     /// Represents a SPDX 2.2 Package.

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SPDXRelationship.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SPDXRelationship.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.SPDX22SBOMParser.Entities.Enums;
+using Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities.Enums;
 using System.Text.Json.Serialization;
 
-namespace Microsoft.SPDX22SBOMParser.Entities
+namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities
 {
     /// <summary>
     /// Defines relationships between elements in the current SBOM.

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SpdxExternalDocumentReference.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SpdxExternalDocumentReference.cs
@@ -3,7 +3,7 @@
 
 using System.Text.Json.Serialization;
 
-namespace Microsoft.SPDX22SBOMParser.Entities
+namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities
 {
     /// <summary>
     /// SPDX 2.2 format External Document reference.

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SpdxFile.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SpdxFile.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.SPDX22SBOMParser.Entities.Enums;
+using Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities.Enums;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
-namespace Microsoft.SPDX22SBOMParser.Entities
+namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities
 {
     public class SPDXFile
     {

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Exceptions/MissingHashValueException.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Exceptions/MissingHashValueException.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Runtime.Serialization;
 
-namespace Microsoft.SPDX22SBOMParser.Exceptions
+namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Exceptions
 {
     [Serializable]
     internal class MissingHashValueException : Exception

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Generator.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Generator.cs
@@ -5,16 +5,16 @@ using Microsoft.Sbom.Extensions;
 using Microsoft.Sbom.Extensions.Entities;
 using Microsoft.Sbom.Contracts;
 using Microsoft.Sbom.Contracts.Enums;
-using Microsoft.SPDX22SBOMParser.Entities;
-using Microsoft.SPDX22SBOMParser.Entities.Enums;
-using Microsoft.SPDX22SBOMParser.Exceptions;
-using Microsoft.SPDX22SBOMParser.Utils;
+using Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
+using Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities.Enums;
+using Microsoft.Sbom.Parsers.Spdx22SbomParser.Exceptions;
+using Microsoft.Sbom.Parsers.Spdx22SbomParser.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 
-namespace Microsoft.SPDX22SBOMParser
+namespace Microsoft.Sbom.Parsers.Spdx22SbomParser
 {
     /// <summary>
     /// Generates a SPDX 2.2 format SBOM document.

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Microsoft.Sbom.Parsers.Spdx22SbomParser.csproj
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Microsoft.Sbom.Parsers.Spdx22SbomParser.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <AssemblyName>Microsoft.Parsers.SPDX22SBOMParser</AssemblyName>
+    <AssemblyName>Microsoft.Sbom.Parsers.Spdx22SbomParser</AssemblyName>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/IdentityUtils.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/IdentityUtils.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.Sbom.Extensions;
 using Microsoft.Sbom.Extensions.Entities;
-using Microsoft.SPDX22SBOMParser.Entities;
+using Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,7 +11,7 @@ using System.Security.Cryptography;
 using System.Text;
 using HashAlgorithmName = Microsoft.Sbom.Contracts.Enums.AlgorithmName;
 
-namespace Microsoft.SPDX22SBOMParser.Utils
+namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Utils
 {
     /// <summary>
     /// Provides helper functions to generate identity strings for SPDX.

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/SPDXExtensions.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/SPDXExtensions.cs
@@ -4,8 +4,8 @@
 using Microsoft.Sbom.Extensions.Exceptions;
 using Microsoft.Sbom.Contracts;
 using Microsoft.Sbom.Contracts.Enums;
-using Microsoft.SPDX22SBOMParser.Entities;
-using Microsoft.SPDX22SBOMParser.Entities.Enums;
+using Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
+using Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities.Enums;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,7 +13,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
 
-namespace Microsoft.SPDX22SBOMParser.Utils
+namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Utils
 {
     /// <summary>
     /// Provides extensions to SPDX objects.

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Validator.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Validator.cs
@@ -5,7 +5,7 @@ using Microsoft.Sbom.Extensions;
 using Microsoft.Sbom.Extensions.Entities;
 using System;
 
-namespace Microsoft.SPDX22SBOMParser
+namespace Microsoft.Sbom.Parsers.Spdx22SbomParser
 {
     /// <summary>
     /// Validates files in a folder against their checksums stored in an SPDX 2.2 SBOM. 

--- a/test/Microsoft.Sbom.Adapters.Tests/ComponentDetectionToSBOMPackageAdapterTests.cs
+++ b/test/Microsoft.Sbom.Adapters.Tests/ComponentDetectionToSBOMPackageAdapterTests.cs
@@ -9,12 +9,12 @@ using System.Linq;
 using Microsoft.Sbom.Adapters.Report;
 using Microsoft.Sbom.Contracts;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
-using Microsoft.Sbom.Adapters.Adapters.ComponentDetection;
+using Microsoft.Sbom.Adapters.ComponentDetection;
 using Microsoft.ComponentDetection.Contracts.BcdeModels;
 using Microsoft.Sbom.Contracts.Enums;
 using Microsoft.ComponentDetection.Contracts.Internal;
 
-namespace Microsoft.Sbom.Adapters.Adapters.Tests
+namespace Microsoft.Sbom.Adapters.Tests
 {
     [TestClass]
     public class ComponentDetectionToSBOMPackageAdapterTests

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests.csproj
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" >
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Microsoft.Sbom.SPDX22SBOMParser\Microsoft.Sbom.SPDX22SBOMParser.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.Sbom.Parsers.Spdx22SbomParser\Microsoft.Sbom.Parsers.Spdx22SbomParser.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Utils/IdentityUtilsTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Utils/IdentityUtilsTests.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System.ComponentModel;
 
-namespace Microsoft.SPDX22SBOMParser.Utils.Tests
+namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Utils.Tests
 {
     [TestClass]
     public class IdentityUtilsTests

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Utils/SPDXExtensionsTest.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Utils/SPDXExtensionsTest.cs
@@ -3,9 +3,9 @@
 
 using Microsoft.Sbom.Contracts;
 using Microsoft.Sbom.Contracts.Enums;
-using Microsoft.SPDX22SBOMParser.Entities;
-using Microsoft.SPDX22SBOMParser.Entities.Enums;
-using Microsoft.SPDX22SBOMParser.Utils;
+using Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
+using Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities.Enums;
+using Microsoft.Sbom.Parsers.Spdx22SbomParser.Utils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;


### PR DESCRIPTION
- Change SPDX22 parser namespace to Microsoft.Sbom.Parsers.Spdx22SbomParser
- Rename Microsoft.SBOM.Adapters to Microsoft.Sbom.Adapters
- Remove redundant Adapters.Adapters namespace