### PR TITLE
refactor: multiple roslyn analyzer fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1031,10 +1031,6 @@ dotnet_diagnostic.IDE0090.severity = suggestion
 # IDE0110: Discard can be removed
 dotnet_diagnostic.IDE0110.severity = suggestion
 
-# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0120
-# IDE0120: Simplify LINQ expression
-dotnet_diagnostic.IDE0120.severity = suggestion
-
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0220
 # IDE0220: 'foreach' statement implicitly converts '...' to '...'
 dotnet_diagnostic.IDE0220.severity = suggestion

--- a/.editorconfig
+++ b/.editorconfig
@@ -1047,10 +1047,6 @@ dotnet_diagnostic.IDE0220.severity = suggestion
 # IDE0251: Member can be made 'readonly'
 dotnet_diagnostic.IDE0251.severity = suggestion
 
-# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0270
-# IDE0270: Null check can be simplified
-dotnet_diagnostic.IDE0270.severity = suggestion
-
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide1006
 # IDE1006: Naming rule violation: These words must begin with upper case characters: ...
 dotnet_diagnostic.IDE1006.severity = suggestion

--- a/.editorconfig
+++ b/.editorconfig
@@ -1035,10 +1035,6 @@ dotnet_diagnostic.IDE0110.severity = suggestion
 # IDE0120: Simplify LINQ expression
 dotnet_diagnostic.IDE0120.severity = suggestion
 
-# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0200
-# IDE0200: Lambda expression can be simplified
-dotnet_diagnostic.IDE0200.severity = suggestion
-
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0220
 # IDE0220: 'foreach' statement implicitly converts '...' to '...'
 dotnet_diagnostic.IDE0220.severity = suggestion

--- a/src/Microsoft.Sbom.Api/Executors/ConcurrentSha256HashValidator.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ConcurrentSha256HashValidator.cs
@@ -47,7 +47,7 @@ public class ConcurrentSha256HashValidator
 
     private async Task Validate(InternalSbomFileInfo internalFileInfo, Channel<FileValidationResult> output, Channel<FileValidationResult> errors)
     {
-        var sha256Checksum = internalFileInfo.Checksum.Where(c => c.Algorithm == AlgorithmName.SHA256).FirstOrDefault();
+        var sha256Checksum = internalFileInfo.Checksum.FirstOrDefault(c => c.Algorithm == AlgorithmName.SHA256);
         var fileHashes = new FileHashes();
         fileHashes.SetHash(internalFileInfo.FileLocation, sha256Checksum);
         FileValidationResult failureResult = null;

--- a/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfigProvider.cs
+++ b/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfigProvider.cs
@@ -190,9 +190,8 @@ public class SbomConfigProvider : ISbomConfigProvider
         IMetadataProvider provider = null;
         if (MetadataDictionary.TryGetValue(MetadataKey.BuildEnvironmentName, out object buildEnvironmentName))
         {
-            provider = metadataProviders
-                .Where(p => p.BuildEnvironmentName != null && p.BuildEnvironmentName == buildEnvironmentName as string)
-                .FirstOrDefault();
+            provider = this.metadataProviders
+                .FirstOrDefault(p => p.BuildEnvironmentName != null && p.BuildEnvironmentName == buildEnvironmentName as string);
         }
         else
         {

--- a/src/Microsoft.Sbom.Api/Utils/ComponentDetectionCliArgumentBuilder.cs
+++ b/src/Microsoft.Sbom.Api/Utils/ComponentDetectionCliArgumentBuilder.cs
@@ -74,7 +74,7 @@ public class ComponentDetectionCliArgumentBuilder
 
         if (keyArgs.Any())
         {
-            var keyArgsCommand = string.Join(" ", keyArgs.Select(x => AsArgumentValue(x)));
+            var keyArgsCommand = string.Join(" ", keyArgs.Select(this.AsArgumentValue));
             command += $" {keyArgsCommand}";
         }
 

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/PackageArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/PackageArrayGenerator.cs
@@ -46,9 +46,8 @@ public class PackageArrayGenerator : IJsonArrayGenerator<PackageArrayGenerator>
         {
             IList<FileValidationResult> totalErrors = new List<FileValidationResult>();
 
-            ISourcesProvider sourcesProvider = sourcesProviders
-                .Where(s => s.IsSupported(ProviderType.Packages))
-                .FirstOrDefault();
+            var sourcesProvider = this.sourcesProviders
+                .FirstOrDefault(s => s.IsSupported(ProviderType.Packages));
 
             // Write the start of the array, if supported.
             IList<ISbomConfig> packagesArraySupportingConfigs = new List<ISbomConfig>();

--- a/src/Microsoft.Sbom.Contracts/Contracts/SBOMSpecification.cs
+++ b/src/Microsoft.Sbom.Contracts/Contracts/SBOMSpecification.cs
@@ -53,9 +53,7 @@ public class SbomSpecification : IEquatable<SbomSpecification>
         }
 
         var values = value.Split(':');
-        if (values == null
-            || values.Length != 2
-            || values.Any(v => string.IsNullOrWhiteSpace(v)))
+        if (values is not { Length: 2 } || values.Any(string.IsNullOrWhiteSpace))
         {
             throw new ArgumentException($"The SBOM specification string is not formatted correctly. The correct format is <name>:<version>.");
         }

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Generator.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Generator.cs
@@ -80,7 +80,7 @@ public class Generator : IManifestGenerator
             FileCopyrightText = fileInfo.FileCopyrightText ?? Constants.NoAssertionValue,
             LicenseConcluded = fileInfo.LicenseConcluded ?? Constants.NoAssertionValue,
             LicenseInfoInFiles = fileInfo.LicenseInfoInFiles ?? Constants.NoAssertionListValue,
-            FileTypes = fileInfo.FileTypes?.Select(f => GetSPDXFileType(f)).ToList(),
+            FileTypes = fileInfo.FileTypes?.Select(this.GetSPDXFileType).ToList(),
         };
 
         spdxFileElement.AddSpdxId(fileInfo.Path, fileInfo.Checksum);

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Generator.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Generator.cs
@@ -297,12 +297,9 @@ public class Generator : IManifestGenerator
             throw new ArgumentNullException(nameof(externalDocumentReferenceInfo.Checksum));
         }
 
-        var sha1Hash = externalDocumentReferenceInfo.Checksum.Where(h => h.Algorithm == AlgorithmName.SHA1).FirstOrDefault();
-
-        if (sha1Hash is null)
-        {
-            throw new MissingHashValueException($"The hash value for algorithm {AlgorithmName.SHA1} is missing from {nameof(externalDocumentReferenceInfo)}");
-        }
+        var sha1Hash = externalDocumentReferenceInfo.Checksum.FirstOrDefault(h => h.Algorithm == AlgorithmName.SHA1) ??
+                       throw new MissingHashValueException(
+                           $"The hash value for algorithm {AlgorithmName.SHA1} is missing from {nameof(externalDocumentReferenceInfo)}");
 
         var checksumValue = sha1Hash.ChecksumValue.ToLower();
         var externalDocumentReferenceElement = new SpdxExternalDocumentReference


### PR DESCRIPTION
Includes:
- [IDE0270: Null check can be simplified][1]
- [IDE0200: Remove unnecessary lambda expression][2]
- [IDE0120: Simplify LINQ expression][3]

[1]: https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0029-ide0030-ide0270
[2]: https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0200
[3]: https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0120