### PR TITLE
Add telemetry when tool fails early.

### DIFF
--- a/src/Microsoft.Sbom.Api/Output/Telemetry/Entities/SBOMTelemetry.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/Entities/SBOMTelemetry.cs
@@ -54,5 +54,11 @@ namespace Microsoft.Sbom.Api.Output.Telemetry.Entities
         /// of the exception.
         /// </summary>
         public IDictionary<string, string> Exceptions { get; set; }
+
+        /// <summary>
+        /// Gets or sets the args that were passed to the tool. This is used when the tool fails before
+        /// the IConfiguration is set.
+        /// </summary>
+        public string[] Arguments { get; set; }
     }
 }

--- a/src/Microsoft.Sbom.Api/Output/Telemetry/TelemetryRecorder.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/TelemetryRecorder.cs
@@ -53,13 +53,20 @@ namespace Microsoft.Sbom.Api.Output.Telemetry
             FileSystemUtils = fileSystemUtils ?? throw new ArgumentNullException(nameof(fileSystemUtils));
         }
 
+        /// <summary>
+        /// Create an instance of TelemtryRecorder without the need for a configuration object for scenarios where the tool fails before a configuration is available.
+        /// </summary>
+        /// <param name="telemetryFilePath">The path where the telemetry will be written to.</param>
+        /// <param name="fileSystemUtils">Wrapper around file system functions.</param>
         public static TelemetryRecorder Create(string telemetryFilePath, IFileSystemUtils fileSystemUtils)
         {
             return new TelemetryRecorder(telemetryFilePath, fileSystemUtils);
         }
 
-        //Method to log telemetry in conditions when the tool is not able to start execution of workflow.
-        public async Task ConsoleLogger(Exception e)
+        /// <summary>
+        /// Method to log telemetry in conditions when the tool is not able to start execution of workflow.
+        /// </summary>
+        public async Task LogToConsole(Exception e)
         {
             var logger = new LoggerConfiguration().WriteTo.Console().CreateLogger();
             try

--- a/src/Microsoft.Sbom.Api/Output/Telemetry/TelemetryRecorder.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/TelemetryRecorder.cs
@@ -89,22 +89,7 @@ namespace Microsoft.Sbom.Api.Output.Telemetry
                 // Log to logger.
                 logger.Information("Could not start execution of workflow. Logging telemetry {@Telemetry}", telemetry);
 
-                // Write to file.
-                if (!string.IsNullOrWhiteSpace(telemetryFilePath))
-                {
-                    using (var fileStream = FileSystemUtils.OpenWrite(telemetryFilePath))
-                    {
-                        var options = new JsonSerializerOptions
-                        {
-                            Converters =
-                        {
-                            new JsonStringEnumConverter()
-                        }
-                        };
-                        await JsonSerializer.SerializeAsync(fileStream, telemetry, options);
-                        logger.Debug($"Wrote telemetry object to path {telemetryFilePath}");
-                    }
-                }
+                await RecordToFile(telemetry, telemetryFilePath);
             }
             catch (Exception ex)
             {
@@ -157,6 +142,30 @@ namespace Microsoft.Sbom.Api.Output.Telemetry
             }
 
             this.sbomFormats[manifestInfo] = sbomFilePath;
+        }
+
+        /// <summary>
+        /// Write telemetry object to the telemetryFilePath.
+        /// </summary>
+        /// <param name="telemetry">The telemetry object to be written to the file.</param>
+        /// /// <param name="telemetryFilePath">The file path we want to write the telemetry to.</param>
+        public async Task RecordToFile(SBOMTelemetry telemetry, string telemetryFilePath)
+        {
+            // Write to file.
+            if (!string.IsNullOrWhiteSpace(telemetryFilePath))
+            {
+                using (var fileStream = FileSystemUtils.OpenWrite(telemetryFilePath))
+                {
+                    var options = new JsonSerializerOptions
+                    {
+                        Converters =
+                        {
+                                new JsonStringEnumConverter()
+                        }
+                    };
+                    await JsonSerializer.SerializeAsync(fileStream, telemetry, options);
+                }
+            }
         }
 
         /// <summary>
@@ -239,22 +248,9 @@ namespace Microsoft.Sbom.Api.Output.Telemetry
                 // Log to logger.
                 Log.Information("Finished execution of the {Action} workflow {@Telemetry}", Configuration.ManifestToolAction, telemetry);
 
-                // Write to file.
-                if (!string.IsNullOrWhiteSpace(Configuration.TelemetryFilePath?.Value))
-                {
-                    using (var fileStream = FileSystemUtils.OpenWrite(Configuration.TelemetryFilePath.Value))
-                    {
-                        var options = new JsonSerializerOptions
-                        {
-                            Converters =
-                        {
-                            new JsonStringEnumConverter()
-                        }
-                        };
-                        await JsonSerializer.SerializeAsync(fileStream, telemetry, options);
-                        Log.Debug($"Wrote telemetry object to path {Configuration.TelemetryFilePath.Value}");
-                    }
-                }
+                await RecordToFile(telemetry, Configuration.TelemetryFilePath?.Value);
+                Log.Debug($"Wrote telemetry object to path {telemetryFilePath}");
+
             }
             catch (Exception ex)
             {

--- a/src/Microsoft.Sbom.Api/Output/Telemetry/TelemetryRecorder.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/TelemetryRecorder.cs
@@ -250,7 +250,6 @@ namespace Microsoft.Sbom.Api.Output.Telemetry
 
                 await RecordToFile(telemetry, Configuration.TelemetryFilePath?.Value);
                 Log.Debug($"Wrote telemetry object to path {telemetryFilePath}");
-
             }
             catch (Exception ex)
             {

--- a/src/Microsoft.Sbom.Api/Output/Telemetry/TelemetryRecorder.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/TelemetryRecorder.cs
@@ -66,7 +66,9 @@ namespace Microsoft.Sbom.Api.Output.Telemetry
         /// <summary>
         /// Method to log telemetry in conditions when the tool is not able to start execution of workflow.
         /// </summary>
-        public async Task LogToConsole(Exception e)
+        /// <param name="e">Exception that we want to log.</param>
+        /// <param name="args">Arguments used to run the tool.</param>
+        public async Task LogToConsole(Exception e, string[] args)
         {
             var logger = new LoggerConfiguration().WriteTo.Console().CreateLogger();
             try
@@ -83,7 +85,8 @@ namespace Microsoft.Sbom.Api.Output.Telemetry
                     Result = Result.Failure,
                     Timings = timingRecorders.Select(t => t.ToTiming()).ToList(),
                     Switches = this.switches,
-                    Exceptions = exceptions
+                    Arguments = args,
+                    Exceptions = exceptions,
                 };
 
                 // Log to logger.

--- a/src/Microsoft.Sbom.Api/Output/Telemetry/TelemetryRecorder.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/TelemetryRecorder.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Sbom.Api.Output.Telemetry
     /// </summary>
     public class TelemetryRecorder : IRecorder
     {
-        private readonly ConcurrentBag<TimingRecorder> timingRecorders = new();
+        private readonly ConcurrentBag<TimingRecorder> timingRecorders = new ();
         private readonly IDictionary<ManifestInfo, string> sbomFormats = new Dictionary<ManifestInfo, string>();
         private readonly IDictionary<string, object> switches = new Dictionary<string, object>();
         private readonly IList<Exception> exceptions = new List<Exception>();

--- a/src/Microsoft.Sbom.Tool/Program.cs
+++ b/src/Microsoft.Sbom.Tool/Program.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Sbom.Tool
                                 {
                                     var recorder = TelemetryRecorder.Create(telemetryFilePath, fileSystemUtils);
                                     _ = recorder.LogToConsole(e);
-                                    throw e;
+                                    throw;
                                 }
                             })
 

--- a/src/Microsoft.Sbom.Tool/Program.cs
+++ b/src/Microsoft.Sbom.Tool/Program.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Sbom.Tool
                                 catch (Exception e)
                                 {
                                     var recorder = TelemetryRecorder.Create(telemetryFilePath, fileSystemUtils);
-                                    _ = recorder.LogToConsole(e);
+                                    _ = recorder.LogToConsole(e, args);
                                     throw;
                                 }
                             })

--- a/src/Microsoft.Sbom.Tool/Program.cs
+++ b/src/Microsoft.Sbom.Tool/Program.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Sbom.Tool
                                 catch (Exception e)
                                 {
                                     var recorder = TelemetryRecorder.Create(telemetryFilePath, fileSystemUtils);
-                                    _ = recorder.ConsoleLogger(e);
+                                    _ = recorder.LogToConsole(e);
                                     throw e;
                                 }
                             })


### PR DESCRIPTION
Logs errors that can happen before execution reaches either of the workflows.