### PR TITLE
Users/viexianong/fix purl encoding

### DIFF
--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -17,14 +17,6 @@ The `Microsoft.Sbom.Common` project contains any common code, constants, etc tha
 
 The `Microsoft.Sbom.Contracts` project defines the interfaces that are used to call the SBOM tool through a C# API. The `ISBOMGenerator` class defines two methods that can be used to directly call the SBOM tool from C# code directly. The `Microsoft.Sbom.Tool` project defines a CLI interface to talk to the SBOM tool.
 
-### Package management using a public ADO feed
-
-The SBOM tool project uses the **SBOMToolPublic** feed as a package source to pull the required packages that are used to build the tool. The feed is a public Azure Artifacts feed, and can be accessed without authentication.
-
-All the packages that are needed to build the SBOM tool are already present in the feed, and most of the time you shouldn't have any issues pulling these packages from the feed. Occasionally, you might be building for a new environment that might require some additional packages that are not in the feed, in this case your build will fail as it won't be able to pull the required packages. If you are in this situation, please open an issue [here](https://github.com/microsoft/sbom-tool/issues) with the package and version for which the build failed. We will manually add those pacakges to the feed to unblock you right away.
-
-In the future, we will remove this feed and directly consume packages from nuget.org, when that happens, this additional steps won't be needed.
-
 ## Building on Visual Studio 
 
 Start Visual Studio 2022, and open the Microsoft.Sbom.sln file in the root of the repository. You can press `Ctrl + Shift + b` or select Build from the menu to build the application.

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/SPDXExtensions.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/SPDXExtensions.cs
@@ -26,11 +26,6 @@ namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Utils
         private static readonly Regex SpdxIdAllowedCharsRegex = new Regex("[^a-zA-Z0-9.-]");
 
         /// <summary>
-        ///  "@" chars in the namespace should be url encoded, SPDX SBOM recommendation.
-        /// </summary>
-        private static readonly Regex PUrlEncodingRegex = new Regex("@", RegexOptions.Compiled);
-
-        /// <summary>
         /// Returns the SPDX-compliant package ID.
         /// </summary>
         public static string GenerateSpdxPackageId(string id) => $"SPDXRef-Package-{GetStringHash(id)}";
@@ -83,21 +78,11 @@ namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Utils
                 {
                     ReferenceCategory = ReferenceCategory.PACKAGE_MANAGER.ToNormalizedString(),
                     Type = ExternalRepositoryType.purl,
-                    Locator = FormatPackageUrl(packageInfo.PackageUrl)
+                    Locator = packageInfo.PackageUrl,
                 };
 
                 spdxPackage.ExternalReferences.Add(extRef);
             }
-        }
-
-        /// <summary>
-        /// Used to encode and format packageurl, specifcally for @ to %40.
-        /// </summary>
-        /// <param name="packageUrl"></param>
-        /// <returns></returns>
-        private static string FormatPackageUrl(string packageUrl)
-        {
-            return PUrlEncodingRegex.Replace(packageUrl, "%40");
         }
 
         /// <summary>

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Utils/SPDXExtensionsTest.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Utils/SPDXExtensionsTest.cs
@@ -73,10 +73,10 @@ namespace SPDX22SBOMParserTest
         }
 
         [DataTestMethod]
-        [DataRow("pkg:npm/glob@7.1.6", "pkg:npm/glob%407.1.6")]
+        [DataRow("pkg:npm/glob@7.1.6", "pkg:npm/glob@7.1.6")]
         [DataRow("https://github.com/actions/virtual-environments", "https://github.com/actions/virtual-environments")]
 
-        public void AddPackageUrlsTest_WithEncoding_Success(string inputUrl, string expectedUrl)
+        public void AddPackageUrlsTest_WithSpecialCharacter_Success(string inputUrl, string expectedUrl)
         {
             spdxPackage = new SPDXPackage();
             spdxPackage.AddPackageUrls(new SBOMPackage { PackageUrl = inputUrl });


### PR DESCRIPTION
Remove the extra '@' character encoding in purl to adhere to Purl standards and SPDX specs. And remove the unneeded package management section from the doc.

**Before (extra '@' encoding in referenceLocator):** 
<img width="471" alt="image" src="https://user-images.githubusercontent.com/36138205/201232839-30366de8-0062-439f-8de6-0a065ee20960.png">
<img width="470" alt="image" src="https://user-images.githubusercontent.com/36138205/201232771-e6f73feb-068b-43ca-9414-d40d5ad5dfc8.png">


**After this change:**
<img width="466" alt="image" src="https://user-images.githubusercontent.com/36138205/201228584-8fd071c0-1eeb-4b37-993e-564f4a43a24b.png">
<img width="468" alt="image" src="https://user-images.githubusercontent.com/36138205/201228704-5844c588-2971-41ea-b097-a149d2e25f03.png">

