### PR TITLE
ci: migrate from `MinVerDefaultPreReleasePhase` to `MinVerDefaultPreReleaseIdentifiers`

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -2,7 +2,7 @@
 
     <Target Name="Versioning" BeforeTargets="MinVer">
         <PropertyGroup Label="Build">
-            <MinVerDefaultPreReleasePhase>preview</MinVerDefaultPreReleasePhase>
+            <MinVerDefaultPreReleaseIdentifiers>preview.0</MinVerDefaultPreReleaseIdentifiers>
             <MinVerTagPrefix>v</MinVerTagPrefix>
         </PropertyGroup>
     </Target>


### PR DESCRIPTION
In [minver v4.3.0][1] `MinVerDefaultPreReleasePhase` was replaced with `MinVerDefaultPreReleaseIdentifiers`. Since we updated in #330 we've been seeing the following build warning:

> MinVerDefaultPreReleasePhase is deprecated and will be removed in the next major version. Use MinVerDefaultPreReleaseIdentifiers instead, with an additional "0" identifier. For example, if you are setting MinVerDefaultPreReleasePhase to "preview", set MinVerDefaultPreReleaseIdentifiers to "preview.0" instead.

[1]: https://github.com/adamralph/minver/blob/main/CHANGELOG.md#430