### PR TITLE
fix serialization of '+' signs

### DIFF
--- a/src/Microsoft.Sbom.Api/Output/ManifestToolJsonSerializer.cs
+++ b/src/Microsoft.Sbom.Api/Output/ManifestToolJsonSerializer.cs
@@ -4,7 +4,9 @@
 using Microsoft.Sbom.Extensions;
 using System;
 using System.IO;
+using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Unicode;
 using System.Threading.Tasks;
 
 namespace Microsoft.Sbom.Api.Output
@@ -27,7 +29,7 @@ namespace Microsoft.Sbom.Api.Output
                 throw new ArgumentNullException(nameof(stream));
             }
 
-            jsonWriter = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true });
+            jsonWriter = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true, Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping });
         }
 
         public void Dispose()
@@ -94,7 +96,7 @@ namespace Microsoft.Sbom.Api.Output
         /// <summary>
         /// Writes the end JSON object. Must be called after finishing writing to 
         /// the serializer to close the json object.
-        /// </summary>
+        /// </summary>s
         public void FinalizeJsonObject() => jsonWriter.WriteEndObject();
 
         /// <summary>

--- a/src/Microsoft.Sbom.Api/Output/ManifestToolJsonSerializer.cs
+++ b/src/Microsoft.Sbom.Api/Output/ManifestToolJsonSerializer.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Sbom.Api.Output
         /// <summary>
         /// Writes the end JSON object. Must be called after finishing writing to 
         /// the serializer to close the json object.
-        /// </summary>s
+        /// </summary>
         public void FinalizeJsonObject() => jsonWriter.WriteEndObject();
 
         /// <summary>


### PR DESCRIPTION
Addresses #234.

This seems to be a common issue. This was the only way I could get the sign to be displayed as a '+' instead of '\u002B'. I have linked some threads below to consider before we make a decision on making this change.

I attempted other methods before going with this approach such as creating custom encoder settings that allowed the specific character in question to be allowed or allowing all unicode chars to be allowed. None of these worked.

1. https://github.com/dotnet/runtime/issues/35281
2. https://github.com/dotnet/runtime/issues/50998

![caution](https://user-images.githubusercontent.com/69322674/230952240-24851656-d4e0-4936-acea-1149e28f6148.png)
