### PR TITLE
Make -nsb parameter optional.

### DIFF
--- a/src/Microsoft.Sbom.Api/Config/ConfigSanitizer.cs
+++ b/src/Microsoft.Sbom.Api/Config/ConfigSanitizer.cs
@@ -12,6 +12,7 @@ using Serilog;
 using Serilog.Core;
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using Constants = Microsoft.Sbom.Api.Utils.Constants;
 
 namespace Microsoft.Sbom.Api.Config
@@ -24,6 +25,13 @@ namespace Microsoft.Sbom.Api.Config
         private readonly IHashAlgorithmProvider hashAlgorithmProvider;
         private readonly IFileSystemUtils fileSystemUtils;
         private readonly IAssemblyConfig assemblyConfig;
+
+        internal static string SBOMToolVersion => VersionValue.Value;
+
+        private static readonly Lazy<string> VersionValue = new Lazy<string>(() =>
+        {
+            return typeof(SbomToolCmdRunner).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? string.Empty;
+        });
 
         public ConfigSanitizer(IHashAlgorithmProvider hashAlgorithmProvider, IFileSystemUtils fileSystemUtils, IAssemblyConfig assemblyConfig)
         {
@@ -50,8 +58,8 @@ namespace Microsoft.Sbom.Api.Config
             // set ManifestDirPath after validation of DirectoryExist and DirectoryPathIsWritable, this wouldn't exist because it needs to be created by the tool.
             configuration.ManifestDirPath = GetManifestDirPath(configuration.ManifestDirPath, configuration.BuildDropPath.Value, configuration.ManifestToolAction);
 
-            // Set namespace value if provided in the assembly
-            configuration.NamespaceUriBase = GetNamespaceBaseUriFromAssembly(configuration, logger);
+            // Set namespace value, this handles default values and user provided values.
+            configuration.NamespaceUriBase = GetNamespaceBaseUri(configuration, logger);
 
             // Set default ManifestInfo for validation in case user doesn't provide a value.
             configuration.ManifestInfo = GetDefaultManifestInfoForValidationAction(configuration);
@@ -106,12 +114,26 @@ namespace Microsoft.Sbom.Api.Config
             };
         }
 
-        private ConfigurationSetting<string> GetNamespaceBaseUriFromAssembly(IConfiguration configuration, ILogger logger)
+        private ConfigurationSetting<string> GetNamespaceBaseUri(IConfiguration configuration, ILogger logger)
         {
-            // If assembly name is not defined returned the current value.
-            if (string.IsNullOrWhiteSpace(assemblyConfig.DefaultSBOMNamespaceBaseUri))
+            // If assembly name is not defined but a namespace was provided, then return the current value.
+            if (string.IsNullOrWhiteSpace(assemblyConfig.DefaultSBOMNamespaceBaseUri) && !string.IsNullOrEmpty(configuration.NamespaceUriBase?.Value))
             {
                 return configuration.NamespaceUriBase;
+            }
+
+            // If assembly name is not defined and namespace was not provided then return the default namespace as per spdx spec https://spdx.github.io/spdx-spec/v2.2.2/document-creation-information/#653-examples.
+            if (string.IsNullOrWhiteSpace(assemblyConfig.DefaultSBOMNamespaceBaseUri) && string.IsNullOrEmpty(configuration.NamespaceUriBase?.Value))
+            {
+                string defaultNamespaceUriBase = "https://spdx.org/spdxdocs/sbom-tool-" + SBOMToolVersion + "-" + Guid.NewGuid();
+
+                logger.Information($"No namespace URI base provided, using default value {defaultNamespaceUriBase}");
+
+                return new ConfigurationSetting<string>
+                {
+                    Source = SettingSource.Default,
+                    Value = defaultNamespaceUriBase
+                };
             }
 
             // If the user provides the parameter even when the assembly attribute is provided, 

--- a/src/Microsoft.Sbom.Api/Config/ConfigSanitizer.cs
+++ b/src/Microsoft.Sbom.Api/Config/ConfigSanitizer.cs
@@ -28,10 +28,7 @@ namespace Microsoft.Sbom.Api.Config
 
         internal static string SBOMToolVersion => VersionValue.Value;
 
-        private static readonly Lazy<string> VersionValue = new Lazy<string>(() =>
-        {
-            return typeof(SbomToolCmdRunner).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? string.Empty;
-        });
+        private static readonly Lazy<string> VersionValue = new Lazy<string>(() => typeof(SbomToolCmdRunner).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? string.Empty);
 
         public ConfigSanitizer(IHashAlgorithmProvider hashAlgorithmProvider, IFileSystemUtils fileSystemUtils, IAssemblyConfig assemblyConfig)
         {
@@ -125,7 +122,7 @@ namespace Microsoft.Sbom.Api.Config
             // If assembly name is not defined and namespace was not provided then return the default namespace as per spdx spec https://spdx.github.io/spdx-spec/v2.2.2/document-creation-information/#653-examples.
             if (string.IsNullOrWhiteSpace(assemblyConfig.DefaultSBOMNamespaceBaseUri) && string.IsNullOrEmpty(configuration.NamespaceUriBase?.Value))
             {
-                string defaultNamespaceUriBase = "https://spdx.org/spdxdocs/sbom-tool-" + SBOMToolVersion + "-" + Guid.NewGuid();
+                string defaultNamespaceUriBase = $"https://spdx.org/spdxdocs/sbom-tool-{SBOMToolVersion}-{Guid.NewGuid()}";
 
                 logger.Information($"No namespace URI base provided, using default value {defaultNamespaceUriBase}");
 

--- a/src/Microsoft.Sbom.Api/Config/Validators/ConfigValidator.cs
+++ b/src/Microsoft.Sbom.Api/Config/Validators/ConfigValidator.cs
@@ -50,12 +50,12 @@ namespace Microsoft.Sbom.Common.Config.Validators
                 return;
             }
 
-            // If default value for namespace base uri is provided in the assembly info, skip value check requirements.
-            if (propertyName == nameof(IConfiguration.NamespaceUriBase) && !string.IsNullOrEmpty(assemblyConfig.DefaultSBOMNamespaceBaseUri))
+            // Skip validation for properties if NamespaceUriBase. This case is handled in the ConfigSanitizer
+            if (propertyName == nameof(IConfiguration.NamespaceUriBase))
             {
                 return;
             }
-            
+  
             if (propertyName == nameof(IConfiguration.PackageSupplier) && !string.IsNullOrEmpty(assemblyConfig.DefaultPackageSupplier))
             {
                 return;

--- a/src/Microsoft.Sbom.Api/Config/Validators/ConfigValidator.cs
+++ b/src/Microsoft.Sbom.Api/Config/Validators/ConfigValidator.cs
@@ -50,8 +50,8 @@ namespace Microsoft.Sbom.Common.Config.Validators
                 return;
             }
 
-            // Skip validation for properties if NamespaceUriBase. This case is handled in the ConfigSanitizer
-            if (propertyName == nameof(IConfiguration.NamespaceUriBase))
+            // Skip validation of the NamespaceUriBase if it is empty. This is handled in the ConfigSanitizer
+            if (propertyName == nameof(IConfiguration.NamespaceUriBase) && propertyValue == null)
             {
                 return;
             }

--- a/src/Microsoft.Sbom.Api/Config/Validators/ConfigValidator.cs
+++ b/src/Microsoft.Sbom.Api/Config/Validators/ConfigValidator.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Sbom.Common.Config.Validators
             }
 
             // Skip validation of the NamespaceUriBase if it is empty. This is handled in the ConfigSanitizer
-            if (propertyName == nameof(IConfiguration.NamespaceUriBase) && propertyValue == null)
+            if (propertyName == nameof(IConfiguration.NamespaceUriBase) && (propertyValue == null || (!string.IsNullOrEmpty(assemblyConfig.DefaultSBOMNamespaceBaseUri))))
             {
                 return;
             }

--- a/src/Microsoft.Sbom.Api/Config/Validators/ConfigValidator.cs
+++ b/src/Microsoft.Sbom.Api/Config/Validators/ConfigValidator.cs
@@ -50,8 +50,8 @@ namespace Microsoft.Sbom.Common.Config.Validators
                 return;
             }
 
-            // Skip validation of the NamespaceUriBase if it is empty. This is handled in the ConfigSanitizer
-            if (propertyName == nameof(IConfiguration.NamespaceUriBase) && (propertyValue == null || (!string.IsNullOrEmpty(assemblyConfig.DefaultSBOMNamespaceBaseUri))))
+            // Skip validation of the NamespaceUriBase if it is empty or has a default provided by the assembly info, This case is handled in the ConfigSanitizer.
+            if (propertyName == nameof(IConfiguration.NamespaceUriBase) && NamespaceUriBaseIsNullOrHasDefaultValue(propertyValue))
             {
                 return;
             }
@@ -82,6 +82,20 @@ namespace Microsoft.Sbom.Common.Config.Validators
 
                 default:
                     throw new ArgumentException($"'{propertyName}' must be of type '{typeof(ConfigurationSetting<>)}'");
+            }
+        }
+
+        private bool NamespaceUriBaseIsNullOrHasDefaultValue(object propertyValue)
+        {
+            var defaultProperty = assemblyConfig.DefaultSBOMNamespaceBaseUri;
+
+            if (propertyValue == null || !string.IsNullOrEmpty(defaultProperty))
+            {
+                return true;
+            }
+            else
+            {
+                return false;
             }
         }
 

--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForGeneration.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForGeneration.cs
@@ -203,6 +203,35 @@ namespace Microsoft.Sbom.Api.Config.Tests
         }
 
         [TestMethod]
+        public async Task ConfigurationBuilderTest_Generation_NullNSBaseUriChangesToDefault()
+        {
+            var configFileParser = new ConfigFileParser(fileSystemUtilsMock.Object);
+            var cb = new ConfigurationBuilder<GenerationArgs>(mapper, configFileParser);
+
+            fileSystemUtilsMock.Setup(f => f.DirectoryExists(It.IsAny<string>())).Returns(true);
+            fileSystemUtilsMock.Setup(f => f.DirectoryHasReadPermissions(It.IsAny<string>())).Returns(true);
+            fileSystemUtilsMock.Setup(f => f.DirectoryHasWritePermissions(It.IsAny<string>())).Returns(true);
+            fileSystemUtilsMock.Setup(f => f.JoinPaths(It.IsAny<string>(), It.IsAny<string>())).Returns((string p1, string p2) => Path.Join(p1, p2));
+
+            var args = new GenerationArgs
+            {
+                BuildDropPath = "BuildDropPath",
+                ManifestDirPath = "ManifestDirPath",
+                NamespaceUriBase = null,
+                PackageSupplier = "Contoso"
+            };
+
+            var config = await cb.GetConfiguration(args);
+
+            Assert.IsNotNull(config); 
+            Assert.IsNotNull(config.ManifestDirPath);
+            Assert.IsNotNull(config.NamespaceUriBase);
+            Assert.AreEqual(Path.Join("ManifestDirPath", Constants.ManifestFolder), config.ManifestDirPath.Value);
+
+            fileSystemUtilsMock.VerifyAll();
+        }
+
+        [TestMethod]
         public async Task ConfigurationBuilderTest_Generation_BadNSBaseUriWithDefaultValue_Succeds()
         {
             var configFileParser = new ConfigFileParser(fileSystemUtilsMock.Object);

--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForGeneration.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForGeneration.cs
@@ -224,7 +224,7 @@ namespace Microsoft.Sbom.Api.Config.Tests
             var config = await cb.GetConfiguration(args);
 
             Assert.IsNotNull(config); 
-            Assert.IsNotNull(config.ManifestDirPath);
+            Assert.IsNotNull(args.ManifestDirPath);
             Assert.IsNotNull(config.NamespaceUriBase);
             Assert.AreEqual(Path.Join("ManifestDirPath", Constants.ManifestFolder), config.ManifestDirPath.Value);
 


### PR DESCRIPTION
Resolves #206

Updated -nsb to provide a default value when it is null. This was done following the spdx specs which allow the use of a default value. (Specified in section 6.5.2).

https://spdx.github.io/spdx-spec/v2.2.2/document-creation-information/#653-examples

