### PR TITLE
Change the initial value of the startup project to Microsoft.Sbom.Tool

### DIFF
--- a/Microsoft.Sbom.sln
+++ b/Microsoft.Sbom.sln
@@ -3,6 +3,8 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.2.32505.173
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Sbom.Tool", "src\Microsoft.Sbom.Tool\Microsoft.Sbom.Tool.csproj", "{3B51DBCC-7305-42B9-8CBB-422F4291AF8E}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Sbom.Extensions", "src\Microsoft.Sbom.Extensions\Microsoft.Sbom.Extensions.csproj", "{256D50F7-5B0E-4394-81E0-DCEE32F96634}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Sbom.Common", "src\Microsoft.Sbom.Common\Microsoft.Sbom.Common.csproj", "{07A58335-CBFF-4A50-9B25-066A1F223894}"
@@ -28,8 +30,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Sbom.Api", "src\Microsoft.Sbom.Api\Microsoft.Sbom.Api.csproj", "{725723C5-DCA4-4BAD-8883-CC94E5F5A5A8}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Sbom.Api.Tests", "test\Microsoft.Sbom.Api.Tests\Microsoft.Sbom.Api.Tests.csproj", "{4F94EA4F-CC6B-4FA0-8A7E-654EAA26B625}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Sbom.Tool", "src\Microsoft.Sbom.Tool\Microsoft.Sbom.Tool.csproj", "{3B51DBCC-7305-42B9-8CBB-422F4291AF8E}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{1A9688BD-D306-4091-A319-FDE110A48CBD}"
 	ProjectSection(SolutionItems) = preProject


### PR DESCRIPTION
Changed so that startup project configuration is no longer required after cloning a repository.