### PR TITLE
chore: remove `serilog.aspnetcore`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -47,6 +47,5 @@
         <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
         <PackageVersion Include="Scrutor" Version="4.2.0" />
         <PackageVersion Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
-        <PackageVersion Include="Serilog.AspNetCore" Version="6.1.0" />
     </ItemGroup>
 </Project>

--- a/src/Microsoft.Sbom.DotNetTool/Microsoft.Sbom.DotNetTool.csproj
+++ b/src/Microsoft.Sbom.DotNetTool/Microsoft.Sbom.DotNetTool.csproj
@@ -24,6 +24,5 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Scrutor" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" />
-    <PackageReference Include="Serilog.AspNetCore" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Sbom.Tool/Microsoft.Sbom.Tool.csproj
+++ b/src/Microsoft.Sbom.Tool/Microsoft.Sbom.Tool.csproj
@@ -25,6 +25,5 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" />
-    <PackageReference Include="Serilog.AspNetCore" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Looks like this was added as part of #202, but this isn't an ASP.NET Core project, so it's an unnecessary dependency. This will also take care of #324.