### PR TITLE
Added SBOM packages parser

### DIFF
--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/ParserUtils.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/ParserUtils.cs
@@ -80,6 +80,16 @@ internal class ParserUtils
         }
     }
 
+
+    internal static void SkipFirstArrayToken(Stream stream, ref byte[] buffer, ref Utf8JsonReader reader)
+    {
+        // Ensure first value is an array and read that so that we are the { token.
+        SkipNoneTokens(stream, ref buffer, ref reader);
+        AssertTokenType(stream, ref reader, JsonTokenType.StartArray);
+        Read(stream, ref buffer, ref reader);
+        GetMoreBytesFromStream(stream, ref buffer, ref reader);
+    }
+
     /// <summary>
     /// Helper method that can be used to display a byte readonlyspan for logging.
     /// </summary>

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/ParserUtils.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/ParserUtils.cs
@@ -9,6 +9,8 @@ using Microsoft.Sbom.Parsers.Spdx22SbomParser;
 using Microsoft.Sbom.Exceptions;
 using System.Runtime.InteropServices.ComTypes;
 using System.Linq;
+using Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
+using System.Collections.Generic;
 
 namespace Microsoft.Sbom.Parser;
 
@@ -143,7 +145,7 @@ internal class ParserUtils
     /// </summary>
     /// <param name="reader"></param>
     /// <param name="buffer"></param>
-    internal static void SkipProperty(Stream stream, ref Utf8JsonReader reader, ref byte[] buffer)
+    internal static void SkipProperty(Stream stream, ref byte[] buffer, ref Utf8JsonReader reader)
     {
         if (reader.TokenType == JsonTokenType.PropertyName)
         {
@@ -238,5 +240,27 @@ internal class ParserUtils
     {
         AssertEitherTokenTypes(stream, ref reader, new JsonTokenType[] { JsonTokenType.True, JsonTokenType.False });
         return reader.GetBoolean();
+    }
+
+    internal static List<string> ParseListOfStrings(Stream stream, ref Utf8JsonReader reader, ref byte[] buffer)
+    {
+        var strings = new List<string>();
+
+        // Read the opening [ of the array
+        AssertTokenType(stream, ref reader, JsonTokenType.StartArray);
+
+        while (reader.TokenType != JsonTokenType.EndArray)
+        {
+            Read(stream, ref buffer, ref reader);
+            if (reader.TokenType == JsonTokenType.EndArray)
+            {
+                break;
+            }
+
+            strings.Add(reader.GetString());
+        }
+
+        AssertTokenType(stream, ref reader, JsonTokenType.EndArray);
+        return strings;
     }
 }

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/SbomFileParser.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/SbomFileParser.cs
@@ -171,35 +171,13 @@ internal ref struct SbomFileParser
 
             case LicenseInfoInFilesProperty:
                 ParserUtils.Read(stream, ref buffer, ref reader);
-                sbomFile.LicenseInfoInFiles = ParseLicenseInfoInFilesArray(ref reader, ref buffer);
+                sbomFile.LicenseInfoInFiles = ParserUtils.ParseListOfStrings(stream, ref reader, ref buffer);
                 break;
 
             default:
-                ParserUtils.SkipProperty(stream, ref reader, ref buffer);
+                ParserUtils.SkipProperty(stream, ref buffer, ref reader);
                 break;
         }
-    }
-
-    private List<string> ParseLicenseInfoInFilesArray(ref Utf8JsonReader reader, ref byte[] buffer)
-    {
-        var licenses = new List<string>();
-
-        // Read the opening [ of the array
-        ParserUtils.AssertTokenType(stream, ref reader, JsonTokenType.StartArray);
-
-        while (reader.TokenType != JsonTokenType.EndArray)
-        {
-            ParserUtils.Read(stream, ref buffer, ref reader);
-            if (reader.TokenType == JsonTokenType.EndArray)
-            {
-                break;
-            }
-
-            licenses.Add(reader.GetString());
-        }
-
-        ParserUtils.AssertTokenType(stream, ref reader, JsonTokenType.EndArray);
-        return licenses;
     }
 
     private IEnumerable<Checksum> ParseChecksumsArray(ref Utf8JsonReader reader, ref byte[] buffer)
@@ -251,7 +229,7 @@ internal ref struct SbomFileParser
                     break;
                 
                 default:
-                    ParserUtils.SkipProperty(stream, ref reader, ref buffer);
+                    ParserUtils.SkipProperty(stream, ref buffer, ref reader);
                     break;
             }
 

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/SbomPackageParser.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/SbomPackageParser.cs
@@ -2,15 +2,22 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Sbom.Contracts;
+using Microsoft.Sbom.Exceptions;
 using System;
 using System.IO;
 using System.Text.Json;
 
 namespace Microsoft.Sbom.Parser;
 
+/// <summary>
+/// Parses a <see cref="SBOMPackage"/> object from a 'packages' array.
+/// </summary>
 internal ref struct SbomPackageParser
 {
+    private const string NameProperty = "name";
+
     private readonly Stream stream;
+    private readonly SBOMPackage sbomPackage = new ();
 
     public SbomPackageParser(Stream stream)
     {
@@ -19,6 +26,67 @@ internal ref struct SbomPackageParser
 
     internal long GetSbomPackage(ref byte[] buffer, ref Utf8JsonReader reader, out SBOMPackage sbomPackage)
     {
+        if (buffer is null || buffer.Length == 0)
+        {
+            throw new ArgumentException($"The {nameof(buffer)} value can't be null or of 0 length.");
+        }
+
+        try
+        {
+            // If the end of the array is reached, return with null value to signal end of the array.
+            if (reader.TokenType == JsonTokenType.EndArray)
+            {
+                sbomPackage = null;
+                return 0;
+            }
+
+            // Read the start { of this object.
+            ParserUtils.SkipNoneTokens(stream, ref buffer, ref reader);
+            ParserUtils.AssertTokenType(stream, ref reader, JsonTokenType.StartObject);
+
+            // Move to the first property name token.
+            ParserUtils.Read(stream, ref buffer, ref reader);
+            ParserUtils.AssertTokenType(stream, ref reader, JsonTokenType.PropertyName);
+
+            while (reader.TokenType != JsonTokenType.EndObject)
+            {
+                ParseProperty(ref reader, ref buffer);
+
+                // Read the end } of this object or the next property name.
+                ParserUtils.Read(stream, ref buffer, ref reader);
+            }
+
+            // Validate the created object
+            ValidateSbomFile(this.sbomPackage);
+
+            sbomPackage = this.sbomPackage;
+            return reader.BytesConsumed;
+        }
+        catch (EndOfStreamException)
+        {
+            sbomPackage = null;
+            return 0;
+        }
+        catch (JsonException e)
+        {
+            sbomPackage = null;
+            throw new ParserException($"Error while parsing JSON, addtional details: ${e.Message}", e);
+        }
+    }
+
+    private void ValidateSbomFile(SBOMPackage sbomPackage)
+    {
         throw new NotImplementedException();
+    }
+
+    private void ParseProperty(ref Utf8JsonReader reader, ref byte[] buffer)
+    {
+        switch (reader.GetString())
+        {
+            case NameProperty:
+                 ParserUtils.Read(stream, ref buffer, ref reader);
+                 sbomPackage.PackageName = ParserUtils.ParseNextString(stream, ref reader);
+                 break;
+        }
     }
 }

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/SbomPackageParser.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/SbomPackageParser.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Sbom.Contracts;
 using Microsoft.Sbom.Exceptions;
 using Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
 using System;
@@ -19,6 +18,11 @@ internal ref struct SbomPackageParser
     private const string SPDXIDProperty = "SPDXID";
     private const string DownloadLocationProperty = "downloadLocation";
     private const string FilesAnalyzedProperty = "filesAnalyzed";
+    private const string LicenseConcludedProperty = "licenseConcluded";
+    private const string LicenseDeclaredProperty = "licenseDeclared";
+    private const string CopyrightTextProperty = "copyrightText";
+    private const string VersionInfoProperty = "versionInfo";
+    private const string SupplierProperty = "supplier";
 
     private readonly Stream stream;
     private readonly SPDXPackage sbomPackage = new ();
@@ -88,28 +92,53 @@ internal ref struct SbomPackageParser
         switch (reader.GetString())
         {
             case NameProperty:
-                 ParserUtils.Read(stream, ref buffer, ref reader);
-                 sbomPackage.Name = ParserUtils.ParseNextString(stream, ref reader);
-                 break;
+                ParserUtils.Read(stream, ref buffer, ref reader);
+                sbomPackage.Name = ParserUtils.ParseNextString(stream, ref reader);
+                break;
 
             case SPDXIDProperty:
-                 ParserUtils.Read(stream, ref buffer, ref reader);
-                 sbomPackage.SpdxId = ParserUtils.ParseNextString(stream, ref reader);
-                 break;
+                ParserUtils.Read(stream, ref buffer, ref reader);
+                sbomPackage.SpdxId = ParserUtils.ParseNextString(stream, ref reader);
+                break;
 
             case DownloadLocationProperty:
-                 ParserUtils.Read(stream, ref buffer, ref reader);
-                 sbomPackage.DownloadLocation = ParserUtils.ParseNextString(stream, ref reader);
-                 break;
+                ParserUtils.Read(stream, ref buffer, ref reader);
+                sbomPackage.DownloadLocation = ParserUtils.ParseNextString(stream, ref reader);
+                break;
 
             case FilesAnalyzedProperty:
-                 ParserUtils.Read(stream, ref buffer, ref reader);
-                 sbomPackage.FilesAnalyzed = ParserUtils.ParseNextBoolean(stream, ref reader);
-                 break;
+                ParserUtils.Read(stream, ref buffer, ref reader);
+                sbomPackage.FilesAnalyzed = ParserUtils.ParseNextBoolean(stream, ref reader);
+                break;
+
+            case LicenseConcludedProperty:
+                ParserUtils.Read(stream, ref buffer, ref reader);
+                sbomPackage.LicenseConcluded = ParserUtils.ParseNextString(stream, ref reader);
+                break;
+
+            case LicenseDeclaredProperty:
+                ParserUtils.Read(stream, ref buffer, ref reader);
+                sbomPackage.LicenseDeclared = ParserUtils.ParseNextString(stream, ref reader);
+                break;
+
+            case CopyrightTextProperty:
+                ParserUtils.Read(stream, ref buffer, ref reader);
+                sbomPackage.LicenseDeclared = ParserUtils.ParseNextString(stream, ref reader);
+                break;
+
+            case VersionInfoProperty:
+                ParserUtils.Read(stream, ref buffer, ref reader);
+                sbomPackage.LicenseDeclared = ParserUtils.ParseNextString(stream, ref reader);
+                break;
+
+            case SupplierProperty:
+                ParserUtils.Read(stream, ref buffer, ref reader);
+                sbomPackage.LicenseDeclared = ParserUtils.ParseNextString(stream, ref reader);
+                break;
 
             default:
-                 ParserUtils.SkipProperty(stream, ref reader, ref buffer);
-                 break;
+                ParserUtils.SkipProperty(stream, ref reader, ref buffer);
+                break;
         }
     }
 }

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/SbomPackageParser.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/SbomPackageParser.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Sbom.Contracts;
 using Microsoft.Sbom.Exceptions;
+using Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
 using System;
 using System.IO;
 using System.Text.Json;
@@ -10,21 +11,24 @@ using System.Text.Json;
 namespace Microsoft.Sbom.Parser;
 
 /// <summary>
-/// Parses a <see cref="SBOMPackage"/> object from a 'packages' array.
+/// Parses a <see cref="SPDXPackage"/> object from a 'packages' array.
 /// </summary>
 internal ref struct SbomPackageParser
 {
     private const string NameProperty = "name";
+    private const string SPDXIDProperty = "SPDXID";
+    private const string DownloadLocationProperty = "downloadLocation";
+    private const string FilesAnalyzedProperty = "filesAnalyzed";
 
     private readonly Stream stream;
-    private readonly SBOMPackage sbomPackage = new ();
+    private readonly SPDXPackage sbomPackage = new ();
 
     public SbomPackageParser(Stream stream)
     {
-        this.stream = stream ?? throw new System.ArgumentNullException(nameof(stream));
+        this.stream = stream ?? throw new ArgumentNullException(nameof(stream));
     }
 
-    internal long GetSbomPackage(ref byte[] buffer, ref Utf8JsonReader reader, out SBOMPackage sbomPackage)
+    internal long GetSbomPackage(ref byte[] buffer, ref Utf8JsonReader reader, out SPDXPackage sbomPackage)
     {
         if (buffer is null || buffer.Length == 0)
         {
@@ -74,9 +78,9 @@ internal ref struct SbomPackageParser
         }
     }
 
-    private void ValidateSbomFile(SBOMPackage sbomPackage)
+    private void ValidateSbomFile(SPDXPackage sbomPackage)
     {
-        throw new NotImplementedException();
+        //throw new NotImplementedException();
     }
 
     private void ParseProperty(ref Utf8JsonReader reader, ref byte[] buffer)
@@ -85,7 +89,26 @@ internal ref struct SbomPackageParser
         {
             case NameProperty:
                  ParserUtils.Read(stream, ref buffer, ref reader);
-                 sbomPackage.PackageName = ParserUtils.ParseNextString(stream, ref reader);
+                 sbomPackage.Name = ParserUtils.ParseNextString(stream, ref reader);
+                 break;
+
+            case SPDXIDProperty:
+                 ParserUtils.Read(stream, ref buffer, ref reader);
+                 sbomPackage.SpdxId = ParserUtils.ParseNextString(stream, ref reader);
+                 break;
+
+            case DownloadLocationProperty:
+                 ParserUtils.Read(stream, ref buffer, ref reader);
+                 sbomPackage.DownloadLocation = ParserUtils.ParseNextString(stream, ref reader);
+                 break;
+
+            case FilesAnalyzedProperty:
+                 ParserUtils.Read(stream, ref buffer, ref reader);
+                 sbomPackage.FilesAnalyzed = ParserUtils.ParseNextBoolean(stream, ref reader);
+                 break;
+
+            default:
+                 ParserUtils.SkipProperty(stream, ref reader, ref buffer);
                  break;
         }
     }

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/SbomPackageParser.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/SbomPackageParser.cs
@@ -1,0 +1,13 @@
+﻿using System.IO;
+
+namespace Microsoft.Sbom.Parser;
+
+internal ref struct SbomPackageParser
+{
+    private readonly Stream stream;
+
+    public SbomPackageParser(Stream stream)
+    {
+        this.stream = stream ?? throw new System.ArgumentNullException(nameof(stream));
+    }
+}

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/SbomPackageParser.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/SbomPackageParser.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using Microsoft.Sbom.Contracts;
+using System;
 using System.IO;
+using System.Text.Json;
 
 namespace Microsoft.Sbom.Parser;
 
@@ -12,5 +15,10 @@ internal ref struct SbomPackageParser
     public SbomPackageParser(Stream stream)
     {
         this.stream = stream ?? throw new System.ArgumentNullException(nameof(stream));
+    }
+
+    internal long GetSbomPackage(ref byte[] buffer, ref Utf8JsonReader reader, out SBOMPackage sbomPackage)
+    {
+        throw new NotImplementedException();
     }
 }

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/SbomPackageParser.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/SbomPackageParser.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
 
 namespace Microsoft.Sbom.Parser;
 

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomPackageParserTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomPackageParserTests.cs
@@ -68,11 +68,13 @@ public class SbomPackageParserTests
     [DataRow(SbomPackageStrings.PackageJsonWith1PackageMissingVersionInfo)]
     [DataRow(SbomPackageStrings.PackageJsonWith1PackageMissingLicenseInfoFromFiles)]
     [DataRow(SbomPackageStrings.PackageJsonWith1PackageMissingSupplier)]
-    [DataRow(SbomPackageStrings.PackageJsonWith1PackageMissingFilesAnalyzed)]
     [DataRow(SbomPackageStrings.PackageJsonWith1PackageMissingId)]
     [DataRow(SbomPackageStrings.PackageJsonWith1PackageMissingLicenseConcluded)]
     [DataRow(SbomPackageStrings.PackageJsonWith1PackageMissingLicenseDeclared)]
     [DataRow(SbomPackageStrings.PackageJsonWith1PackageMissingName)]
+    [DataRow(SbomPackageStrings.PackageJsonWith1PackageBadReferenceType)]
+    [DataRow(SbomPackageStrings.PackageJsonWith1PackageMissingReferenceLocator)]
+    [DataRow(SbomPackageStrings.PackageJsonWith1PackageMissingPackageVerificationCode)]
     [TestMethod]
     [ExpectedException(typeof(ParserException))]
     public void MissingPropertiesTest_Throws(string json)
@@ -86,9 +88,10 @@ public class SbomPackageParserTests
     }
 
     [DataTestMethod]
-    [DataRow(SbomFileJsonStrings.GoodJsonWith1FileAdditionalObjectPropertyString)]
-    [DataRow(SbomFileJsonStrings.GoodJsonWith1FileAdditionalArrayPropertyString)]
-    [DataRow(SbomFileJsonStrings.GoodJsonWith1FileAdditionalStringPropertyString)]
+    [DataRow(SbomPackageStrings.PackageJsonWith1PackageAdditionalString)]
+    [DataRow(SbomPackageStrings.PackageJsonWith1PackageAdditionalArray)]
+    [DataRow(SbomPackageStrings.PackageJsonWith1PackageAdditionalObject)]
+    [DataRow(SbomPackageStrings.PackageJsonWith1PackageAdditionalArrayNoKey)]
     [TestMethod]
     public void IgnoresAdditionalPropertiesTest(string json)
     {

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomPackageParserTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomPackageParserTests.cs
@@ -9,44 +9,44 @@ using System.Text;
 namespace Microsoft.Sbom.Parser;
 
 [TestClass]
-public class SbomFileParserTests
+public class SbomPackageParserTests
 {
     [TestMethod]
-    public void ParseSbomFilesTest()
+    public void ParseSbomPackagesTest()
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(SbomFileJsonStrings.GoodJsonWith2FilesString);
+        byte[] bytes = Encoding.UTF8.GetBytes(SbomPackageStrings.GoodJsonWith3PackagesString);
         using var stream = new MemoryStream(bytes);
 
         TestParser parser = new ();
         var count = 0;
 
-        foreach (var file in parser.GetFiles(stream))
+        foreach (var package in parser.GetPackages(stream))
         {
             count++;
-            Assert.IsNotNull(file);
+            Assert.IsNotNull(package);
         }
 
-        Assert.AreEqual(2, count);
+        Assert.AreEqual(3, count);
     }
 
     [TestMethod]
     [ExpectedException(typeof(ArgumentNullException))]
     public void NullStreamThrows()
     {
-        new SbomFileParser(null);
+        new SbomPackageParser(null);
     }
 
     [TestMethod]
     [ExpectedException(typeof(ObjectDisposedException))]
     public void StreamClosedTestReturnsNull()
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(SbomFileJsonStrings.GoodJsonWith2FilesString);
+        byte[] bytes = Encoding.UTF8.GetBytes(SbomPackageStrings.GoodJsonWith3PackagesString);
         using var stream = new MemoryStream(bytes);
 
         TestParser parser = new ();
         stream.Close();
 
-        parser.GetFiles(stream).GetEnumerator().MoveNext(); 
+        parser.GetPackages(stream).GetEnumerator().MoveNext();
     }
 
     [TestMethod]
@@ -56,21 +56,23 @@ public class SbomFileParserTests
         using var stream = new MemoryStream();
         stream.Read(new byte[Constants.ReadBufferSize]);
         var buffer = new byte[Constants.ReadBufferSize];
-        
+
         TestParser parser = new ();
 
-        parser.GetFiles(stream).GetEnumerator().MoveNext();
+        parser.GetPackages(stream).GetEnumerator().MoveNext();
     }
 
     [DataTestMethod]
-    [DataRow(SbomFileJsonStrings.JsonWith1FileMissingNameString)]
-    [DataRow(SbomFileJsonStrings.JsonWith1FileMissingIDString)]
-    [DataRow(SbomFileJsonStrings.JsonWith1FileMissingChecksumsString)]
-    [DataRow(SbomFileJsonStrings.JsonWith1FileMissingSHA256ChecksumsString)]
-    [DataRow(SbomFileJsonStrings.JsonWith1FileMissingLicenseConcludedString)]
-    [DataRow(SbomFileJsonStrings.JsonWith1FileMissingLicenseInfoInFilesString)]
-    [DataRow(SbomFileJsonStrings.JsonWith1FileMissingCopyrightString)]
-    [DataRow(SbomFileJsonStrings.JsonWith1FileMissingCopyrightAndPathString)]
+    [DataRow(SbomPackageStrings.PackageJsonWith1PackageMissingCopyrightText)]
+    [DataRow(SbomPackageStrings.PackageJsonWith1PackageMissingDownloadLocation)]
+    [DataRow(SbomPackageStrings.PackageJsonWith1PackageMissingVersionInfo)]
+    [DataRow(SbomPackageStrings.PackageJsonWith1PackageMissingLicenseInfoFromFiles)]
+    [DataRow(SbomPackageStrings.PackageJsonWith1PackageMissingSupplier)]
+    [DataRow(SbomPackageStrings.PackageJsonWith1PackageMissingFilesAnalyzed)]
+    [DataRow(SbomPackageStrings.PackageJsonWith1PackageMissingId)]
+    [DataRow(SbomPackageStrings.PackageJsonWith1PackageMissingLicenseConcluded)]
+    [DataRow(SbomPackageStrings.PackageJsonWith1PackageMissingLicenseDeclared)]
+    [DataRow(SbomPackageStrings.PackageJsonWith1PackageMissingName)]
     [TestMethod]
     [ExpectedException(typeof(ParserException))]
     public void MissingPropertiesTest_Throws(string json)
@@ -80,14 +82,13 @@ public class SbomFileParserTests
 
         TestParser parser = new (40);
 
-        parser.GetFiles(stream).GetEnumerator().MoveNext();
+        parser.GetPackages(stream).GetEnumerator().MoveNext();
     }
 
     [DataTestMethod]
     [DataRow(SbomFileJsonStrings.GoodJsonWith1FileAdditionalObjectPropertyString)]
     [DataRow(SbomFileJsonStrings.GoodJsonWith1FileAdditionalArrayPropertyString)]
     [DataRow(SbomFileJsonStrings.GoodJsonWith1FileAdditionalStringPropertyString)]
-    [DataRow(SbomFileJsonStrings.GoodJsonWith1FileAdditionalValueArrayPropertyString)]
     [TestMethod]
     public void IgnoresAdditionalPropertiesTest(string json)
     {
@@ -96,14 +97,14 @@ public class SbomFileParserTests
 
         TestParser parser = new ();
 
-        foreach (var file in parser.GetFiles(stream))
+        foreach (var package in parser.GetPackages(stream))
         {
-            Assert.IsNotNull(file);
+            Assert.IsNotNull(package);
         }
     }
 
     [DataTestMethod]
-    [DataRow(SbomFileJsonStrings.MalformedJson)]
+    [DataRow(SbomPackageStrings.MalformedJson)]
     [DataRow(SbomFileJsonStrings.MalformedJsonEmptyObject)]
     [DataRow(SbomFileJsonStrings.MalformedJsonEmptyObjectNoArrayEnd)]
     [TestMethod]
@@ -115,7 +116,7 @@ public class SbomFileParserTests
 
         TestParser parser = new ();
 
-        parser.GetFiles(stream).GetEnumerator().MoveNext();
+        parser.GetPackages(stream).GetEnumerator().MoveNext();
     }
 
     [TestMethod]
@@ -126,7 +127,7 @@ public class SbomFileParserTests
 
         TestParser parser = new ();
 
-        parser.GetFiles(stream).GetEnumerator().MoveNext();
+        parser.GetPackages(stream).GetEnumerator().MoveNext();
     }
 
     [TestMethod]
@@ -138,6 +139,6 @@ public class SbomFileParserTests
 
         TestParser parser = new (0);
 
-        parser.GetFiles(stream).GetEnumerator().MoveNext();
+        parser.GetPackages(stream).GetEnumerator().MoveNext();
     }
 }

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/Strings/JsonStrings.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/Strings/JsonStrings.cs
@@ -111,6 +111,28 @@ internal struct SbomFileJsonStrings
                 ],
                 ""copyrightText"": ""NOASSERTION""
             }]";
+          
+    public const string GoodJsonWith1FileAdditionalValueArrayPropertyString = @"[
+            {
+                ""fileName"": ""./file1"",
+                ""SPDXID"": ""SPDXRef-File--sbom-tool-win-x64.exe-E55F25E239D8D3572D75D5CDC5CA24899FD4993F"",
+                ""additionalProperty"": [""Additional value 1"", ""Additional value 2""],
+                ""checksums"": [
+                {
+                    ""algorithm"": ""SHA256"",
+                    ""checksumValue"": ""56624d8ab67ac0e323bcac0ae1ec0656f1721c6bb60640ecf9b30e861062aad5""
+                },
+                {
+                    ""algorithm"": ""SHA1"",
+                    ""checksumValue"": ""e55f25e239d8d3572d75d5cdc5ca24899fd4993f""
+                }
+                ],
+                ""licenseConcluded"": ""NOASSERTION"",
+                ""licenseInfoInFiles"": [
+                    ""NOASSERTION""
+                ],
+                ""copyrightText"": ""NOASSERTION""
+            }]";
 
     public const string GoodJsonWith1FileAdditionalArrayPropertyString = @"[
             {

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/Strings/SbomPackageStrings.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/Strings/SbomPackageStrings.cs
@@ -123,6 +123,94 @@ internal struct SbomPackageStrings
       ""supplier"": ""Organization: testa""
     }]";
 
+    public const string PackageJsonWith1PackageMissingPackageVerificationCode = @"[{
+      ""name"": ""pest"",
+      ""SPDXID"": ""SPDXRef-RootPackage"",
+      ""downloadLocation"": ""NOASSERTION"",
+      ""packageVerificationCode"": {
+        ""packageVerificationCodeValue"": """"
+      },
+      ""filesAnalyzed"": true,
+      ""licenseConcluded"": ""NOASSERTION"",
+      ""licenseInfoFromFiles"": [
+        ""NOASSERTION""
+      ],
+      ""licenseDeclared"": ""NOASSERTION"",
+      ""copyrightText"": ""NOASSERTION"",
+      ""versionInfo"": ""1208"",
+      ""supplier"": ""Organization: Microsoft"",
+      ""hasFiles"": [
+        ""SPDXRef-File--package-services-metadata-core-properties-16e5bdb646ef44f485b1227d6d005f14.psmdcp-81EC7E121D7F03CDE59C8A4570A7D75C7EBB063A"",
+        ""SPDXRef-File--packages.config-69B7910C6FC95DB019934AA3BE0CDFDC3F3F2D8E"",
+        ""SPDXRef-File--pest.nuspec-A2EBA85861EAFD340496A9A7948D193284A19408"",
+        ""SPDXRef-File---rels-.rels-2DBE1B6566BFF9F17C259FB7D8B21231D4F11857"",
+        ""SPDXRef-File---Content-Types-.xml-EB0036B6C11A1AF694FA8ABACA0A4C43584225DE""
+      ]
+    }]";
+
+    public const string PackageJsonWith1PackageMissingReferenceLocator = @"[{
+      ""name"": ""pest"",
+      ""SPDXID"": ""SPDXRef-RootPackage"",
+      ""downloadLocation"": ""NOASSERTION"",
+      ""packageVerificationCode"": {
+        ""packageVerificationCodeValue"": ""a2f8875f69c1b3814120e98bd3c0864e3c586a24""
+      },
+      ""filesAnalyzed"": true,
+      ""licenseConcluded"": ""NOASSERTION"",
+      ""licenseInfoFromFiles"": [
+        ""NOASSERTION""
+      ],
+      ""licenseDeclared"": ""NOASSERTION"",
+      ""copyrightText"": ""NOASSERTION"",
+      ""versionInfo"": ""1208"",
+      ""supplier"": ""Organization: Microsoft"",
+      ""hasFiles"": [
+        ""SPDXRef-File--package-services-metadata-core-properties-16e5bdb646ef44f485b1227d6d005f14.psmdcp-81EC7E121D7F03CDE59C8A4570A7D75C7EBB063A"",
+        ""SPDXRef-File--packages.config-69B7910C6FC95DB019934AA3BE0CDFDC3F3F2D8E"",
+        ""SPDXRef-File--pest.nuspec-A2EBA85861EAFD340496A9A7948D193284A19408"",
+        ""SPDXRef-File---rels-.rels-2DBE1B6566BFF9F17C259FB7D8B21231D4F11857"",
+        ""SPDXRef-File---Content-Types-.xml-EB0036B6C11A1AF694FA8ABACA0A4C43584225DE""
+      ],
+      ""externalRefs"": [
+        {
+          ""referenceCategory"": ""PACKAGE_MANAGER"",
+          ""referenceType"": ""purl"",
+        }
+      ],
+    }]";
+
+    public const string PackageJsonWith1PackageBadReferenceType = @"[{
+      ""name"": ""pest"",
+      ""SPDXID"": ""SPDXRef-RootPackage"",
+      ""downloadLocation"": ""NOASSERTION"",
+      ""packageVerificationCode"": {
+        ""packageVerificationCodeValue"": ""a2f8875f69c1b3814120e98bd3c0864e3c586a24""
+      },
+      ""filesAnalyzed"": true,
+      ""licenseConcluded"": ""NOASSERTION"",
+      ""licenseInfoFromFiles"": [
+        ""NOASSERTION""
+      ],
+      ""licenseDeclared"": ""NOASSERTION"",
+      ""copyrightText"": ""NOASSERTION"",
+      ""versionInfo"": ""1208"",
+      ""supplier"": ""Organization: Microsoft"",
+      ""hasFiles"": [
+        ""SPDXRef-File--package-services-metadata-core-properties-16e5bdb646ef44f485b1227d6d005f14.psmdcp-81EC7E121D7F03CDE59C8A4570A7D75C7EBB063A"",
+        ""SPDXRef-File--packages.config-69B7910C6FC95DB019934AA3BE0CDFDC3F3F2D8E"",
+        ""SPDXRef-File--pest.nuspec-A2EBA85861EAFD340496A9A7948D193284A19408"",
+        ""SPDXRef-File---rels-.rels-2DBE1B6566BFF9F17C259FB7D8B21231D4F11857"",
+        ""SPDXRef-File---Content-Types-.xml-EB0036B6C11A1AF694FA8ABACA0A4C43584225DE""
+      ],
+      ""externalRefs"": [
+        {
+          ""referenceCategory"": ""PACKAGE_MANAGER"",
+          ""referenceType"": ""testss"",
+          ""referenceLocator"": ""pkg:nuget/System.Runtime.InteropServices.WindowsRuntime%404.3.0""
+        }
+      ],
+    }]";
+
     public const string PackageJsonWith1PackageMissingName = @"[{
       ""SPDXID"": ""SPDXRef-RootPackage"",
       ""downloadLocation"": ""NOASSERTION"",

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/Strings/SbomPackageStrings.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/Strings/SbomPackageStrings.cs
@@ -1,0 +1,431 @@
+﻿namespace Microsoft.Sbom.Parser.Strings;
+
+internal struct SbomPackageStrings
+{
+    public SbomPackageStrings()
+    {
+    }
+
+    public const string PackageJsonWith1PackageAdditionalString = @"[{
+      ""name"": ""pest"",
+      ""other"": ""tt"",
+      ""SPDXID"": ""SPDXRef-Package-1C4595D6D70121622649BB913859B18A3C0A2D49EC7D36279777025C4AC92303"",
+      ""downloadLocation"": ""NOASSERTION"",
+      ""filesAnalyzed"": false,
+      ""licenseConcluded"": ""NOASSERTION"",
+      ""licenseInfoFromFiles"": [
+        ""NOASSERTION""
+      ],
+      ""licenseDeclared"": ""NOASSERTION"",
+      ""copyrightText"": ""NOASSERTION"",
+      ""versionInfo"": ""1.0.0"",
+      ""externalRefs"": [
+        {
+          ""referenceCategory"": ""PACKAGE_MANAGER"",
+          ""referenceType"": ""purl"",
+          ""referenceLocator"": ""pkg:nuget/pest%401.0.0""
+        }
+      ],
+      ""supplier"": ""Organization: testa""
+    }]";
+
+    public const string PackageJsonWith1PackageAdditionalArray = @"[{
+      ""name"": ""pest"",
+      ""SPDXID"": ""SPDXRef-Package-1C4595D6D70121622649BB913859B18A3C0A2D49EC7D36279777025C4AC92303"",
+      ""downloadLocation"": ""NOASSERTION"",
+      ""filesAnalyzed"": false,
+      ""licenseConcluded"": ""NOASSERTION"",
+      ""licenseInfoFromFiles"": [
+        ""NOASSERTION""
+      ], 
+      ""additionalProperty"": [
+        {""childAddtionalProperty"": ""Additional property value"" }],
+      ""licenseDeclared"": ""NOASSERTION"",
+      ""copyrightText"": ""NOASSERTION"",
+      ""versionInfo"": ""1.0.0"",
+      ""externalRefs"": [
+        {
+          ""referenceCategory"": ""PACKAGE_MANAGER"",
+          ""referenceType"": ""purl"",
+          ""referenceLocator"": ""pkg:nuget/pest%401.0.0""
+        }
+      ],
+      ""supplier"": ""Organization: testa""
+    }]";
+
+    public const string PackageJsonWith1PackageAdditionalArrayNoKey = @"[{
+      ""name"": ""pest"",
+      ""SPDXID"": ""SPDXRef-Package-1C4595D6D70121622649BB913859B18A3C0A2D49EC7D36279777025C4AC92303"",
+      ""downloadLocation"": ""NOASSERTION"",
+      ""filesAnalyzed"": false,
+      ""licenseConcluded"": ""NOASSERTION"",
+      ""licenseInfoFromFiles"": [
+        ""NOASSERTION""
+      ], 
+      ""additionalProperty"": [""Additional value 1"", ""Additional value 2""],
+      ""licenseDeclared"": ""NOASSERTION"",
+      ""copyrightText"": ""NOASSERTION"",
+      ""versionInfo"": ""1.0.0"",
+      ""externalRefs"": [
+        {
+          ""referenceCategory"": ""PACKAGE_MANAGER"",
+          ""referenceType"": ""purl"",
+          ""referenceLocator"": ""pkg:nuget/pest%401.0.0""
+        }
+      ],
+      ""supplier"": ""Organization: testa""
+    }]";
+
+    public const string PackageJsonWith1PackageAdditionalObject = @"[{
+      ""name"": ""pest"",
+      ""SPDXID"": ""SPDXRef-Package-1C4595D6D70121622649BB913859B18A3C0A2D49EC7D36279777025C4AC92303"",
+      ""downloadLocation"": ""NOASSERTION"",
+      ""filesAnalyzed"": false,
+      ""licenseConcluded"": ""NOASSERTION"",
+      ""licenseInfoFromFiles"": [
+        ""NOASSERTION""
+      ],
+      ""additionalProperty"": {
+        ""childAddtionalProperty"": ""Additional property value"" 
+      },
+      ""licenseDeclared"": ""NOASSERTION"",
+      ""copyrightText"": ""NOASSERTION"",
+      ""versionInfo"": ""1.0.0"",
+      ""externalRefs"": [
+        {
+          ""referenceCategory"": ""PACKAGE_MANAGER"",
+          ""referenceType"": ""purl"",
+          ""referenceLocator"": ""pkg:nuget/pest%401.0.0""
+        }
+      ],
+      ""supplier"": ""Organization: testa""
+    }]";
+
+    public const string MalformedJson = @"[{
+      ""name"": ""pest"",
+      ""SPDXID"": ""SPDXRef-Package-1C4595D6D70121622649BB913859B18A3C0A2D49EC7D36279777025C4AC92303"",
+      ""downloadLocation"": ""NOASSERTION"",
+      ""filesAnalyzed"": false,
+      ""licenseConcluded"": ""NOASSERTION"",
+      ""licenseInfoFromFiles"": [
+        ""NOASSERTION""
+      ],
+      ""licenseDeclared"": ""NOASSERTION"",
+      ""copyrightText"": ""NOASSERTION"",
+      ""versionInfo"": ""1.0.0,
+      ""externalRefs"": [
+        {
+          ""referenceCategory"": ""PACKAGE_MANAGER"",
+          ""referenceType"": ""purl"",
+          ""referenceLocator"": ""pkg:nuget/pest%401.0.0""
+        }
+      ],
+      ""supplier"": ""Organization: testa""
+    }]";
+
+    public const string PackageJsonWith1PackageMissingName = @"[{
+      ""SPDXID"": ""SPDXRef-RootPackage"",
+      ""downloadLocation"": ""NOASSERTION"",
+      ""packageVerificationCode"": {
+        ""packageVerificationCodeValue"": ""a2f8875f69c1b3814120e98bd3c0864e3c586a24""
+      },
+      ""filesAnalyzed"": true,
+      ""licenseConcluded"": ""NOASSERTION"",
+      ""licenseInfoFromFiles"": [
+        ""NOASSERTION""
+      ],
+      ""licenseDeclared"": ""NOASSERTION"",
+      ""copyrightText"": ""NOASSERTION"",
+      ""versionInfo"": ""1208"",
+      ""supplier"": ""Organization: Microsoft"",
+      ""hasFiles"": [
+        ""SPDXRef-File--package-services-metadata-core-properties-16e5bdb646ef44f485b1227d6d005f14.psmdcp-81EC7E121D7F03CDE59C8A4570A7D75C7EBB063A"",
+        ""SPDXRef-File--packages.config-69B7910C6FC95DB019934AA3BE0CDFDC3F3F2D8E"",
+        ""SPDXRef-File--pest.nuspec-A2EBA85861EAFD340496A9A7948D193284A19408"",
+        ""SPDXRef-File---rels-.rels-2DBE1B6566BFF9F17C259FB7D8B21231D4F11857"",
+        ""SPDXRef-File---Content-Types-.xml-EB0036B6C11A1AF694FA8ABACA0A4C43584225DE""
+      ]
+    }]";
+
+    public const string PackageJsonWith1PackageMissingId = @"[{
+      ""name"": ""Testing cross platform signing"",
+      ""downloadLocation"": ""NOASSERTION"",
+      ""packageVerificationCode"": {
+        ""packageVerificationCodeValue"": ""a2f8875f69c1b3814120e98bd3c0864e3c586a24""
+      },
+      ""filesAnalyzed"": true,
+      ""licenseConcluded"": ""NOASSERTION"",
+      ""licenseInfoFromFiles"": [
+        ""NOASSERTION""
+      ],
+      ""licenseDeclared"": ""NOASSERTION"",
+      ""copyrightText"": ""NOASSERTION"",
+      ""versionInfo"": ""1208"",
+      ""supplier"": ""Organization: Microsoft"",
+      ""hasFiles"": [
+        ""SPDXRef-File--package-services-metadata-core-properties-16e5bdb646ef44f485b1227d6d005f14.psmdcp-81EC7E121D7F03CDE59C8A4570A7D75C7EBB063A"",
+        ""SPDXRef-File--packages.config-69B7910C6FC95DB019934AA3BE0CDFDC3F3F2D8E"",
+        ""SPDXRef-File--pest.nuspec-A2EBA85861EAFD340496A9A7948D193284A19408"",
+        ""SPDXRef-File---rels-.rels-2DBE1B6566BFF9F17C259FB7D8B21231D4F11857"",
+        ""SPDXRef-File---Content-Types-.xml-EB0036B6C11A1AF694FA8ABACA0A4C43584225DE""
+      ]
+    }]";
+
+    public const string PackageJsonWith1PackageMissingDownloadLocation = @"[{
+      ""name"": ""Testing cross platform signing"",
+      ""SPDXID"": ""SPDXRef-RootPackage"",
+      ""packageVerificationCode"": {
+        ""packageVerificationCodeValue"": ""a2f8875f69c1b3814120e98bd3c0864e3c586a24""
+      },
+      ""filesAnalyzed"": true,
+      ""licenseConcluded"": ""NOASSERTION"",
+      ""licenseInfoFromFiles"": [
+        ""NOASSERTION""
+      ],
+      ""licenseDeclared"": ""NOASSERTION"",
+      ""copyrightText"": ""NOASSERTION"",
+      ""versionInfo"": ""1208"",
+      ""supplier"": ""Organization: Microsoft"",
+      ""hasFiles"": [
+        ""SPDXRef-File--package-services-metadata-core-properties-16e5bdb646ef44f485b1227d6d005f14.psmdcp-81EC7E121D7F03CDE59C8A4570A7D75C7EBB063A"",
+        ""SPDXRef-File--packages.config-69B7910C6FC95DB019934AA3BE0CDFDC3F3F2D8E"",
+        ""SPDXRef-File--pest.nuspec-A2EBA85861EAFD340496A9A7948D193284A19408"",
+        ""SPDXRef-File---rels-.rels-2DBE1B6566BFF9F17C259FB7D8B21231D4F11857"",
+        ""SPDXRef-File---Content-Types-.xml-EB0036B6C11A1AF694FA8ABACA0A4C43584225DE""
+      ]
+    }]";
+
+    public const string PackageJsonWith1PackageMissingFilesAnalyzed = @"[{
+      ""name"": ""Testing cross platform signing"",
+      ""SPDXID"": ""SPDXRef-RootPackage"",
+      ""downloadLocation"": ""NOASSERTION"",
+      ""packageVerificationCode"": {
+        ""packageVerificationCodeValue"": ""a2f8875f69c1b3814120e98bd3c0864e3c586a24""
+      },
+      ""licenseConcluded"": ""NOASSERTION"",
+      ""licenseInfoFromFiles"": [
+        ""NOASSERTION""
+      ],
+      ""licenseDeclared"": ""NOASSERTION"",
+      ""copyrightText"": ""NOASSERTION"",
+      ""versionInfo"": ""1208"",
+      ""supplier"": ""Organization: Microsoft"",
+      ""hasFiles"": [
+        ""SPDXRef-File--package-services-metadata-core-properties-16e5bdb646ef44f485b1227d6d005f14.psmdcp-81EC7E121D7F03CDE59C8A4570A7D75C7EBB063A"",
+        ""SPDXRef-File--packages.config-69B7910C6FC95DB019934AA3BE0CDFDC3F3F2D8E"",
+        ""SPDXRef-File--pest.nuspec-A2EBA85861EAFD340496A9A7948D193284A19408"",
+        ""SPDXRef-File---rels-.rels-2DBE1B6566BFF9F17C259FB7D8B21231D4F11857"",
+        ""SPDXRef-File---Content-Types-.xml-EB0036B6C11A1AF694FA8ABACA0A4C43584225DE""
+      ]
+    }]";
+
+    public const string PackageJsonWith1PackageMissingLicenseConcluded = @"[{
+      ""name"": ""Testing cross platform signing"",
+      ""SPDXID"": ""SPDXRef-RootPackage"",
+      ""downloadLocation"": ""NOASSERTION"",
+      ""packageVerificationCode"": {
+        ""packageVerificationCodeValue"": ""a2f8875f69c1b3814120e98bd3c0864e3c586a24""
+      },
+      ""filesAnalyzed"": true,
+      ""licenseInfoFromFiles"": [
+        ""NOASSERTION""
+      ],
+      ""licenseDeclared"": ""NOASSERTION"",
+      ""copyrightText"": ""NOASSERTION"",
+      ""versionInfo"": ""1208"",
+      ""supplier"": ""Organization: Microsoft"",
+      ""hasFiles"": [
+        ""SPDXRef-File--package-services-metadata-core-properties-16e5bdb646ef44f485b1227d6d005f14.psmdcp-81EC7E121D7F03CDE59C8A4570A7D75C7EBB063A"",
+        ""SPDXRef-File--packages.config-69B7910C6FC95DB019934AA3BE0CDFDC3F3F2D8E"",
+        ""SPDXRef-File--pest.nuspec-A2EBA85861EAFD340496A9A7948D193284A19408"",
+        ""SPDXRef-File---rels-.rels-2DBE1B6566BFF9F17C259FB7D8B21231D4F11857"",
+        ""SPDXRef-File---Content-Types-.xml-EB0036B6C11A1AF694FA8ABACA0A4C43584225DE""
+      ]
+    }]";
+
+    public const string PackageJsonWith1PackageMissingLicenseInfoFromFiles = @"[{
+      ""name"": ""Testing cross platform signing"",
+      ""SPDXID"": ""SPDXRef-RootPackage"",
+      ""downloadLocation"": ""NOASSERTION"",
+      ""packageVerificationCode"": {
+        ""packageVerificationCodeValue"": ""a2f8875f69c1b3814120e98bd3c0864e3c586a24""
+      },
+      ""filesAnalyzed"": true,
+      ""licenseConcluded"": ""NOASSERTION"",
+      ""licenseDeclared"": ""NOASSERTION"",
+      ""copyrightText"": ""NOASSERTION"",
+      ""versionInfo"": ""1208"",
+      ""supplier"": ""Organization: Microsoft"",
+      ""hasFiles"": [
+        ""SPDXRef-File--package-services-metadata-core-properties-16e5bdb646ef44f485b1227d6d005f14.psmdcp-81EC7E121D7F03CDE59C8A4570A7D75C7EBB063A"",
+        ""SPDXRef-File--packages.config-69B7910C6FC95DB019934AA3BE0CDFDC3F3F2D8E"",
+        ""SPDXRef-File--pest.nuspec-A2EBA85861EAFD340496A9A7948D193284A19408"",
+        ""SPDXRef-File---rels-.rels-2DBE1B6566BFF9F17C259FB7D8B21231D4F11857"",
+        ""SPDXRef-File---Content-Types-.xml-EB0036B6C11A1AF694FA8ABACA0A4C43584225DE""
+      ]
+    }]";
+
+    public const string PackageJsonWith1PackageMissingLicenseDeclared = @"[{
+      ""name"": ""Testing cross platform signing"",
+      ""SPDXID"": ""SPDXRef-RootPackage"",
+      ""downloadLocation"": ""NOASSERTION"",
+      ""packageVerificationCode"": {
+        ""packageVerificationCodeValue"": ""a2f8875f69c1b3814120e98bd3c0864e3c586a24""
+      },
+      ""filesAnalyzed"": true,
+      ""licenseConcluded"": ""NOASSERTION"",
+      ""licenseInfoFromFiles"": [
+        ""NOASSERTION""
+      ],
+      ""copyrightText"": ""NOASSERTION"",
+      ""versionInfo"": ""1208"",
+      ""supplier"": ""Organization: Microsoft"",
+      ""hasFiles"": [
+        ""SPDXRef-File--package-services-metadata-core-properties-16e5bdb646ef44f485b1227d6d005f14.psmdcp-81EC7E121D7F03CDE59C8A4570A7D75C7EBB063A"",
+        ""SPDXRef-File--packages.config-69B7910C6FC95DB019934AA3BE0CDFDC3F3F2D8E"",
+        ""SPDXRef-File--pest.nuspec-A2EBA85861EAFD340496A9A7948D193284A19408"",
+        ""SPDXRef-File---rels-.rels-2DBE1B6566BFF9F17C259FB7D8B21231D4F11857"",
+        ""SPDXRef-File---Content-Types-.xml-EB0036B6C11A1AF694FA8ABACA0A4C43584225DE""
+      ]
+    }]";
+
+    public const string PackageJsonWith1PackageMissingCopyrightText = @"[{
+      ""name"": ""Testing cross platform signing"",
+      ""SPDXID"": ""SPDXRef-RootPackage"",
+      ""downloadLocation"": ""NOASSERTION"",
+      ""packageVerificationCode"": {
+        ""packageVerificationCodeValue"": ""a2f8875f69c1b3814120e98bd3c0864e3c586a24""
+      },
+      ""filesAnalyzed"": true,
+      ""licenseConcluded"": ""NOASSERTION"",
+      ""licenseInfoFromFiles"": [
+        ""NOASSERTION""
+      ],
+      ""licenseDeclared"": ""NOASSERTION"",
+      ""versionInfo"": ""1208"",
+      ""supplier"": ""Organization: Microsoft"",
+      ""hasFiles"": [
+        ""SPDXRef-File--package-services-metadata-core-properties-16e5bdb646ef44f485b1227d6d005f14.psmdcp-81EC7E121D7F03CDE59C8A4570A7D75C7EBB063A"",
+        ""SPDXRef-File--packages.config-69B7910C6FC95DB019934AA3BE0CDFDC3F3F2D8E"",
+        ""SPDXRef-File--pest.nuspec-A2EBA85861EAFD340496A9A7948D193284A19408"",
+        ""SPDXRef-File---rels-.rels-2DBE1B6566BFF9F17C259FB7D8B21231D4F11857"",
+        ""SPDXRef-File---Content-Types-.xml-EB0036B6C11A1AF694FA8ABACA0A4C43584225DE""
+      ]
+    }]";
+
+    public const string PackageJsonWith1PackageMissingVersionInfo = @"[{
+      ""name"": ""Testing cross platform signing"",
+      ""SPDXID"": ""SPDXRef-RootPackage"",
+      ""downloadLocation"": ""NOASSERTION"",
+      ""packageVerificationCode"": {
+        ""packageVerificationCodeValue"": ""a2f8875f69c1b3814120e98bd3c0864e3c586a24""
+      },
+      ""filesAnalyzed"": true,
+      ""licenseConcluded"": ""NOASSERTION"",
+      ""licenseInfoFromFiles"": [
+        ""NOASSERTION""
+      ],
+      ""licenseDeclared"": ""NOASSERTION"",
+      ""copyrightText"": ""NOASSERTION"",
+      ""supplier"": ""Organization: Microsoft"",
+      ""hasFiles"": [
+        ""SPDXRef-File--package-services-metadata-core-properties-16e5bdb646ef44f485b1227d6d005f14.psmdcp-81EC7E121D7F03CDE59C8A4570A7D75C7EBB063A"",
+        ""SPDXRef-File--packages.config-69B7910C6FC95DB019934AA3BE0CDFDC3F3F2D8E"",
+        ""SPDXRef-File--pest.nuspec-A2EBA85861EAFD340496A9A7948D193284A19408"",
+        ""SPDXRef-File---rels-.rels-2DBE1B6566BFF9F17C259FB7D8B21231D4F11857"",
+        ""SPDXRef-File---Content-Types-.xml-EB0036B6C11A1AF694FA8ABACA0A4C43584225DE""
+      ]
+    }]";
+
+    public const string PackageJsonWith1PackageMissingSupplier = @"[{
+      ""name"": ""Testing cross platform signing"",
+      ""SPDXID"": ""SPDXRef-RootPackage"",
+      ""downloadLocation"": ""NOASSERTION"",
+      ""packageVerificationCode"": {
+        ""packageVerificationCodeValue"": ""a2f8875f69c1b3814120e98bd3c0864e3c586a24""
+      },
+      ""filesAnalyzed"": true,
+      ""licenseConcluded"": ""NOASSERTION"",
+      ""licenseInfoFromFiles"": [
+        ""NOASSERTION""
+      ],
+      ""licenseDeclared"": ""NOASSERTION"",
+      ""copyrightText"": ""NOASSERTION"",
+      ""versionInfo"": ""1208"",
+      ""hasFiles"": [
+        ""SPDXRef-File--package-services-metadata-core-properties-16e5bdb646ef44f485b1227d6d005f14.psmdcp-81EC7E121D7F03CDE59C8A4570A7D75C7EBB063A"",
+        ""SPDXRef-File--packages.config-69B7910C6FC95DB019934AA3BE0CDFDC3F3F2D8E"",
+        ""SPDXRef-File--pest.nuspec-A2EBA85861EAFD340496A9A7948D193284A19408"",
+        ""SPDXRef-File---rels-.rels-2DBE1B6566BFF9F17C259FB7D8B21231D4F11857"",
+        ""SPDXRef-File---Content-Types-.xml-EB0036B6C11A1AF694FA8ABACA0A4C43584225DE""
+      ]
+    }]";
+
+    public const string GoodJsonWith3PackagesString = @"[
+    {
+      ""name"": ""pest"",
+      ""SPDXID"": ""SPDXRef-Package-1C4595D6D70121622649BB913859B18A3C0A2D49EC7D36279777025C4AC92303"",
+      ""downloadLocation"": ""NOASSERTION"",
+      ""filesAnalyzed"": false,
+      ""licenseConcluded"": ""NOASSERTION"",
+      ""licenseInfoFromFiles"": [
+        ""NOASSERTION""
+      ],
+      ""licenseDeclared"": ""NOASSERTION"",
+      ""copyrightText"": ""NOASSERTION"",
+      ""versionInfo"": ""1.0.0"",
+      ""externalRefs"": [
+        {
+          ""referenceCategory"": ""PACKAGE_MANAGER"",
+          ""referenceType"": ""purl"",
+          ""referenceLocator"": ""pkg:nuget/pest%401.0.0""
+        }
+      ],
+      ""supplier"": ""Organization: testa""
+    },
+    {
+      ""name"": ""Azure Pipelines Hosted Image win22"",
+      ""SPDXID"": ""SPDXRef-Package-8A7096C32BB7E49E0D8FEAB886ECEDDBF108DCBA505DD9E8AAB73C294F903EB2"",
+      ""downloadLocation"": ""NOASSERTION"",
+      ""filesAnalyzed"": false,
+      ""licenseConcluded"": ""NOASSERTION"",
+      ""licenseInfoFromFiles"": [
+        ""NOASSERTION""
+      ],
+      ""licenseDeclared"": ""NOASSERTION"",
+      ""copyrightText"": ""NOASSERTION"",
+      ""versionInfo"": ""20220905.1"",
+      ""externalRefs"": [
+        {
+          ""referenceCategory"": ""PACKAGE_MANAGER"",
+          ""referenceType"": ""purl"",
+          ""referenceLocator"": ""https://github.com/actions/virtual-environments""
+        }
+      ],
+      ""supplier"": ""Microsoft/GitHub""
+    },
+    {
+      ""name"": ""Testing cross platform signing"",
+      ""SPDXID"": ""SPDXRef-RootPackage"",
+      ""downloadLocation"": ""NOASSERTION"",
+      ""packageVerificationCode"": {
+        ""packageVerificationCodeValue"": ""a2f8875f69c1b3814120e98bd3c0864e3c586a24""
+      },
+      ""filesAnalyzed"": true,
+      ""licenseConcluded"": ""NOASSERTION"",
+      ""licenseInfoFromFiles"": [
+        ""NOASSERTION""
+      ],
+      ""licenseDeclared"": ""NOASSERTION"",
+      ""copyrightText"": ""NOASSERTION"",
+      ""versionInfo"": ""1208"",
+      ""supplier"": ""Organization: Microsoft"",
+      ""hasFiles"": [
+        ""SPDXRef-File--package-services-metadata-core-properties-16e5bdb646ef44f485b1227d6d005f14.psmdcp-81EC7E121D7F03CDE59C8A4570A7D75C7EBB063A"",
+        ""SPDXRef-File--packages.config-69B7910C6FC95DB019934AA3BE0CDFDC3F3F2D8E"",
+        ""SPDXRef-File--pest.nuspec-A2EBA85861EAFD340496A9A7948D193284A19408"",
+        ""SPDXRef-File---rels-.rels-2DBE1B6566BFF9F17C259FB7D8B21231D4F11857"",
+        ""SPDXRef-File---Content-Types-.xml-EB0036B6C11A1AF694FA8ABACA0A4C43584225DE""
+      ]
+    }]";
+}

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/TestParser.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/TestParser.cs
@@ -17,6 +17,11 @@ namespace Microsoft.Sbom.Parser
             buffer = new byte[bufferSize];
         }
 
+        public IEnumerable<SBOMPackage> GetPackages(Stream stream)
+        {
+            return null;
+        }
+
         public IEnumerable<SBOMFile> GetFiles(Stream stream)
         {        
             stream.Read(buffer);

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/TestParser.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/TestParser.cs
@@ -8,7 +8,8 @@ namespace Microsoft.Sbom.Parser
 {
     internal class TestParser
     {
-        private bool isFirstToken = true;
+        private bool isFileArrayParsingStarted = false;
+        private bool isPackageArrayParsingStarted = false;
         private JsonReaderState readerState;
         private byte[] buffer;
 
@@ -19,7 +20,36 @@ namespace Microsoft.Sbom.Parser
 
         public IEnumerable<SBOMPackage> GetPackages(Stream stream)
         {
-            return null;
+            stream.Read(buffer);
+
+            while (GetPackages(stream, out SBOMPackage sbomPackage) != 0)
+            {
+                yield return sbomPackage;
+            }
+
+            long GetPackages(Stream stream, out SBOMPackage sbomPackage)
+            {
+                var reader = new Utf8JsonReader(buffer, isFinalBlock: false, readerState);
+
+                if (!isPackageArrayParsingStarted)
+                {
+                    ParserUtils.SkipFirstArrayToken(stream, ref buffer, ref reader);
+                    isPackageArrayParsingStarted = true;
+                }
+
+                var parser = new SbomPackageParser(stream);
+                var result = parser.GetSbomPackage(ref buffer, ref reader, out sbomPackage);
+
+                // The caller always closes the ending }
+                if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    ParserUtils.Read(stream, ref buffer, ref reader);
+                    ParserUtils.GetMoreBytesFromStream(stream, ref buffer, ref reader);
+                }
+
+                readerState = reader.CurrentState;
+                return result;
+            }
         }
 
         public IEnumerable<SBOMFile> GetFiles(Stream stream)
@@ -35,15 +65,10 @@ namespace Microsoft.Sbom.Parser
             {
                 var reader = new Utf8JsonReader(buffer, isFinalBlock: false, readerState);
 
-                if (isFirstToken)
+                if (!isFileArrayParsingStarted)
                 {
-                    // Ensure first value is an array and read that so that we are the { token.
-                    ParserUtils.SkipNoneTokens(stream, ref buffer, ref reader);
-                    ParserUtils.AssertTokenType(stream, ref reader, JsonTokenType.StartArray);
-                    ParserUtils.Read(stream, ref buffer, ref reader);
-                    ParserUtils.GetMoreBytesFromStream(stream, ref buffer, ref reader);
-
-                    isFirstToken = false;
+                    ParserUtils.SkipFirstArrayToken(stream, ref buffer, ref reader);
+                    isFileArrayParsingStarted = true;
                 }
 
                 var parser = new SbomFileParser(stream);

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/TestParser.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/TestParser.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Sbom.Contracts;
 using Microsoft.Sbom.Parsers.Spdx22SbomParser;
+using Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
@@ -18,16 +19,16 @@ namespace Microsoft.Sbom.Parser
             buffer = new byte[bufferSize];
         }
 
-        public IEnumerable<SBOMPackage> GetPackages(Stream stream)
+        public IEnumerable<SPDXPackage> GetPackages(Stream stream)
         {
             stream.Read(buffer);
 
-            while (GetPackages(stream, out SBOMPackage sbomPackage) != 0)
+            while (GetPackages(stream, out SPDXPackage sbomPackage) != 0)
             {
                 yield return sbomPackage;
             }
 
-            long GetPackages(Stream stream, out SBOMPackage sbomPackage)
+            long GetPackages(Stream stream, out SPDXPackage sbomPackage)
             {
                 var reader = new Utf8JsonReader(buffer, isFinalBlock: false, readerState);
 

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/TestParser.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/TestParser.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Sbom.Contracts;
-using Microsoft.Sbom.Parsers.Spdx22SbomParser;
+﻿using Microsoft.Sbom.Parsers.Spdx22SbomParser;
 using Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
 using System.Collections.Generic;
 using System.IO;
@@ -53,16 +52,16 @@ namespace Microsoft.Sbom.Parser
             }
         }
 
-        public IEnumerable<SBOMFile> GetFiles(Stream stream)
+        public IEnumerable<SPDXFile> GetFiles(Stream stream)
         {        
             stream.Read(buffer);
 
-            while (GetFiles(stream, out SBOMFile sbomFile) != 0)
+            while (GetFiles(stream, out SPDXFile sbomFile) != 0)
             {
                 yield return sbomFile;
             }
 
-            long GetFiles(Stream stream, out SBOMFile sbomFile)
+            long GetFiles(Stream stream, out SPDXFile sbomFile)
             {
                 var reader = new Utf8JsonReader(buffer, isFinalBlock: false, readerState);
 


### PR DESCRIPTION
* Added the packages parser, which is exactly the same as the files parser with different properties.
* Moved some code into the ParserUtils struct for reusability. I will continue to move more stuff there to reuse in future PRs.
* Changed return type to SPDXFile and SPDXPackage, which makes sense since this is a SPDX parser. The conversion to SbomFile should be handled separately (most likely using an implicit constructor).