### PR TITLE
refactor: fix SA1108 block statements must not contain embedded comments

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -493,10 +493,6 @@ dotnet_diagnostic.SA1028.severity = suggestion
 # SA1101: Prefix local calls with this
 dotnet_diagnostic.SA1101.severity = suggestion
 
-# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1108.md
-# SA1108: Block statements should not contain embedded comments
-dotnet_diagnostic.SA1108.severity = suggestion
-
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1117.md
 # SA1117: Parameters should be on same line or separate lines
 dotnet_diagnostic.SA1117.severity = suggestion

--- a/src/Microsoft.Sbom.Api/Converters/SerilogLoggerConverter.cs
+++ b/src/Microsoft.Sbom.Api/Converters/SerilogLoggerConverter.cs
@@ -28,7 +28,9 @@ public class SerilogLoggerConverter<T> : ILogger<T>
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
     {
         var serilogLogLevel = ConvertLogLevel(logLevel);
-        if (serilogLogger.IsEnabled(serilogLogLevel)) // Check the log level before logging
+
+        // Check the log level before logging
+        if (serilogLogger.IsEnabled(serilogLogLevel))
         {
             serilogLogger.Write(serilogLogLevel, exception, formatter(state, exception));
         }


### PR DESCRIPTION
[SA1108: block statements must not contain embedded comments](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1108.md)

Part of #340