### PR TITLE
Fix null ref when multiple SPDX components are detected.

### DIFF
--- a/src/Microsoft.Sbom.Api/Executors/LicenseInformationFetcher.cs
+++ b/src/Microsoft.Sbom.Api/Executors/LicenseInformationFetcher.cs
@@ -44,7 +44,7 @@ public class LicenseInformationFetcher : ILicenseInformationFetcher
                 var componentName = scannedComponent.Component.PackageUrl?.Name;
 
                 // If the clearlyDefinedName contains a / then split it and use the first part as the clearlyDefinedNamespace and the second part as the clearlyDefinedName
-                if (componentName.Contains('/'))
+                if (!string.IsNullOrEmpty(componentName) && componentName.Contains('/'))
                 {
                     string[] clearlyDefinedNameParts = componentName.Split('/');
                     clearlyDefinedNamespace = clearlyDefinedNameParts[0];


### PR DESCRIPTION
Discovered a null ref exception while attempting to fetch license information and multiple spdx files are present. This PR fixes the issue.