### PR TITLE
chore: SA1117 parameters must be on same line or separate lines

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -493,10 +493,6 @@ dotnet_diagnostic.SA1028.severity = suggestion
 # SA1101: Prefix local calls with this
 dotnet_diagnostic.SA1101.severity = suggestion
 
-# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1117.md
-# SA1117: Parameters should be on same line or separate lines
-dotnet_diagnostic.SA1117.severity = suggestion
-
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1124.md
 # SA1124: Do not use regions
 dotnet_diagnostic.SA1124.severity = suggestion

--- a/src/Microsoft.Sbom.Api/Executors/PackageInfoJsonWriter.cs
+++ b/src/Microsoft.Sbom.Api/Executors/PackageInfoJsonWriter.cs
@@ -54,7 +54,10 @@ public class PackageInfoJsonWriter
         return (result, errors);
     }
 
-    private async Task GenerateJson(IList<ISbomConfig> packagesArraySupportingConfigs, SbomPackage packageInfo, Channel<JsonDocWithSerializer> result,
+    private async Task GenerateJson(
+        IList<ISbomConfig> packagesArraySupportingConfigs,
+        SbomPackage packageInfo,
+        Channel<JsonDocWithSerializer> result,
         Channel<FileValidationResult> errors)
     {
         try

--- a/src/Microsoft.Sbom.Api/Providers/FilesProviders/CGScannedExternalDocumentReferenceFileProvider.cs
+++ b/src/Microsoft.Sbom.Api/Providers/FilesProviders/CGScannedExternalDocumentReferenceFileProvider.cs
@@ -33,7 +33,8 @@ public class CGScannedExternalDocumentReferenceFileProvider : PathBasedFileToJso
     public CGScannedExternalDocumentReferenceFileProvider(
         IConfiguration configuration,
         ChannelUtils channelUtils,
-        ILogger log, FileHasher fileHasher,
+        ILogger log,
+        FileHasher fileHasher,
         ManifestFolderFilterer fileFilterer,
         FileInfoWriter fileHashWriter,
         InternalSBOMFileInfoDeduplicator internalSBOMFileInfoDeduplicator,

--- a/src/Microsoft.Sbom.Api/SBOMGenerator.cs
+++ b/src/Microsoft.Sbom.Api/SBOMGenerator.cs
@@ -58,8 +58,14 @@ public class SbomGenerator : ISBOMGenerator
         // Get scan configuration
         var inputConfiguration = ApiConfigurationBuilder.GetConfiguration(
             rootPath,
-            manifestDirPath, null, null, metadata, specifications,
-            runtimeConfiguration, externalDocumentReferenceListFile, componentPath);
+            manifestDirPath,
+            null,
+            null,
+            metadata,
+            specifications,
+            runtimeConfiguration,
+            externalDocumentReferenceListFile,
+            componentPath);
 
         // Validate the configuration
         inputConfiguration = ValidateConfig(inputConfiguration);
@@ -99,8 +105,14 @@ public class SbomGenerator : ISBOMGenerator
         ArgumentNullException.ThrowIfNull(manifestDirPath);
 
         var inputConfiguration = ApiConfigurationBuilder.GetConfiguration(
-            rootPath, manifestDirPath, files, packages, metadata, specifications,
-            runtimeConfiguration, externalDocumentReferenceListFile);
+            rootPath,
+            manifestDirPath,
+            files,
+            packages,
+            metadata,
+            specifications,
+            runtimeConfiguration,
+            externalDocumentReferenceListFile);
         inputConfiguration = ValidateConfig(inputConfiguration);
 
         inputConfiguration.ToConfiguration();

--- a/src/Microsoft.Sbom.Api/Workflows/SBOMGenerationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SBOMGenerationWorkflow.cs
@@ -182,9 +182,10 @@ public class SbomGenerationWorkflow : IWorkflow<SbomGenerationWorkflow>
         }
         catch (Exception e)
         {
-            log.Warning(
+            this.log.Warning(
                 $"Manifest generation failed, however we were " +
-                $"unable to delete the partially generated manifest.json file and the {sbomDir} directory.", e);
+                $"unable to delete the partially generated manifest.json file and the {sbomDir} directory.",
+                e);
         }
     }
 

--- a/src/Microsoft.Sbom.Common/Config/IConfiguration.cs
+++ b/src/Microsoft.Sbom.Common/Config/IConfiguration.cs
@@ -171,8 +171,6 @@ public interface IConfiguration
     /// <summary>
     /// Gets or sets a timestamp in the format <code>yyyy-MM-ddTHH:mm:ssZ</code> that will be used as the generated timestamp for the SBOM.
     /// </summary>
-    [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1629:Documentation text should end with a period",
-        Justification = "Code element in comment.")]
     ConfigurationSetting<string> GenerationTimestamp { get; set; }
 
     /// <summary>

--- a/src/Microsoft.Sbom.Extensions/Entities/ManifestInfo.cs
+++ b/src/Microsoft.Sbom.Extensions/Entities/ManifestInfo.cs
@@ -24,12 +24,10 @@ public class ManifestInfo : IEquatable<ManifestInfo>
 
     /// <summary>
     /// Parses the manifest info from a string
-    /// The format is <name>:<version>
+    /// The format is <code>&lt;name&gt;:&lt;version&gt;</code>
     /// </summary>
     /// <param name="value"></param>
     /// <returns></returns>
-    [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1629:Documentation text should end with a period",
-        Justification = "Code element in comment.")]
     public static ManifestInfo Parse(string value)
     {
         if (string.IsNullOrEmpty(value))

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Enums/ExternalRepositoryType.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Enums/ExternalRepositoryType.cs
@@ -11,7 +11,9 @@ namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities.Enums;
 /// https://spdx.github.io/spdx-spec/appendix-VI-external-repository-identifiers/.
 /// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter))]
-[SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter",
+[SuppressMessage(
+    "StyleCop.CSharp.NamingRules",
+    "SA1300:Element should begin with upper-case letter",
     Justification = "These are enum types that are case sensitive and defined by external code.")]
 public enum ExternalRepositoryType
 {

--- a/test/Microsoft.Sbom.Api.Tests/ApiConfigurationBuilderTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/ApiConfigurationBuilderTests.cs
@@ -124,8 +124,13 @@ public class ApiConfigurationBuilderTests
         };
 
         var config = ApiConfigurationBuilder.GetConfiguration(
-            RootPath, string.Empty, null, null,
-            metadata, null, runtime);
+            RootPath,
+            string.Empty,
+            null,
+            null,
+            this.metadata,
+            null,
+            runtime);
 
         Assert.AreEqual(output, config.Verbosity.Value);
     }


### PR DESCRIPTION
[SA1117: Parameters should be on same line or separate lines](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1117.md)

Related to #340