### PR TITLE
chore: silence IL3000

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1082,6 +1082,10 @@ dotnet_diagnostic.IDE0270.severity = suggestion
 # IDE1006: Naming rule violation: These words must begin with upper case characters: ...
 dotnet_diagnostic.IDE1006.severity = suggestion
 
+# https://learn.microsoft.com/en-us/dotnet/core/deploying/single-file/warnings/il3000
+# IL3000: Avoid accessing Assembly file path when publishing as a single file
+dotnet_diagnostic.IL3000.severity = suggestion
+
 ##########################################
 # Provided by Microsoft.VisualStudio.Threading.Analyzers
 # https://github.com/Microsoft/vs-threading


### PR DESCRIPTION
This was implicitly ignored before, but now that we have enabled all warnings as errors, it is bubbling up.

The suggested fix is to replace `Assembly.Location` with `AppContext.BaseDirectory`, but this will require more investigation.