### PR TITLE
chore: update dotnet sdk from `6.0.400` to `7.0.400`

### DIFF
--- a/Microsoft.Sbom.sln
+++ b/Microsoft.Sbom.sln
@@ -18,6 +18,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Packages.props = Directory.Packages.props
 		README.md = README.md
 		.editorconfig = .editorconfig
+		global.json = global.json
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Sbom.Contracts", "src\Microsoft.Sbom.Contracts\Microsoft.Sbom.Contracts.csproj", "{AA73B697-C992-4940-8375-17B9B77AB351}"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.400",
+    "version": "7.0.400",
     "rollForward": "latestMajor",
     "allowPrerelease": false
   }


### PR DESCRIPTION
The SBOM Tool is still a .NET 6 runtime project, but this change allows us to include the new Roslyn Analyzers from newer SDKs.

Also add `global.json` to `Solution Items`