### PR TITLE
Handle incomplete reads

### DIFF
--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/ParserUtils.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/ParserUtils.cs
@@ -228,6 +228,12 @@ internal class ParserUtils
 
             leftover.CopyTo(buffer);
             bytesRead = stream.Read(buffer.AsSpan(leftover.Length));
+
+            // stream.Read doesn't always return the whole buffer length, so we need to resize the buffer
+            if (bytesRead + leftover.Length != buffer.Length)
+            {
+                bytesRead = stream.Read(buffer.AsSpan(bytesRead + leftover.Length));
+            }
         }
         else
         {

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/ParserUtils.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/ParserUtils.cs
@@ -229,7 +229,7 @@ internal class ParserUtils
             leftover.CopyTo(buffer);
             bytesRead = stream.Read(buffer.AsSpan(leftover.Length));
 
-            // stream.Read doesn't always return the whole buffer length, so we need to resize the buffer
+            // stream.Read doesn't always return the whole buffer length, so we need to fill the rest
             if (bytesRead + leftover.Length != buffer.Length)
             {
                 bytesRead = stream.Read(buffer.AsSpan(bytesRead + leftover.Length));


### PR DESCRIPTION
`Stream.Read` does not always fill the entire buffer (if their own buffer was at its end for example), so in cases where that happened we would be reading "junk" data from a perevious `stream.Read`. We must therefore check afterward and fill up the rest of the buffer (TECHNICALLY this could be wrong for the same reason, but in real world cases [and at least the one that made us find this] it should suffice).