### PR TITLE
Update check for SPDX files in file filterer.

### DIFF
--- a/src/Microsoft.Sbom.Api/Executors/FileFilterer.cs
+++ b/src/Microsoft.Sbom.Api/Executors/FileFilterer.cs
@@ -8,7 +8,6 @@ using Microsoft.Sbom.Common.Config;
 using Microsoft.Sbom.Extensions.Entities;
 using Serilog;
 using System;
-using System.IO;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 

--- a/src/Microsoft.Sbom.Api/Executors/FileFilterer.cs
+++ b/src/Microsoft.Sbom.Api/Executors/FileFilterer.cs
@@ -58,18 +58,6 @@ namespace Microsoft.Sbom.Api.Executors
         {
             try
             {
-                // Filter SPDX type files.
-                if (file.FileTypes != null && file.FileTypes.Contains(Contracts.Enums.FileType.SPDX))
-                {
-                    await errors.Writer.WriteAsync(new FileValidationResult
-                    {
-                        ErrorType = ErrorType.ReferencedSbomFile,
-                        Path = file.Path,
-                    });
-
-                    return;
-                }
-
                 // Filter paths that are not present on disk.
                 var fullPath = fileSystemUtils.JoinPaths(configuration.BuildDropPath.Value, file.Path);
                 if (!rootPathFilter.IsValid(fullPath))

--- a/src/Microsoft.Sbom.Api/Executors/FileFilterer.cs
+++ b/src/Microsoft.Sbom.Api/Executors/FileFilterer.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Sbom.Api.Executors
                     {
                         await errors.Writer.WriteAsync(new FileValidationResult
                         {
-                            ErrorType = ErrorType.FilteredRootPath,
+                            ErrorType = ErrorType.ReferencedSbomFile,
                             Path = file.Path
                         });
 


### PR DESCRIPTION
Addresses #213. Stops validation from skipping spdx files that are present within the same build drop path.