### PR TITLE
chore: SA1206 declaration keywords must follow order

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -513,10 +513,6 @@ dotnet_diagnostic.SA1203.severity = suggestion
 # SA1204: Static elements must appear before instance elements
 dotnet_diagnostic.SA1204.severity = suggestion
 
-# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1206.md
-# SA1206: Declaration keywords should follow order
-dotnet_diagnostic.SA1206.severity = suggestion
-
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1207.md
 # SA1207: Member attributes should follow the order
 dotnet_diagnostic.SA1207.severity = suggestion

--- a/src/Microsoft.Sbom.Common/FileSystemUtils.cs
+++ b/src/Microsoft.Sbom.Common/FileSystemUtils.cs
@@ -62,9 +62,9 @@ public abstract class FileSystemUtils : IFileSystemUtils
         Constants.DefaultStreamBufferSize,
         FileOptions.Asynchronous);
 
-    abstract public bool DirectoryHasReadPermissions(string directoryPath);
+    public abstract bool DirectoryHasReadPermissions(string directoryPath);
 
-    abstract public bool DirectoryHasWritePermissions(string directoryPath);
+    public abstract bool DirectoryHasWritePermissions(string directoryPath);
 
     public DirectoryInfo CreateDirectory(string path) => Directory.CreateDirectory(path);
 

--- a/src/Microsoft.Sbom.Common/UnixFileSystemUtils.cs
+++ b/src/Microsoft.Sbom.Common/UnixFileSystemUtils.cs
@@ -8,13 +8,13 @@ namespace Microsoft.Sbom.Common;
 
 internal class UnixFileSystemUtils : FileSystemUtils
 {
-    override public bool DirectoryHasReadPermissions(string directoryPath)
+    public override bool DirectoryHasReadPermissions(string directoryPath)
     {
         var directoryInfo = new UnixDirectoryInfo(directoryPath);
         return directoryInfo.CanAccess(AccessModes.R_OK) && directoryInfo.CanAccess(AccessModes.F_OK);
     }
 
-    override public bool DirectoryHasWritePermissions(string directoryPath)
+    public override bool DirectoryHasWritePermissions(string directoryPath)
     {
         var directoryInfo = new UnixDirectoryInfo(directoryPath);
         return directoryInfo.CanAccess(AccessModes.W_OK) && directoryInfo.CanAccess(AccessModes.F_OK);

--- a/src/Microsoft.Sbom.Common/WindowsFileSystemUtils.cs
+++ b/src/Microsoft.Sbom.Common/WindowsFileSystemUtils.cs
@@ -13,9 +13,9 @@ namespace Microsoft.Sbom.Common;
 [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "This is a Windows only implementation")]
 public class WindowsFileSystemUtils : FileSystemUtils
 {
-    override public bool DirectoryHasReadPermissions(string directoryPath) => DirectoryHasRights(directoryPath, FileSystemRights.Read);
+    public override bool DirectoryHasReadPermissions(string directoryPath) => DirectoryHasRights(directoryPath, FileSystemRights.Read);
 
-    override public bool DirectoryHasWritePermissions(string directoryPath) => DirectoryHasRights(directoryPath, FileSystemRights.Write);
+    public override bool DirectoryHasWritePermissions(string directoryPath) => DirectoryHasRights(directoryPath, FileSystemRights.Write);
 
     // Get the collection of authorization rules that apply to the directory
     private bool DirectoryHasRights(string directoryPath, FileSystemRights fileSystemRights)


### PR DESCRIPTION
[SA1206: Declaration keywords must follow order](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1206.md)

Related to #340