### PR TITLE
Check manifest exists on path before validating.

### DIFF
--- a/src/Microsoft.Sbom.Api/Config/ConfigSanitizer.cs
+++ b/src/Microsoft.Sbom.Api/Config/ConfigSanitizer.cs
@@ -12,6 +12,8 @@ using Serilog;
 using Serilog.Core;
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using Constants = Microsoft.Sbom.Api.Utils.Constants;
 
 namespace Microsoft.Sbom.Api.Config
@@ -190,11 +192,11 @@ namespace Microsoft.Sbom.Api.Config
         /// </summary>
         private void ValidateManifestFileExists(IConfiguration configuration)
         {
-            var manifestFilePath = fileSystemUtils.JoinPaths(configuration.ManifestDirPath.Value, "manifest.spdx.json");
+            string[] filesInsideManifestDirPath = Directory.GetFileSystemEntries(configuration.ManifestDirPath.Value, "*", SearchOption.AllDirectories);
 
-            if (!fileSystemUtils.FileExists(manifestFilePath))
+            if (!filesInsideManifestDirPath.Any(entry => entry.EndsWith(".spdx.json") || entry.EndsWith("manifest.json")))
             {
-                throw new ValidationArgException($"No manifest file found at {manifestFilePath}. Please provide a buildDropPath (-b) that contains a manifest.");
+                throw new ValidationArgException($"No manifest file found in the manifest directory {configuration.ManifestDirPath.Value}");
             }
         }
 

--- a/src/Microsoft.Sbom.Api/Config/ConfigSanitizer.cs
+++ b/src/Microsoft.Sbom.Api/Config/ConfigSanitizer.cs
@@ -12,8 +12,6 @@ using Serilog;
 using Serilog.Core;
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using Constants = Microsoft.Sbom.Api.Utils.Constants;
 
 namespace Microsoft.Sbom.Api.Config

--- a/src/Microsoft.Sbom.Api/Config/ConfigSanitizer.cs
+++ b/src/Microsoft.Sbom.Api/Config/ConfigSanitizer.cs
@@ -194,30 +194,16 @@ namespace Microsoft.Sbom.Api.Config
         {
             var spdxManifestDirPath = fileSystemUtils.JoinPaths(configuration.ManifestDirPath.Value, "spdx_2.2");
             var spdxManifestFilePath = fileSystemUtils.JoinPaths(spdxManifestDirPath, "manifest.spdx.json");
-            var manifestInfo = configuration.ManifestInfo.Value;
+            var nonSpdxManifestFilePath = fileSystemUtils.JoinPaths(configuration.ManifestDirPath.Value, "manifest.json");
 
-            if (!fileSystemUtils.DirectoryExists(spdxManifestDirPath))
+            if (!fileSystemUtils.FileExists(spdxManifestFilePath))
             {
+                if (fileSystemUtils.FileExists(nonSpdxManifestFilePath))
+                {
+                    return;
+                }
+
                 throw new ValidationArgException($"No manifest file found at {configuration.ManifestDirPath.Value}.");
-            }
-
-            if (fileSystemUtils.DirectoryExists(spdxManifestDirPath))
-            {
-                if (!fileSystemUtils.FileExists(spdxManifestFilePath))
-                {
-                    throw new ValidationArgException($"No manifest file found at {configuration.ManifestDirPath.Value}.");
-                }
-            }
-
-            //If we are not working with SPDX:2.2 then check for other possible manifest name.
-            if (!manifestInfo[0].Equals(Constants.SPDX22ManifestInfo))
-            {
-                var nonSpdxManifestFilePath = fileSystemUtils.JoinPaths(configuration.ManifestDirPath.Value, "manifest.json");
-
-                if (!fileSystemUtils.FileExists(nonSpdxManifestFilePath))
-                {
-                    throw new ValidationArgException($"No manifest file found at {configuration.ManifestDirPath.Value}.");
-                }
             }
 
             return;

--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigSanitizerTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigSanitizerTests.cs
@@ -35,7 +35,9 @@ namespace Microsoft.Sbom.Api.Tests.Config
             mockFileSystemUtils
                 .Setup(f => f.JoinPaths(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns((string p1, string p2) => Path.Join(p1, p2));
-
+            mockFileSystemUtils
+                .Setup(f => f.FileExists(It.IsAny<string>()))
+                .Returns(true);
             mockHashAlgorithmProvider = new Mock<IHashAlgorithmProvider>();
             mockHashAlgorithmProvider
                 .Setup(h => h.Get(It.IsAny<string>()))

--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigSanitizerTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigSanitizerTests.cs
@@ -38,6 +38,9 @@ namespace Microsoft.Sbom.Api.Tests.Config
             mockFileSystemUtils
                 .Setup(f => f.FileExists(It.IsAny<string>()))
                 .Returns(true);
+            mockFileSystemUtils
+                .Setup(f => f.DirectoryExists(It.IsAny<string>()))
+                .Returns(true);
             mockHashAlgorithmProvider = new Mock<IHashAlgorithmProvider>();
             mockHashAlgorithmProvider
                 .Setup(h => h.Get(It.IsAny<string>()))

--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigSanitizerTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigSanitizerTests.cs
@@ -38,9 +38,6 @@ namespace Microsoft.Sbom.Api.Tests.Config
             mockFileSystemUtils
                 .Setup(f => f.FileExists(It.IsAny<string>()))
                 .Returns(true);
-            mockFileSystemUtils
-                .Setup(f => f.DirectoryExists(It.IsAny<string>()))
-                .Returns(true);
             mockHashAlgorithmProvider = new Mock<IHashAlgorithmProvider>();
             mockHashAlgorithmProvider
                 .Setup(h => h.Get(It.IsAny<string>()))

--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForValidation.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForValidation.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Sbom.Api.Config.Tests
             var cb = new ConfigurationBuilder<ValidationArgs>(mapper, configFileParser);
 
             fileSystemUtilsMock.Setup(f => f.OpenRead(It.IsAny<string>())).Returns(TestUtils.GenerateStreamFromString(JSONConfigWithManifestPath)).Verifiable();
+            fileSystemUtilsMock.Setup(f => f.FileExists(It.IsAny<string>())).Returns(true).Verifiable();
             fileSystemUtilsMock.Setup(f => f.DirectoryExists(It.IsAny<string>())).Returns(true).Verifiable();
             fileSystemUtilsMock.Setup(f => f.DirectoryHasReadPermissions(It.IsAny<string>())).Returns(true).Verifiable();
             fileSystemUtilsMock.Setup(f => f.GetDirectoryName(It.IsAny<string>())).Returns("test").Verifiable();
@@ -64,6 +65,7 @@ namespace Microsoft.Sbom.Api.Config.Tests
             var cb = new ConfigurationBuilder<ValidationArgs>(mapper, configFileParser);
 
             fileSystemUtilsMock.Setup(f => f.OpenRead(It.IsAny<string>())).Returns(TestUtils.GenerateStreamFromString(JSONConfigWithManifestPath)).Verifiable();
+            fileSystemUtilsMock.Setup(f => f.FileExists(It.IsAny<string>())).Returns(true).Verifiable();
             fileSystemUtilsMock.Setup(f => f.DirectoryExists(It.IsAny<string>())).Returns(true).Verifiable();
             fileSystemUtilsMock.Setup(f => f.DirectoryHasReadPermissions(It.IsAny<string>())).Returns(true).Verifiable();
             fileSystemUtilsMock.Setup(f => f.GetDirectoryName(It.IsAny<string>())).Returns("test").Verifiable();
@@ -138,6 +140,7 @@ namespace Microsoft.Sbom.Api.Config.Tests
 
             fileSystemUtilsMock.Setup(f => f.DirectoryExists(It.IsAny<string>())).Returns(true).Verifiable();
             fileSystemUtilsMock.Setup(f => f.DirectoryHasReadPermissions(It.IsAny<string>())).Returns(true).Verifiable();
+            fileSystemUtilsMock.Setup(f => f.FileExists(It.IsAny<string>())).Returns(true).Verifiable();
             fileSystemUtilsMock.Setup(f => f.DirectoryHasWritePermissions(It.IsAny<string>())).Returns(true).Verifiable();
             fileSystemUtilsMock.Setup(f => f.JoinPaths(It.IsAny<string>(), It.IsAny<string>())).Returns((string p1, string p2) => Path.Join(p1, p2));
 
@@ -164,6 +167,7 @@ namespace Microsoft.Sbom.Api.Config.Tests
 
             fileSystemUtilsMock.Setup(f => f.DirectoryExists(It.IsAny<string>())).Returns(true).Verifiable();
             fileSystemUtilsMock.Setup(f => f.DirectoryHasReadPermissions(It.IsAny<string>())).Returns(true).Verifiable();
+            fileSystemUtilsMock.Setup(f => f.FileExists(It.IsAny<string>())).Returns(true).Verifiable();
             fileSystemUtilsMock.Setup(f => f.DirectoryHasWritePermissions(It.IsAny<string>())).Returns(true).Verifiable();
 
             var args = new ValidationArgs


### PR DESCRIPTION
Different approach to #228 

We have had issues when attempting to run validation on a buildDropPath that doesn't contain a manifest throws a misleading error about a missing key. Checking if the manifest is present on the path before running the validation workflow will allow us to catch this.

Question: The new logic checks for manifest.json or manifest.spdx.json. Do we know if this could cause any issues? If so, would just looking for a JSON be good enough?