### PR TITLE
[docs] remove unsupported ARM notice for Homebrew installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,6 @@ winget install Microsoft.SbomTool
 
 ##### Homebrew
 
-> [!NOTE]
-> This Formulae requires the `x86_64` architecture, ARM is not supported at this time. For details see [#223](https://github.com/microsoft/sbom-tool/issues/223).
-
 ```bash
 brew install sbom-tool
 ```


### PR DESCRIPTION
Since issue #223 has been resolved by #346 ARM is now fully supported for Homebrew installations. The corresponding adjustment to the Formulae has been made here Homebrew/homebrew-core#141840.