### PR TITLE
Don't warn on NU5104 for Mono.Unix Package

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -469,11 +469,6 @@ dotnet_diagnostic.SA1623.severity = none
 # https://github.com/dotnet/roslyn-analyzers/issues/6852
 dotnet_diagnostic.CA1859.severity = none
 
-# NU5104: A stable release of a package should not have a prerelease dependency
-# Justification: The Mono.Unix package that allows our tool to be built on ARM is labeled as 7.1.0-final.1.21458.1 which is detected as a prerelease dependency.
-# https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5104
-dotnet_diagnostic.NU5104.severity = none
-
 ##########################################
 # Temporary rules
 #

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,7 +28,7 @@
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
         <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30" />
         <PackageVersion Include="MinVer" Version="4.3.0" />
-        <PackageVersion Include="Mono.Unix" Version="7.1.0-final.1.21458.1" />
+        <PackageVersion Include="Mono.Unix" Version="7.1.0-final.1.21458.1" NoWarn="NU5104" />
         <PackageVersion Include="Moq" Version="4.17.2" />
         <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageVersion Include="NuGet.Frameworks" Version="6.7.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,7 +28,7 @@
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
         <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30" />
         <PackageVersion Include="MinVer" Version="4.3.0" />
-        <PackageVersion Include="Mono.Unix" Version="7.1.0-final.1.21458.1" NoWarn="NU5104" />
+        <PackageVersion Include="Mono.Unix" Version="7.1.0-final.1.21458.1" />
         <PackageVersion Include="Moq" Version="4.17.2" />
         <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageVersion Include="NuGet.Frameworks" Version="6.7.0" />

--- a/src/Microsoft.Sbom.Common/Microsoft.Sbom.Common.csproj
+++ b/src/Microsoft.Sbom.Common/Microsoft.Sbom.Common.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Unix" />
+    <PackageReference Include="Mono.Unix" NoWarn="NU5104" />
     <PackageReference Include="Serilog.Sinks.Console" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" />
     <PackageReference Include="System.Private.Uri" />


### PR DESCRIPTION
Error NU5104: Warning As Error: A stable release of a package should not have a prerelease dependency. Either modify the version spec of dependency "Mono.Unix [7.1.0-final.1.21458.1, )" or update the version field in the nuspec. was blocking builds