### PR TITLE
ci: simplify ci build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,11 +5,20 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-  
+    
+permissions:
+  contents: read
+
 jobs:
-  windows_job:
-    name: Windows
-    runs-on: windows-latest
+  build:
+    name: build-${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - 'windows-latest'
+          - 'ubuntu-latest'
+          - 'macos-latest'
 
     env:
         OFFICIAL_BUILD: 'True'
@@ -24,6 +33,7 @@ jobs:
 
       - name: Verify files contain copyright header
         run: .\scripts\verification\Verify-LicenceHeader.ps1 -Target .\src -LicenseHeaderPath .\scripts\verification\LicenseHeader.txt -Extensions *.xaml,*.xml,*.cs,*.ps1 -AddIfAbsent $false
+        shell: pwsh
       
       - name: Restore dependencies
         run: dotnet restore 
@@ -31,29 +41,5 @@ jobs:
       - name: Build
         run: dotnet build --no-restore
       
-      - name: Test
-        run: dotnet test --no-build --verbosity normal
-
-  linux_job:
-    name: Linux
-    runs-on: ubuntu-latest
-
-    env:
-        OFFICIAL_BUILD: 'True'
-        # Set the build number in MinVer.
-        MINVERBUILDMETADATA: build.${{github.run_number}}
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v2
-
-      - name: Restore dependencies
-        run: dotnet restore
-
-      - name: Build
-        run: dotnet build --no-restore
-
       - name: Test
         run: dotnet test --no-build --verbosity normal


### PR DESCRIPTION
This uses [GitHub Actions matrix builds][1] to run across Windows, Ubuntu and macOS with the same build configuration.

This change also scopes down the permissions of the default `GITHUB_TOKEN` from all permissions, to `contents: read` (ability to read code)[^1].

Finally, I specified the shell that the copyright header should use, to allow the script to run on Ubuntu and macOS, which otherwise default to `bash`

[1]: https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs
[^1]: https://docs.github.com/en/actions/security-guides/automatic-token-authentication