### PR TITLE
Update Package Parser to fit SPDX2.2 specs.

### DIFF
--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/SbomPackageParser.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/SbomPackageParser.cs
@@ -109,7 +109,7 @@ internal ref struct SbomPackageParser
             missingProps.Add(nameof(sbomPackage.LicenseConcluded));
         }
 
-        if (sbomPackage.LicenseInfoFromFiles == null || sbomPackage.LicenseInfoFromFiles.Count == 0)
+        if ((sbomPackage.LicenseInfoFromFiles == null && sbomPackage.FilesAnalyzed == true) || (sbomPackage.LicenseInfoFromFiles?.Count == 0 && sbomPackage.FilesAnalyzed == true))
         {
             missingProps.Add(nameof(sbomPackage.LicenseInfoFromFiles));
         }

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/SbomPackageParser.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/SbomPackageParser.cs
@@ -109,7 +109,7 @@ internal ref struct SbomPackageParser
             missingProps.Add(nameof(sbomPackage.LicenseConcluded));
         }
 
-        if ((sbomPackage.LicenseInfoFromFiles == null && sbomPackage.FilesAnalyzed == true) || (sbomPackage.LicenseInfoFromFiles?.Count == 0 && sbomPackage.FilesAnalyzed == true))
+        if (sbomPackage.FilesAnalyzed && (sbomPackage.LicenseInfoFromFiles == null || sbomPackage.LicenseInfoFromFiles?.Count == 0))
         {
             missingProps.Add(nameof(sbomPackage.LicenseInfoFromFiles));
         }

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomPackageParserTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomPackageParserTests.cs
@@ -85,6 +85,7 @@ public class SbomPackageParserTests
     [DataRow(SbomPackageStrings.PackageJsonWith1PackageBadReferenceType)]
     [DataRow(SbomPackageStrings.PackageJsonWith1PackageMissingReferenceLocator)]
     [DataRow(SbomPackageStrings.PackageJsonWith1PackageMissingPackageVerificationCode)]
+    [DataRow(SbomPackageStrings.PackageJsonWith1PackageFilesAnalyzedTrueAndMissingLicenseInfoFromFiles)]
     [ExpectedException(typeof(ParserException))]
     public void MissingPropertiesTest_Throws(string json)
     {

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/Strings/SbomPackageStrings.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/Strings/SbomPackageStrings.cs
@@ -134,6 +134,27 @@ internal struct SbomPackageStrings
       ""supplier"": ""Organization: testa""
     }]}";
 
+    public const string PackageJsonWith1PackageFilesAnalyzedTrueAndMissingLicenseInfoFromFiles = @"{
+       ""packages"": [{
+      ""name"": ""pest"",
+      ""other"": ""tt"",
+      ""SPDXID"": ""SPDXRef-Package-1C4595D6D70121622649BB913859B18A3C0A2D49EC7D36279777025C4AC92303"",
+      ""downloadLocation"": ""NOASSERTION"",
+      ""filesAnalyzed"": true,
+      ""licenseConcluded"": ""NOASSERTION"",
+      ""licenseDeclared"": ""NOASSERTION"",
+      ""copyrightText"": ""NOASSERTION"",
+      ""versionInfo"": ""1.0.0"",
+      ""externalRefs"": [
+        {
+          ""referenceCategory"": ""PACKAGE_MANAGER"",
+          ""referenceType"": ""purl"",
+          ""referenceLocator"": ""pkg:nuget/pest%401.0.0""
+        }
+      ],
+      ""supplier"": ""Organization: testa""
+    }]}";
+
     public const string PackageJsonWith1PackageMissingPackageVerificationCode = @"{
        ""packages"": [{
       ""name"": ""pest"",
@@ -504,9 +525,6 @@ internal struct SbomPackageStrings
       ""downloadLocation"": ""NOASSERTION"",
       ""filesAnalyzed"": false,
       ""licenseConcluded"": ""NOASSERTION"",
-      ""licenseInfoFromFiles"": [
-        ""NOASSERTION""
-      ],
       ""licenseDeclared"": ""NOASSERTION"",
       ""copyrightText"": ""NOASSERTION"",
       ""versionInfo"": ""20220905.1"",


### PR DESCRIPTION
Package parser needed to be updated to fit SPDX2.2 specs. when filesAnalyzed is false then licenseInfoFromFiles can be omitted and should not throw an error.