### PR TITLE
Handle BOM's at the beginning of SbomParser streams

### DIFF
--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/SPDXParser.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/SPDXParser.cs
@@ -95,10 +95,56 @@ public class SPDXParser : ISbomParser
             throw new ArgumentException($"The {nameof(buffer)} value can't be null or of 0 length.");
         }
 
+        // Utf8JsonReader will not handle BOM's, so we need to "eat" them before.
+        this.stream.Position = GetCursor(this.stream);
+
         // Fill up the buffer.
         if (!stream.CanRead || stream.Read(buffer) == 0)
         {
             throw new EndOfStreamException();
+        }
+
+        static int GetCursor(Stream stream)
+        {
+            // UTF-32, big-endian
+            if (IsMatch(stream, new byte[] { 0x00, 0x00, 0xFE, 0xFF }))
+            {
+                return 4;
+            }
+
+            // UTF-32, little-endian
+            if (IsMatch(stream, new byte[] { 0xFF, 0xFE, 0x00, 0x00 }))
+            {
+                return 4;
+            }
+
+            // UTF-16, big-endian
+            if (IsMatch(stream, new byte[] { 0xFE, 0xFF }))
+            {
+                return 2;
+            }
+
+            // UTF-16, little-endian
+            if (IsMatch(stream, new byte[] { 0xFF, 0xFE }))
+            {
+                return 2;
+            }
+
+            // UTF-8
+            if (IsMatch(stream, new byte[] { 0xEF, 0xBB, 0xBF }))
+            {
+                return 3;
+            }
+
+            return 0;
+        }
+
+        static bool IsMatch(Stream stream, byte[] match)
+        {
+            stream.Position = 0;
+            var buffer = new byte[match.Length];
+            stream.Read(buffer, 0, buffer.Length);
+            return !buffer.Where((t, i) => t != match[i]).Any();
         }
     }
 

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomParserTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomParserTests.cs
@@ -12,6 +12,45 @@ namespace Microsoft.Sbom.Parser;
 public class SbomParserTests
 {
     [TestMethod]
+    public void ParseWithBOMTest()
+    {
+        var utf8BOM = Encoding.UTF8.GetString(Encoding.UTF8.Preamble);
+        byte[] bytes = Encoding.UTF8.GetBytes(utf8BOM + SbomParserStrings.JsonWithAll4Properties);
+        using var stream = new MemoryStream(bytes);
+
+        var parser = new SPDXParser(stream);
+
+        Assert.AreEqual(ParserState.NONE, parser.CurrentState);
+
+        var state = parser.Next();
+        Assert.AreEqual(ParserState.FILES, state);
+
+        Assert.AreEqual(0, parser.GetFiles().Count());
+
+        state = parser.Next();
+        Assert.AreEqual(ParserState.PACKAGES, state);
+
+        Assert.AreEqual(0, parser.GetPackages().Count());
+
+        state = parser.Next();
+        Assert.AreEqual(ParserState.RELATIONSHIPS, state);
+
+        Assert.AreEqual(0, parser.GetRelationships().Count());
+
+        state = parser.Next();
+        Assert.AreEqual(ParserState.REFERENCES, state);
+
+        Assert.AreEqual(0, parser.GetReferences().Count());
+
+        state = parser.Next();
+        Assert.AreEqual(ParserState.METADATA, state);
+        _ = parser.GetMetadata();
+
+        state = parser.Next();
+        Assert.AreEqual(ParserState.FINISHED, state);
+    }
+
+    [TestMethod]
     public void ParseMultiplePropertiesTest()
     {
         byte[] bytes = Encoding.UTF8.GetBytes(SbomParserStrings.JsonWithAll4Properties);


### PR DESCRIPTION
https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/use-utf8jsonreader#filter-data-using-utf8jsonreader Ctrl+F "BOM". The Utf8JsonReader will not gracefully handle BOM marks, so we need to "eat" them before we create our buffer.