### PR TITLE
chore: remove `system.composition` dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,11 +17,6 @@
         <PackageVersion Include="Serilog.Extensions.Hosting" Version="7.0.0"/>
         <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118"/>
         <PackageVersion Include="System.Text.Json" Version="7.0.3" />
-        <PackageVersion Include="System.Composition.AttributedModel" Version="1.4.1"/>
-        <PackageVersion Include="System.Composition.Convention" Version="1.4.1"/>
-        <PackageVersion Include="System.Composition.Hosting" Version="1.4.1"/>
-        <PackageVersion Include="System.Composition.Runtime" Version="1.4.1"/>
-        <PackageVersion Include="System.Composition.TypedParts" Version="1.4.1"/>
         <PackageVersion Include="System.Memory" Version="4.5.5"/>
         <PackageVersion Include="System.Reactive" Version="5.0.0"/>
         <PackageVersion Include="System.Runtime.Loader" Version="4.3.0"/>


### PR DESCRIPTION
These libraries were required in the initial implementation to provide a form of dependency injection via property injection using [Managed Extensibility Framework (MEF)][1]. However, since #202 this repo has used [`Microsoft.Extensions.DependencyInjection`][2] to perform dependency injection instead. Therefore, these dependencies are no longer required.

This will also close #310 

[1]: https://learn.microsoft.com/en-us/dotnet/framework/mef/
[2]: https://learn.microsoft.com/en-us/dotnet/core/extensions/dependency-injection