### PR TITLE
refactor: fix IDE0004

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -942,10 +942,6 @@ dotnet_diagnostic.CS8001.severity = suggestion
 # CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. 
 dotnet_diagnostic.CS8632.severity = suggestion
 
-# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0004
-# IDE0004: Cast is redundant
-dotnet_diagnostic.IDE0004.severity = suggestion
-
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0005
 # IDE0005: Using directive is unnecessary
 dotnet_diagnostic.IDE0005.severity = suggestion

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Utils/InternalMetadataProviderIdentityExtensionsTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Utils/InternalMetadataProviderIdentityExtensionsTests.cs
@@ -54,7 +54,7 @@ public class InternalMetadataProviderIdentityExtensionsTests
 
         var actualPackageVersion = mdProviderMock.Object.GetPackageVersion();
 
-        Assert.AreEqual(packageVersion as string, actualPackageVersion);
+        Assert.AreEqual(packageVersion, actualPackageVersion);
     }
 
     [TestMethod]
@@ -112,7 +112,7 @@ public class InternalMetadataProviderIdentityExtensionsTests
 
         var actualPackageName = mdProviderMock.Object.GetPackageName();
 
-        Assert.AreEqual(packageName as string, actualPackageName);
+        Assert.AreEqual(packageName, actualPackageName);
     }
 
     [TestMethod]
@@ -170,7 +170,7 @@ public class InternalMetadataProviderIdentityExtensionsTests
         object packageSupplier = "Microsoft";
         Uri namespaceUri = new Uri("https://test.com/");
         string expectedSwidPurlPattern = @"^pkg:swid\/Microsoft\/test.com\/name@1\.0\.0\?tag_id=.*";
-  
+
         mdProviderMock.Setup(m => m.TryGetMetadata(MetadataKey.PackageSupplier, out packageSupplier))
             .Returns(true);
         mdProviderMock.Setup(m => m.TryGetMetadata(MetadataKey.PackageVersion, out packageVersion))


### PR DESCRIPTION
[IDE0004: Remove Unnecessary cast][1]

Part of #340

[1]: https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0004