### PR TITLE
Throw appropriate error message when a manifest file is not present during validation.

### DIFF
--- a/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfigProvider.cs
+++ b/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfigProvider.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Sbom.Common.Extensions;
 using System.IO;
+using Microsoft.Sbom.Common.Config;
 
 namespace Microsoft.Sbom.Api.Manifest.Configuration
 {
@@ -67,22 +68,20 @@ namespace Microsoft.Sbom.Api.Manifest.Configuration
         private readonly IEnumerable<IMetadataProvider> metadataProviders;
         private readonly ILogger logger;
         private readonly IRecorder recorder;
+        private readonly IConfiguration config;
 
         public SbomConfigProvider(
             IEnumerable<IManifestConfigHandler> manifestConfigHandlers,
             IEnumerable<IMetadataProvider> metadataProviders,
             ILogger logger,
-            IRecorder recorder)
+            IRecorder recorder,
+            IConfiguration config)
         {
-            if (manifestConfigHandlers is null)
-            {
-                throw new ArgumentNullException(nameof(manifestConfigHandlers));
-            }
-
             this.manifestConfigHandlers = manifestConfigHandlers ?? throw new ArgumentNullException(nameof(manifestConfigHandlers));
             this.metadataProviders = metadataProviders ?? throw new ArgumentNullException(nameof(metadataProviders));
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this.recorder = recorder ?? throw new ArgumentNullException(nameof(recorder));
+            this.config = config ?? throw new ArgumentNullException(nameof(config));
         }
 
         /// <inheritdoc/>
@@ -96,7 +95,7 @@ namespace Microsoft.Sbom.Api.Manifest.Configuration
             }
             else
             {
-                throw new FileNotFoundException($"Unable to handle a manifest of type {manifestInfo} or no manifest file was found.");
+                throw new FileNotFoundException($"Unable to handle a manifest of type {manifestInfo} or no manifest file was found in the provided drop path {config.BuildDropPath}.");
             }
         }
 

--- a/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfigProvider.cs
+++ b/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfigProvider.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Sbom.Common.Extensions;
+using System.IO;
 
 namespace Microsoft.Sbom.Api.Manifest.Configuration
 {
@@ -87,12 +88,16 @@ namespace Microsoft.Sbom.Api.Manifest.Configuration
         /// <inheritdoc/>
         public ISbomConfig Get(ManifestInfo manifestInfo)
         {
-            if (manifestInfo is null)
-            {
-                throw new ArgumentNullException(nameof(manifestInfo));
-            }
+            ArgumentNullException.ThrowIfNull(nameof(manifestInfo));
 
-            return ConfigsDictionary[manifestInfo];
+            if (ConfigsDictionary.TryGetValue(manifestInfo, out var value))
+            {
+                return value;
+            }
+            else
+            {
+                throw new FileNotFoundException($"Unable to handle a manifest of type {manifestInfo} or no manifest file was found.");
+            }
         }
 
         /// <inheritdoc/>

--- a/test/Microsoft.Sbom.Api.Tests/Config/SBOMConfigTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/SBOMConfigTests.cs
@@ -92,6 +92,7 @@ namespace Microsoft.Sbom.Api.Tests.Config
                 manifestConfigHandlers: new IManifestConfigHandler[] { configHandler.Object },
                 metadataProviders: metadataProviders,
                 logger: logger.Object,
-                recorder: recorder.Object);
+                recorder: recorder.Object,
+                config: config);
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/ManifestGenerationWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/ManifestGenerationWorkflowTests.cs
@@ -107,7 +107,8 @@ namespace Microsoft.Sbom.Api.Workflows.Tests
                 new IManifestConfigHandler[] { mockConfigHandler.Object },
                 new IMetadataProvider[] { mockMetadataProvider.Object },
                 mockLogger.Object,
-                recorderMock.Object);
+                recorderMock.Object,
+                configurationMock.Object);
 
             using var manifestStream = new MemoryStream();
             using var manifestWriter = new StreamWriter(manifestStream);


### PR DESCRIPTION
I think where this fix is made is awkward, but given how the objects are initialized, this seems to be the most appropriate place for it.  Initially, I wanted to add this code within the validation workflow, but at that point it's "too late" and the condition handled in this PR has already occurred.