### PR TITLE
Fix stream handling

### DIFF
--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/ParserUtils.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/ParserUtils.cs
@@ -261,6 +261,7 @@ internal class ParserUtils
         {
             bytesRead = stream.Read(buffer);
 
+            // stream.Read doesn't always return the whole buffer length, so we need to fill the rest
             if (bytesRead < buffer.Length)
             {
                 bytesRead = stream.Read(buffer.AsSpan(bytesRead));

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/ParserUtils.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/ParserUtils.cs
@@ -209,7 +209,7 @@ internal class ParserUtils
                 }
 
                 Read(stream, ref buffer, ref reader);
-                
+
                 if (reader.TokenType == JsonTokenType.StartObject)
                 {
                     objectCount++;
@@ -260,6 +260,11 @@ internal class ParserUtils
         else
         {
             bytesRead = stream.Read(buffer);
+
+            if (bytesRead < buffer.Length)
+            {
+                bytesRead = stream.Read(buffer.AsSpan(bytesRead));
+            }
         }
 
         reader = new Utf8JsonReader(buffer, isFinalBlock: bytesRead == 0, reader.CurrentState);

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/RootPropertiesParser.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/RootPropertiesParser.cs
@@ -32,10 +32,10 @@ internal ref struct RootPropertiesParser
     private readonly Stream stream;
     private readonly IEnumerable<ParserState> statesToSkip;
 
-    public RootPropertiesParser(Stream stream, IEnumerable<ParserState>? statesToSkip = null)
+    public RootPropertiesParser(Stream stream, IEnumerable<ParserState> statesToSkip)
     {
         this.stream = stream ?? throw new ArgumentNullException(nameof(stream));
-        this.statesToSkip = statesToSkip ?? Enumerable.Empty<ParserState>();
+        this.statesToSkip = statesToSkip;
     }
 
     internal ParserStateResult MoveNext(ref byte[] buffer, ref Utf8JsonReader reader)

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomRelationshipParserTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomRelationshipParserTests.cs
@@ -51,7 +51,7 @@ public class SbomRelationshipParserTests
 
         var state = parser.Next();
         Assert.AreEqual(ParserState.RELATIONSHIPS, state);
-        
+
         stream.Close();
 
         parser.GetRelationships().GetEnumerator().MoveNext();
@@ -64,12 +64,12 @@ public class SbomRelationshipParserTests
         using var stream = new MemoryStream();
         stream.Read(new byte[Constants.ReadBufferSize]);
         var buffer = new byte[Constants.ReadBufferSize];
-         
+
         SPDXParser parser = new (stream, Array.Empty<ParserState>(), ignoreValidation: true);
 
         var state = parser.Next();
         Assert.AreEqual(ParserState.RELATIONSHIPS, state);
-        
+
         parser.GetRelationships().GetEnumerator().MoveNext();
     }
 


### PR DESCRIPTION
This is a follow-up to https://github.com/microsoft/sbom-tool/pull/290, we failed to account for the scenario where there was no leftover in the previous reader but the stream didn't return us a full result.