### PR TITLE
Update CD library to get the nuget missing version parsing issue fixed

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
         </PackageVersion>
     </ItemDefinitionGroup>
     <PropertyGroup>
-        <ComponentDetectionPackageVersion>3.6.0</ComponentDetectionPackageVersion>
+        <ComponentDetectionPackageVersion>3.6.2</ComponentDetectionPackageVersion>
     </PropertyGroup>
     <ItemGroup>
         <PackageVersion Include="MinVer" Version="2.5.0"/>


### PR DESCRIPTION
Here is the fix we want to include:
https://github.com/microsoft/component-detection/pull/730