### PR TITLE
ci: scope down permissions of `GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,12 @@ name: Build
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
   pull_request:
-    branches: [ "main" ]
-    
+    branches:
+      - main
+
 permissions:
   contents: read
 
@@ -16,9 +18,9 @@ jobs:
     strategy:
       matrix:
         os:
-          - 'windows-latest'
-          - 'ubuntu-latest'
-          - 'macos-latest'
+          - windows-latest
+          - ubuntu-latest
+          - macos-latest
 
     env:
         OFFICIAL_BUILD: 'True'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,21 +1,9 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
-name: "CodeQL"
+name: CodeQL
 
 on:
   push:
     branches: [ main ]
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [ main ]
   schedule:
     - cron: '27 10 * * 1'
@@ -23,46 +11,28 @@ on:
 env:
   CODEQL_BUILD: True
 
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest    
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
 
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [ 'csharp' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
 
-    # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+        languages: csharp
 
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v2
-
-    - name: dotnet restore
-      run: dotnet restore
-      
-    - name: Build solution
-      run: dotnet build --no-restore
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/create_release_tag.yml
+++ b/.github/workflows/create_release_tag.yml
@@ -1,11 +1,14 @@
-name: "Create new tag"
+name: Create new tag
 
 on: 
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag (example v0.1.5)"
+        description: 'Tag (example v0.1.5)'
         required: true
+        
+permissions:
+  contents: write
 
 jobs:
   create-tag:

--- a/.github/workflows/gen-docs.yml
+++ b/.github/workflows/gen-docs.yml
@@ -1,4 +1,4 @@
-name: 'Generate docs'
+name: Generate docs
 
 on:
   workflow_dispatch:
@@ -9,22 +9,17 @@ on:
       - 'src/Microsoft.Sbom.Api/Config/Args/*.cs'
       - 'src/Microsoft.Sbom.Common/Config/IConfiguration.cs'
 
+permissions:
+  contents: write
+
 jobs:
   gen-docs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v2
-
-      - name: Restore dependencies
-        run: dotnet restore 
-        
-      - name: Build
-        run: dotnet build --no-restore
 
       - name: Generate docs
         run: |

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,11 +6,12 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   update_release_draft:
-    permissions:
-      contents: write
-      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v5


### PR DESCRIPTION
By default the `GITHUB_TOKEN` secret comes with global read/write permissions. It's considered a good practice to scope down the token to the minimum required scopes[^1].

This also includes some other refactorings.

[^1]: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs