### PR TITLE
Use WriteAllText to write Sha256 hash.

### DIFF
--- a/src/Microsoft.Sbom.Api/Workflows/SBOMGenerationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SBOMGenerationWorkflow.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Sbom.Api.Entities;
 using Microsoft.Sbom.Api.Exceptions;
@@ -201,9 +200,8 @@ public class SbomGenerationWorkflow : IWorkflow<SbomGenerationWorkflow>
 
         using var readStream = fileSystemUtils.OpenRead(manifestJsonFilePath);
         using var bufferedStream = new BufferedStream(readStream, 1024 * 32);
-        using var writeFileStream = fileSystemUtils.OpenWrite(hashFileName);
-        var hashValue = Encoding.Unicode.GetBytes(BitConverter.ToString(new Sha256HashAlgorithm().ComputeHash(bufferedStream)).Replace("-", string.Empty).ToLower());
-        writeFileStream.Write(hashValue, 0, hashValue.Length);
+        var hashValue = BitConverter.ToString(new Sha256HashAlgorithm().ComputeHash(bufferedStream)).Replace("-", string.Empty).ToLower();
+        fileSystemUtils.WriteAllText(hashFileName, hashValue);
     }
 
     private void RemoveExistingManifestDirectory()

--- a/src/Microsoft.Sbom.Api/Workflows/SBOMGenerationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SBOMGenerationWorkflow.cs
@@ -200,7 +200,8 @@ public class SbomGenerationWorkflow : IWorkflow<SbomGenerationWorkflow>
 
         using var readStream = fileSystemUtils.OpenRead(manifestJsonFilePath);
         using var bufferedStream = new BufferedStream(readStream, 1024 * 32);
-        var hashValue = BitConverter.ToString(new Sha256HashAlgorithm().ComputeHash(bufferedStream)).Replace("-", string.Empty).ToLower();
+        var hashBytes = new Sha256HashAlgorithm().ComputeHash(bufferedStream);
+        var hashValue = Convert.ToHexString(bytes).ToLowerInvariant();
         fileSystemUtils.WriteAllText(hashFileName, hashValue);
     }
 

--- a/src/Microsoft.Sbom.Api/Workflows/SBOMGenerationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SBOMGenerationWorkflow.cs
@@ -201,7 +201,7 @@ public class SbomGenerationWorkflow : IWorkflow<SbomGenerationWorkflow>
         using var readStream = fileSystemUtils.OpenRead(manifestJsonFilePath);
         using var bufferedStream = new BufferedStream(readStream, 1024 * 32);
         var hashBytes = new Sha256HashAlgorithm().ComputeHash(bufferedStream);
-        var hashValue = Convert.ToHexString(bytes).ToLowerInvariant();
+        var hashValue = Convert.ToHexString(hashBytes).ToLowerInvariant();
         fileSystemUtils.WriteAllText(hashFileName, hashValue);
     }
 

--- a/src/Microsoft.Sbom.Common/FileSystemUtils.cs
+++ b/src/Microsoft.Sbom.Common/FileSystemUtils.cs
@@ -53,6 +53,8 @@ public abstract class FileSystemUtils : IFileSystemUtils
 
     public string ReadAllText(string filePath) => File.ReadAllText(filePath);
 
+    public void WriteAllText(string filePath, string contents) => File.WriteAllText(filePath, contents);
+
     public bool FileExists(string path) => File.Exists(path);
 
     public Stream OpenWrite(string filePath) => new FileStream(

--- a/src/Microsoft.Sbom.Common/IFileSystemUtils.cs
+++ b/src/Microsoft.Sbom.Common/IFileSystemUtils.cs
@@ -26,6 +26,8 @@ public interface IFileSystemUtils
         
     string ReadAllText(string filePath);
         
+    void WriteAllText(string filePath, string contents);
+        
     string JoinPaths(string root, string relativePath);
 
     string JoinPaths(string root, string relativePath, string secondRelativePath);

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/ManifestGenerationWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/ManifestGenerationWorkflowTests.cs
@@ -166,7 +166,7 @@ public class ManifestGenerationWorkflowTests
 
         fileSystemMock.Setup(f => f.FileExists(It.Is<string>(c => c == jsonFilePath))).Returns(true);
         fileSystemMock.Setup(f => f.OpenRead(It.Is<string>(c => c == jsonFilePath))).Returns(TestUtils.GenerateStreamFromString("randomContent"));
-        fileSystemMock.Setup(f => f.OpenWrite(It.Is<string>(c => c == "/root/_manifest/manifest.json.sha256"))).Returns(sha256Writer.BaseStream);
+        fileSystemMock.Setup(f => f.WriteAllText(It.Is<string>(c => c == "/root/_manifest/manifest.json.sha256"), It.IsAny<string>()));
 
         hashCodeGeneratorMock.Setup(h => h.GenerateHashes(It.IsAny<string>(), It.IsAny<AlgorithmName[]>()))
             .Returns((string fileName, AlgorithmName[] algos) =>
@@ -346,7 +346,7 @@ public class ManifestGenerationWorkflowTests
         hashCodeGeneratorMock.VerifyAll();
         mockLogger.VerifyAll();
         fileSystemMock.Verify(x => x.FileExists(jsonFilePath), Times.Once);
-        fileSystemMock.Verify(x => x.OpenWrite($"{jsonFilePath}.sha256"), Times.Once);
+        fileSystemMock.Verify(x => x.WriteAllText($"{jsonFilePath}.sha256", It.IsAny<string>()), Times.Once);
     }
 
     [TestMethod]


### PR DESCRIPTION
This pull request modified hash writing to use WriteAllText so the resultant file is written using the .NET rules for writing text files. This pull request addresses issue #275.