### PR TITLE
chore: remove `System.Security.Cryptography.ProtectedData`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -43,7 +43,6 @@
         <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
         <PackageVersion Include="System.Reactive" Version="5.0.0" />
         <PackageVersion Include="System.Runtime.Loader" Version="4.3.0" />
-        <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="6.0.0" />
         <PackageVersion Include="System.Text.Json" Version="7.0.3" />
         <PackageVersion Include="System.Threading.Channels" Version="6.0.0" />
         <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="4.11.1" />

--- a/src/Microsoft.Sbom.Api/Microsoft.Sbom.Api.csproj
+++ b/src/Microsoft.Sbom.Api/Microsoft.Sbom.Api.csproj
@@ -23,7 +23,6 @@
         <PackageReference Include="Serilog.Sinks.Console" />
         <PackageReference Include="System.IO.FileSystem.AccessControl" />
         <PackageReference Include="System.Private.Uri" />
-        <PackageReference Include="System.Security.Cryptography.ProtectedData" />
         <PackageReference Include="System.Threading.Channels" />
         <PackageReference Include="System.Threading.Tasks.Extensions" />
     </ItemGroup>
@@ -39,7 +38,7 @@
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>
     </ItemGroup>
-  
+
     <ItemGroup>
       <ProjectReference Include="..\Microsoft.Sbom.Adapters\Microsoft.Sbom.Adapters.csproj" />
       <ProjectReference Include="..\Microsoft.Sbom.Common\Microsoft.Sbom.Common.csproj" />


### PR DESCRIPTION
This was added in the initial commit, but there were no uses of it.

Related to #337