### PR TITLE
Pacakge external references values should have dash character instead…

### DIFF
--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/ExternalReference.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/ExternalReference.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities
         /// Gets or sets the category for the external reference.
         /// </summary>
         [JsonPropertyName("referenceCategory")]
-        public ReferenceCategory ReferenceCategory { get; set; }
+        public string ReferenceCategory { get; set; }
 
         /// <summary>
         /// Gets or sets type of the external reference. These are definined in an appendix in the SPDX specification.

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/SPDXExtensions.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/SPDXExtensions.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Utils
                 // Create a new PURL external reference.
                 var extRef = new ExternalReference
                 {
-                    ReferenceCategory = ReferenceCategory.PACKAGE_MANAGER,
+                    ReferenceCategory = ReferenceCategory.PACKAGE_MANAGER.ToNormalizedString(),
                     Type = ExternalRepositoryType.purl,
                     Locator = FormatPackageUrl(packageInfo.PackageUrl)
                 };
@@ -191,6 +191,16 @@ namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Utils
             return reference.ExternalDocumentId;
         }
 
+        /// <summary>
+        /// Extension method to normalize the string value of <see cref="ReferenceCategory"/> to be compliant with SPDX 2.2 spec.
+        /// </summary>
+        /// <param name="referenceCategory"></param>
+        /// <returns>A reference category value complaint with the SPDX 2.2 spec.</returns>
+        public static string ToNormalizedString(this ReferenceCategory referenceCategory)
+        {
+            return referenceCategory.ToString().Replace('_', '-');
+        }
+
         /// Compute the SHA256 string representation (omitting dashes) of a given string
         /// </summary>
         /// <remarks>
@@ -202,5 +212,7 @@ namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Utils
             var spdxId = BitConverter.ToString(hash).Replace("-", string.Empty);
             return spdxId;
         }
+
+
     }
 }

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/SPDXExtensions.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/SPDXExtensions.cs
@@ -212,7 +212,5 @@ namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Utils
             var spdxId = BitConverter.ToString(hash).Replace("-", string.Empty);
             return spdxId;
         }
-
-
     }
 }

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Utils/SPDXExtensionsTest.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Utils/SPDXExtensionsTest.cs
@@ -43,7 +43,7 @@ namespace SPDX22SBOMParserTest
         {
             spdxPackage.AddPackageUrls(packageInfo);
             var externalRef = spdxPackage.ExternalReferences.First();
-            Assert.AreEqual(ReferenceCategory.PACKAGE_MANAGER, externalRef.ReferenceCategory);
+            Assert.AreEqual(ReferenceCategory.PACKAGE_MANAGER.ToNormalizedString(), externalRef.ReferenceCategory);
             Assert.AreEqual(ExternalRepositoryType.purl, externalRef.Type);
             Assert.AreEqual(PackageUrl, externalRef.Locator);
         }
@@ -83,7 +83,7 @@ namespace SPDX22SBOMParserTest
 
             var externalRef = spdxPackage.ExternalReferences.First();
 
-            Assert.AreEqual(ReferenceCategory.PACKAGE_MANAGER, externalRef.ReferenceCategory);
+            Assert.AreEqual(ReferenceCategory.PACKAGE_MANAGER.ToNormalizedString(), externalRef.ReferenceCategory);
             Assert.AreEqual(ExternalRepositoryType.purl, externalRef.Type);
             Assert.AreEqual(expectedUrl, externalRef.Locator);
         }
@@ -132,6 +132,18 @@ namespace SPDX22SBOMParserTest
             var spdxId = spdxFile.AddSpdxId(fileName, checksums);
 
             Assert.AreEqual(spdxId, spdxFile.SPDXId);
+        }
+
+        [TestMethod]
+        public void ReferenceCategoryToNormalizedString_DoesNotContainUnderscore()
+        {
+            foreach (ReferenceCategory referenceCategory in Enum.GetValues(typeof(ReferenceCategory)))
+            {
+                var value = referenceCategory.ToNormalizedString();
+                Assert.IsFalse(
+                    value.Contains('_'), 
+                    $"The value {value} of the {nameof(ReferenceCategory)} enum contains an underscore character.");
+            }
         }
     }
 }


### PR DESCRIPTION
… of underscore to meet SPDX 2.2 specs
Fix #108 