### PR TITLE
Fix console error when generating sbom.

### DIFF
--- a/src/Microsoft.Sbom.Api/Manifest/ManifestConfigHandlers/SPDX22ManifestConfigHandler.cs
+++ b/src/Microsoft.Sbom.Api/Manifest/ManifestConfigHandlers/SPDX22ManifestConfigHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Sbom.Api.Manifest.ManifestConfigHandlers
         private readonly IConfiguration configuration;
         private readonly IFileSystemUtils fileSystemUtils;
 
-        private string ManifestDirPath => configuration.ManifestDirPath.Value;
+        private string ManifestDirPath => configuration.ManifestDirPath?.Value;
 
         // directory path for SPDX 2.2 is 
         // root/_manifest/spdx_2.2/


### PR DESCRIPTION
Stops "Object reference not set to an instance of an object." from being displayed in the console at the end of the Generation task.