### PR TITLE
Optimize calls to `TryGetManifestConfig` in `SbomConfigProvider`

### DIFF
--- a/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfigProvider.cs
+++ b/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfigProvider.cs
@@ -26,8 +26,14 @@ namespace Microsoft.Sbom.Api.Manifest.Configuration
         {
             get
             {
-                configsDictionary ??= new Dictionary<ManifestInfo, ISbomConfig>();
-
+                if (configsDictionary is not null)
+                {
+                    // Exit fast if config map is already initialized.
+                    return configsDictionary;
+                }
+               
+                // Initialize new config map.
+                configsDictionary = new Dictionary<ManifestInfo, ISbomConfig>();
                 foreach (var configHandler in manifestConfigHandlers)
                 {
                     if (configHandler.TryGetManifestConfig(out ISbomConfig sbomConfig))
@@ -73,11 +79,6 @@ namespace Microsoft.Sbom.Api.Manifest.Configuration
             ILogger logger,
             IRecorder recorder)
         {
-            if (manifestConfigHandlers is null)
-            {
-                throw new ArgumentNullException(nameof(manifestConfigHandlers));
-            }
-
             this.manifestConfigHandlers = manifestConfigHandlers ?? throw new ArgumentNullException(nameof(manifestConfigHandlers));
             this.metadataProviders = metadataProviders ?? throw new ArgumentNullException(nameof(metadataProviders));
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));


### PR DESCRIPTION
I changed getter for `ConfigsDictionary` to exit fast if config dictionary already exists. This getter is a hot path during file hash generation [here](https://github.com/microsoft/sbom-tool/blob/b47f3e1d43c2974a67db1a8ab591f7e29adcaf55/src/Microsoft.Sbom.Api/Executors/FileHasher.cs#L129). Because of that we were calling `TryGetManifestConfig` and `RecordSBOMFormat` methods on every file enumerated, doing unnecessary allocations.