### PR TITLE
fix: GH action gen-docs need match file_pattern

### DIFF
--- a/.github/workflows/gen-docs.yml
+++ b/.github/workflows/gen-docs.yml
@@ -46,5 +46,5 @@ jobs:
       - name: Commit
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: 'Update docs'
-          file_pattern: '*.md'
+          commit_message: 'Auto update docs/*.md'
+          file_pattern: 'docs/*.md'


### PR DESCRIPTION
Issue:
docs not get updated by GH action, see log: https://github.com/microsoft/sbom-tool/runs/7346957735?check_suite_focus=true
Since sbom-tools-arguments.md was (probably) first lived in GIT_ROOT, then later moved to "docs" folder, this need to be updated
Ref: 
https://github.com/stefanzweifel/git-auto-commit-action/blob/488db3d5039c2879d03cb74567b8215a01208a9e/action.yml#L27