### PR TITLE
chore: CA1715 identifiers should have correct prefix

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -738,10 +738,6 @@ dotnet_diagnostic.CA1707.severity = suggestion
 # CA1711: Identifiers should not have incorrect suffix
 dotnet_diagnostic.CA1711.severity = suggestion
 
-# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1715
-# CA1715: Prefix generic type names with 'T'
-dotnet_diagnostic.CA1715.severity = suggestion
-
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1716
 # CA1716: Identifiers should not match keywords
 dotnet_diagnostic.CA1716.severity = suggestion

--- a/src/Microsoft.Sbom.Common/Extensions/DictionaryExtensions.cs
+++ b/src/Microsoft.Sbom.Common/Extensions/DictionaryExtensions.cs
@@ -15,15 +15,15 @@ public static class DictionaryExtensions
     /// Adds the value to the dictionary only if the value is not null,
     /// and the if dictionary already doesn't contain the given key.
     /// </summary>
-    /// <typeparam name="Tkey"></typeparam>
+    /// <typeparam name="TKey"></typeparam>
     /// <typeparam name="TValue"></typeparam>
     /// <param name="dictionary"></param>
     /// <param name="key"></param>
     /// <param name="value"></param>
     /// <exception cref="ArgumentNullException"></exception>
-    public static void AddIfKeyNotPresentAndValueNotNull<Tkey, TValue>(
-        this IDictionary<Tkey, TValue> dictionary,
-        Tkey key,
+    public static void AddIfKeyNotPresentAndValueNotNull<TKey, TValue>(
+        this IDictionary<TKey, TValue> dictionary,
+        TKey key,
         TValue value)
     {
         if (dictionary is null)


### PR DESCRIPTION
[CA1715: Identifiers should have correct prefix](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1715)

Related to #340