### PR TITLE
LicenseInfoFromFiles ignored to fit SPDX2.2 specs.

### DIFF
--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SPDXPackage.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SPDXPackage.cs
@@ -58,6 +58,7 @@ namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities
         /// <summary>
         /// Gets or sets contains all license found in the package.
         /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         [JsonPropertyName("licenseInfoFromFiles")]
         public List<string> LicenseInfoFromFiles { get; set; }
 

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Generator.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Generator.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Sbom.Parsers.Spdx22SbomParser
                 CopyrightText = packageInfo.CopyrightText ?? Constants.NoAssertionValue,
                 LicenseConcluded = packageInfo.LicenseInfo?.Concluded ?? Constants.NoAssertionValue,
                 LicenseDeclared = packageInfo.LicenseInfo?.Declared ?? Constants.NoAssertionValue,
-                LicenseInfoFromFiles = Constants.NoAssertionListValue,
+                LicenseInfoFromFiles = packageInfo.FilesAnalyzed ? Constants.NoAssertionListValue : null,
                 FilesAnalyzed = packageInfo.FilesAnalyzed,
                 Supplier = packageInfo.Supplier ?? Constants.NoAssertionValue
             };

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/GeneratorTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/GeneratorTests.cs
@@ -30,8 +30,8 @@ namespace Microsoft.Sbom.Parser
         public void GenerateJsonDocumentTest_FilesAnalyzed_IsTrue()
         {
             var generator = new Generator();
-            var expected = """"["NOASSERTION"]"""";
-
+            var expected = "[\"NOASSERTION\"]";
+            
             const string PackageUrl = "packageUrl";
             var packageInfo = new SbomPackage
             {

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/GeneratorTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/GeneratorTests.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.Sbom.Contracts;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Sbom.Parsers.Spdx22SbomParser;
+
+namespace Microsoft.Sbom.Parser
+{
+    [TestClass]
+    public class GeneratorTests
+    {
+        [TestMethod]
+        public void GenerateJsonDocumentTest_FilesAnalyzed_IsFalse()
+        {
+            var generator = new Generator();
+
+            const string PackageUrl = "packageUrl";
+            var packageInfo = new SbomPackage
+            {
+                PackageName = "test",
+                PackageUrl = PackageUrl,
+                FilesAnalyzed = false
+            };
+
+            var result = generator.GenerateJsonDocument(packageInfo);
+            var propertyExists = result.Document.RootElement.TryGetProperty("licenseInfoFromFiles", out var property);
+
+            Assert.IsFalse(propertyExists);
+        }
+
+        [TestMethod]
+        public void GenerateJsonDocumentTest_FilesAnalyzed_IsTrue()
+        {
+            var generator = new Generator();
+            var expected = """"["NOASSERTION"]"""";
+
+            const string PackageUrl = "packageUrl";
+            var packageInfo = new SbomPackage
+            {
+                PackageName = "test",
+                PackageUrl = PackageUrl,
+                FilesAnalyzed = true
+            };
+
+            var result = generator.GenerateJsonDocument(packageInfo);
+            var propertyExists = result.Document.RootElement.TryGetProperty("licenseInfoFromFiles", out var property);
+
+            Assert.IsTrue(propertyExists);
+            Assert.AreEqual(expected.ToString(), property.ToString());
+        }
+    }
+}


### PR DESCRIPTION
Addresses #216 by ignoring LicenseInfoFromFiles when FilesAnalyzed is false.