### PR TITLE
refactor: IDE0007 Use `var` instead of explicit type

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -919,10 +919,6 @@ dotnet_diagnostic.CS8632.severity = suggestion
 # IDE0005: Using directive is unnecessary
 dotnet_diagnostic.IDE0005.severity = suggestion
 
-# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0007
-# IDE0007:  use 'var' instead of explicit type
-dotnet_diagnostic.IDE0007.severity = suggestion
-
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0009
 # IDE0009: Add 'this' or 'Me' qualification
 dotnet_diagnostic.IDE0009.severity = suggestion

--- a/src/Microsoft.Sbom.Adapters/ComponentDetectionToSBOMPackageAdapter.cs
+++ b/src/Microsoft.Sbom.Adapters/ComponentDetectionToSBOMPackageAdapter.cs
@@ -34,7 +34,7 @@ public class ComponentDetectionToSBOMPackageAdapter
 
         try
         {
-            ScanResultWithLicense? componentDetectionScanResult = JsonConvert.DeserializeObject<ScanResultWithLicense>(File.ReadAllText(bcdeOutputPath));
+            var componentDetectionScanResult = JsonConvert.DeserializeObject<ScanResultWithLicense>(File.ReadAllText(bcdeOutputPath));
 
             if (componentDetectionScanResult == null)
             {

--- a/src/Microsoft.Sbom.Api/Config/ApiConfigurationBuilder.cs
+++ b/src/Microsoft.Sbom.Api/Config/ApiConfigurationBuilder.cs
@@ -53,7 +53,7 @@ public static class ApiConfigurationBuilder
             throw new ArgumentNullException(nameof(metadata));
         }
 
-        RuntimeConfiguration sanitizedRuntimeConfiguration = SanitiseRuntimeConfiguration(runtimeConfiguration);
+        var sanitizedRuntimeConfiguration = SanitiseRuntimeConfiguration(runtimeConfiguration);
 
         var configuration = new InputConfiguration
         {

--- a/src/Microsoft.Sbom.Api/Config/ArgRevivers.cs
+++ b/src/Microsoft.Sbom.Api/Config/ArgRevivers.cs
@@ -23,7 +23,7 @@ public class ArgRevivers
         try
         {
             IList<ManifestInfo> manifestInfos = new List<ManifestInfo>();
-            string[] values = value.Split(',');
+            var values = value.Split(',');
             foreach (var manifestInfoStr in values)
             {
                 manifestInfos.Add(ManifestInfo.Parse(manifestInfoStr));

--- a/src/Microsoft.Sbom.Api/Config/ConfigFileParser.cs
+++ b/src/Microsoft.Sbom.Api/Config/ConfigFileParser.cs
@@ -28,7 +28,7 @@ public class ConfigFileParser
             throw new ArgumentNullException($"{nameof(filePath)} cannot be emtpy.");
         }
 
-        using Stream openStream = fileSystemUtils.OpenRead(filePath);
+        using var openStream = fileSystemUtils.OpenRead(filePath);
         return await JsonSerializer.DeserializeAsync<ConfigFile>(openStream);
     }
 }

--- a/src/Microsoft.Sbom.Api/Config/ConfigSanitizer.cs
+++ b/src/Microsoft.Sbom.Api/Config/ConfigSanitizer.cs
@@ -175,7 +175,7 @@ public class ConfigSanitizer
         // If assembly name is not defined and namespace was not provided then return the default namespace as per spdx spec https://spdx.github.io/spdx-spec/v2.2.2/document-creation-information/#653-examples.
         if (string.IsNullOrWhiteSpace(assemblyConfig.DefaultSBOMNamespaceBaseUri) && string.IsNullOrEmpty(configuration.NamespaceUriBase?.Value))
         {
-            string defaultNamespaceUriBase = $"https://spdx.org/spdxdocs/sbom-tool-{SBOMToolVersion}-{Guid.NewGuid()}";
+            var defaultNamespaceUriBase = $"https://spdx.org/spdxdocs/sbom-tool-{SBOMToolVersion}-{Guid.NewGuid()}";
 
             logger.Information($"No namespace URI base provided, using unique generated default value {defaultNamespaceUriBase}");
 

--- a/src/Microsoft.Sbom.Api/Config/Validators/ConfigValidator.cs
+++ b/src/Microsoft.Sbom.Api/Config/Validators/ConfigValidator.cs
@@ -44,7 +44,7 @@ public abstract class ConfigValidator
             throw new ArgumentException($"'{nameof(propertyName)}' cannot be null or empty", nameof(propertyName));
         }
 
-        Attribute attribute = attributeCollection[supportedAttribute];
+        var attribute = attributeCollection[supportedAttribute];
         if (attribute == null)
         {
             return;

--- a/src/Microsoft.Sbom.Api/Config/Validators/IntRangeValidator.cs
+++ b/src/Microsoft.Sbom.Api/Config/Validators/IntRangeValidator.cs
@@ -23,7 +23,7 @@ public class IntRangeValidator : ConfigValidator
     {
         if (paramValue != null && paramValue is int value)
         {
-            IntRangeAttribute intRangeAttribute = attribute as IntRangeAttribute;
+            var intRangeAttribute = attribute as IntRangeAttribute;
 
             if (value < intRangeAttribute.MinRange || value > intRangeAttribute.MaxRange)
             {

--- a/src/Microsoft.Sbom.Api/Converters/ComponentToExternalReferenceInfoConverter.cs
+++ b/src/Microsoft.Sbom.Api/Converters/ComponentToExternalReferenceInfoConverter.cs
@@ -34,7 +34,7 @@ public class ComponentToExternalReferenceInfoConverter
 
         Task.Run(async () =>
         {
-            await foreach (ScannedComponent scannedComponent in componentReader.ReadAllAsync())
+            await foreach (var scannedComponent in componentReader.ReadAllAsync())
             {
                 try
                 {

--- a/src/Microsoft.Sbom.Api/Converters/ExternalReferenceInfoToPathConverter.cs
+++ b/src/Microsoft.Sbom.Api/Converters/ExternalReferenceInfoToPathConverter.cs
@@ -29,7 +29,7 @@ public class ExternalReferenceInfoToPathConverter
 
         Task.Run(async () =>
         {
-            await foreach (ExternalDocumentReferenceInfo externalDocumentRef in externalDocumentRefReader.ReadAllAsync())
+            await foreach (var externalDocumentRef in externalDocumentRefReader.ReadAllAsync())
             {
                 try
                 {

--- a/src/Microsoft.Sbom.Api/Converters/SbomToolManifestPathConverter.cs
+++ b/src/Microsoft.Sbom.Api/Converters/SbomToolManifestPathConverter.cs
@@ -37,11 +37,11 @@ public class SbomToolManifestPathConverter : IManifestPathConverter
 
     public (string, bool) Convert(string path, bool prependDotToPath = false)
     {
-        string dotString = prependDotToPath ? "." : string.Empty;
+        var dotString = prependDotToPath ? "." : string.Empty;
 
         // relativeTo
-        string buildDropPath = configuration.BuildDropPath.Value;
-        bool isOutsideDropPath = false;
+        var buildDropPath = configuration.BuildDropPath.Value;
+        var isOutsideDropPath = false;
         if (path == null)
         {
             throw new ArgumentNullException(nameof(path));
@@ -59,8 +59,8 @@ public class SbomToolManifestPathConverter : IManifestPathConverter
             }
         }
 
-        string relativePath = fileSystemUtils.GetRelativePath(buildDropPath, path);
-        string formattedRelativePath = $"{dotString}/{relativePath.Replace("\\", "/")}";
+        var relativePath = fileSystemUtils.GetRelativePath(buildDropPath, path);
+        var formattedRelativePath = $"{dotString}/{relativePath.Replace("\\", "/")}";
 
         return (formattedRelativePath, isOutsideDropPath);
     }

--- a/src/Microsoft.Sbom.Api/Entities/FileValidationResult.cs
+++ b/src/Microsoft.Sbom.Api/Entities/FileValidationResult.cs
@@ -26,8 +26,8 @@ public class FileValidationResult
     // TODO: Deprecate FileValidationResult to use EntityError
     public EntityError ToEntityError()
     {
-        EntityErrorType errorType = EntityErrorType.Other;
-        EntityType entityType = EntityType.Unknown;
+        var errorType = EntityErrorType.Other;
+        var entityType = EntityType.Unknown;
         Entity entity = null;
 
         switch (ErrorType)

--- a/src/Microsoft.Sbom.Api/Executors/ChannelUtils.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ChannelUtils.cs
@@ -24,7 +24,7 @@ public class ChannelUtils
         {
             async Task Redirect(ChannelReader<T> input)
             {
-                await foreach (T item in input.ReadAllAsync())
+                await foreach (var item in input.ReadAllAsync())
                 {
                     await output.Writer.WriteAsync(item);
                 }
@@ -56,13 +56,13 @@ public class ChannelUtils
         {
             var index = 0;
 
-            await foreach (T item in input.ReadAllAsync())
+            await foreach (var item in input.ReadAllAsync())
             {
                 await outputs[index].Writer.WriteAsync(item);
                 index = (index + 1) % n;
             }
 
-            foreach (Channel<T> ch in outputs)
+            foreach (var ch in outputs)
             {
                 ch.Writer.Complete();
             }

--- a/src/Microsoft.Sbom.Api/Executors/ComponentDetectionBaseWalker.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ComponentDetectionBaseWalker.cs
@@ -80,7 +80,7 @@ public abstract class ComponentDetectionBaseWalker
         // Enable SPDX22 detector which is disabled by default.
         cliArgumentBuilder.AddDetectorArg("SPDX22SBOM", "EnableIfDefaultOff");
 
-        if (sbomConfigs.TryGet(Constants.SPDX22ManifestInfo, out ISbomConfig spdxSbomConfig))
+        if (sbomConfigs.TryGet(Constants.SPDX22ManifestInfo, out var spdxSbomConfig))
         {
             var directory = Path.GetDirectoryName(spdxSbomConfig.ManifestJsonFilePath);
             if (!string.IsNullOrEmpty(directory))
@@ -117,18 +117,18 @@ public abstract class ComponentDetectionBaseWalker
             // Check if the configuration is set to fetch license information.
             if (configuration.FetchLicenseInformation?.Value == true)
             {
-                List<string> listOfComponentsForApi = licenseInformationFetcher.ConvertComponentsToListForApi(uniqueComponents);
+                var listOfComponentsForApi = licenseInformationFetcher.ConvertComponentsToListForApi(uniqueComponents);
 
                 // Check that an API call hasn't already been made. During the first execution of this class this list is empty (because we are detecting the files section of the SBOM). During the second execution we have all the components in the project. There are subsequent executions but not important in this scenario.
                 if (!licenseInformationRetrieved && listOfComponentsForApi?.Count > 0)
                 {
                     licenseInformationRetrieved = true;
 
-                    List<string> apiResponses = await licenseInformationFetcher.FetchLicenseInformationAsync(listOfComponentsForApi);
+                    var apiResponses = await licenseInformationFetcher.FetchLicenseInformationAsync(listOfComponentsForApi);
 
-                    foreach (string response in apiResponses)
+                    foreach (var response in apiResponses)
                     {
-                        Dictionary<string, string> licenseInfo = licenseInformationFetcher.ConvertClearlyDefinedApiResponseToList(response);
+                        var licenseInfo = licenseInformationFetcher.ConvertClearlyDefinedApiResponseToList(response);
 
                         if (licenseInfo != null)
                         {
@@ -143,10 +143,10 @@ public abstract class ComponentDetectionBaseWalker
             }
 
             // Converts every ScannedComponent into an ExtendedScannedComponent and attempts to add license information before writing to the channel.
-            foreach (ScannedComponent scannedComponent in uniqueComponents)
+            foreach (var scannedComponent in uniqueComponents)
             {
-                string componentName = scannedComponent.Component.PackageUrl?.Name;
-                string componentVersion = scannedComponent.Component.PackageUrl?.Version;
+                var componentName = scannedComponent.Component.PackageUrl?.Name;
+                var componentVersion = scannedComponent.Component.PackageUrl?.Version;
 
                 ScannedComponentWithLicense extendedComponent;
 

--- a/src/Microsoft.Sbom.Api/Executors/ExternalDocumentReferenceWriter.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ExternalDocumentReferenceWriter.cs
@@ -47,7 +47,7 @@ public class ExternalDocumentReferenceWriter
 
         Task.Run(async () =>
         {
-            await foreach (ExternalDocumentReferenceInfo externalDocumentReferenceInfo in externalDocumentReferenceInfos.ReadAllAsync())
+            await foreach (var externalDocumentReferenceInfo in externalDocumentReferenceInfos.ReadAllAsync())
             {
                 foreach (var config in externalDocumentReferenceArraySupportingConfigs)
                 {

--- a/src/Microsoft.Sbom.Api/Executors/FileHasher.cs
+++ b/src/Microsoft.Sbom.Api/Executors/FileHasher.cs
@@ -99,7 +99,7 @@ public class FileHasher
 
         Task.Run(async () =>
         {
-            await foreach (string file in fileInfo.ReadAllAsync())
+            await foreach (var file in fileInfo.ReadAllAsync())
             {
                 await GenerateHash(file, output, errors, fileLocation, prependDotToPath);
             }
@@ -114,11 +114,11 @@ public class FileHasher
     private async Task GenerateHash(string file, Channel<InternalSbomFileInfo> output, Channel<FileValidationResult> errors, FileLocation fileLocation, bool prependDotToPath = false)
     {
         string relativeFilePath = null;
-        bool isOutsideDropPath = false;
+        var isOutsideDropPath = false;
         try
         {
             (relativeFilePath, isOutsideDropPath) = manifestPathConverter.Convert(file, prependDotToPath);
-            Checksum[] fileHashes = hashCodeGenerator.GenerateHashes(file, HashAlgorithmNames);
+            var fileHashes = hashCodeGenerator.GenerateHashes(file, HashAlgorithmNames);
             if (fileHashes == null || fileHashes.Length == 0 || fileHashes.Any(f => string.IsNullOrEmpty(f.ChecksumValue)))
             {
                 throw new HashGenerationException($"Failed to generate hashes for '{file}'.");

--- a/src/Microsoft.Sbom.Api/Executors/FileInfoWriter.cs
+++ b/src/Microsoft.Sbom.Api/Executors/FileInfoWriter.cs
@@ -41,7 +41,7 @@ public class FileInfoWriter
 
         Task.Run(async () =>
         {
-            await foreach (InternalSbomFileInfo fileInfo in fileInfos.ReadAllAsync())
+            await foreach (var fileInfo in fileInfos.ReadAllAsync())
             {
                 await Generate(filesArraySupportingSBOMs, fileInfo, result, errors);
             }

--- a/src/Microsoft.Sbom.Api/Executors/FileListEnumerator.cs
+++ b/src/Microsoft.Sbom.Api/Executors/FileListEnumerator.cs
@@ -73,14 +73,14 @@ public class FileListEnumerator
             }
 
             // Split on Environment.NewLine and discard blank lines.
-            string[] separator = new string[] { Environment.NewLine };
-            IEnumerable<string> files = allText.Split(separator, StringSplitOptions.None)
+            var separator = new string[] { Environment.NewLine };
+            var files = allText.Split(separator, StringSplitOptions.None)
                 .Where(t => !string.IsNullOrEmpty(t));
             foreach (var oneFile in files)
             {
                 try
                 {
-                    string absoluteFileName = fileSystemUtils.AbsolutePath(oneFile);
+                    var absoluteFileName = fileSystemUtils.AbsolutePath(oneFile);
                     if (!fileSystemUtils.FileExists(absoluteFileName))
                     {
                         await errors.Writer.WriteAsync(new FileValidationResult

--- a/src/Microsoft.Sbom.Api/Executors/HashValidator.cs
+++ b/src/Microsoft.Sbom.Api/Executors/HashValidator.cs
@@ -55,7 +55,7 @@ public class HashValidator
             Path = fileHash.Path
         };
 
-        if (manifestData.HashesMap.TryGetValue(fileHash.Path, out Checksum[] expectedHashes))
+        if (manifestData.HashesMap.TryGetValue(fileHash.Path, out var expectedHashes))
         {
             manifestData.HashesMap.Remove(fileHash.Path);
 

--- a/src/Microsoft.Sbom.Api/Executors/LicenseInformationFetcher.cs
+++ b/src/Microsoft.Sbom.Api/Executors/LicenseInformationFetcher.cs
@@ -30,13 +30,13 @@ public class LicenseInformationFetcher : ILicenseInformationFetcher
 
     public List<string> ConvertComponentsToListForApi(IEnumerable<ScannedComponent> scannedComponents)
     {
-        List<string> listOfComponentsForApi = new List<string>();
+        var listOfComponentsForApi = new List<string>();
 
         foreach (var scannedComponent in scannedComponents)
         {
-            string[] parts = scannedComponent.Component.Id.Split(' ');
-            string componentVersion = scannedComponent.Component.PackageUrl?.Version;
-            string componentType = scannedComponent.Component.PackageUrl?.Type.ToLower();
+            var parts = scannedComponent.Component.Id.Split(' ');
+            var componentVersion = scannedComponent.Component.PackageUrl?.Version;
+            var componentType = scannedComponent.Component.PackageUrl?.Type.ToLower();
 
             if (parts.Length > 2)
             {
@@ -46,7 +46,7 @@ public class LicenseInformationFetcher : ILicenseInformationFetcher
                 // If the clearlyDefinedName contains a / then split it and use the first part as the clearlyDefinedNamespace and the second part as the clearlyDefinedName
                 if (!string.IsNullOrEmpty(componentName) && componentName.Contains('/'))
                 {
-                    string[] clearlyDefinedNameParts = componentName.Split('/');
+                    var clearlyDefinedNameParts = componentName.Split('/');
                     clearlyDefinedNamespace = clearlyDefinedNameParts[0];
                     componentName = clearlyDefinedNameParts[1];
                 }
@@ -90,20 +90,20 @@ public class LicenseInformationFetcher : ILicenseInformationFetcher
     // Will attempt to extract license information from a clearlyDefined batch API response. Will always return a dictionary which may be empty depending on the response.
     public Dictionary<string, string> ConvertClearlyDefinedApiResponseToList(string httpResponseContent)
     {
-        Dictionary<string, string> extractedLicenses = new Dictionary<string, string>();
+        var extractedLicenses = new Dictionary<string, string>();
 
         try
         {
-            JObject responseObject = JObject.Parse(httpResponseContent);
+            var responseObject = JObject.Parse(httpResponseContent);
 
-            foreach (JToken packageInfoToken in responseObject.Values())
+            foreach (var packageInfoToken in responseObject.Values())
             {
-                JObject packageInfo = packageInfoToken.ToObject<JObject>();
-                JObject coordinates = packageInfo.Value<JObject>("coordinates");
-                string packageNamespace = coordinates.Value<string>("namespace");
-                string packageName = coordinates.Value<string>("name");
-                string packageVersion = coordinates.Value<string>("revision");
-                string declaredLicense = packageInfo
+                var packageInfo = packageInfoToken.ToObject<JObject>();
+                var coordinates = packageInfo.Value<JObject>("coordinates");
+                var packageNamespace = coordinates.Value<string>("namespace");
+                var packageName = coordinates.Value<string>("name");
+                var packageVersion = coordinates.Value<string>("revision");
+                var declaredLicense = packageInfo
                     .Value<JObject>("licensed")
                     .Value<string>("declared");
 
@@ -152,7 +152,7 @@ public class LicenseInformationFetcher : ILicenseInformationFetcher
 
     public string GetFromLicenseDictionary(string key)
     {
-        string value = string.Empty;
+        var value = string.Empty;
 
         if (licenseDictionary.ContainsKey(key))
         {

--- a/src/Microsoft.Sbom.Api/Executors/LicenseInformationService.cs
+++ b/src/Microsoft.Sbom.Api/Executors/LicenseInformationService.cs
@@ -31,19 +31,19 @@ public class LicenseInformationService : ILicenseInformationService
 
     public async Task<List<string>> FetchLicenseInformationFromAPI(List<string> listOfComponentsForApi)
     {
-        int batchSize = 500;
-        List<HttpResponseMessage> responses = new List<HttpResponseMessage>();
-        List<string> responseContent = new List<string>();
+        var batchSize = 500;
+        var responses = new List<HttpResponseMessage>();
+        var responseContent = new List<string>();
 
-        Uri uri = new Uri("https://api.clearlydefined.io/definitions?expand=-files");
+        var uri = new Uri("https://api.clearlydefined.io/definitions?expand=-files");
 
         httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         httpClient.Timeout = TimeSpan.FromSeconds(ClientTimeoutSeconds);
 
-        for (int i = 0; i < listOfComponentsForApi.Count; i += batchSize)
+        for (var i = 0; i < listOfComponentsForApi.Count; i += batchSize)
         {
-            List<string> batch = listOfComponentsForApi.Skip(i).Take(batchSize).ToList();
-            string formattedData = JsonSerializer.Serialize(batch);
+            var batch = listOfComponentsForApi.Skip(i).Take(batchSize).ToList();
+            var formattedData = JsonSerializer.Serialize(batch);
 
             log.Debug($"Retrieving license information for {batch.Count} components...");
 
@@ -67,7 +67,7 @@ public class LicenseInformationService : ILicenseInformationService
             log.Debug($"Retrieving license information for {batch.Count} components took {stopwatch.Elapsed.TotalSeconds} seconds");
         }
 
-        foreach (HttpResponseMessage response in responses)
+        foreach (var response in responses)
         {
             if (response.IsSuccessStatusCode)
             {

--- a/src/Microsoft.Sbom.Api/Executors/ManifestFileFilterer.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ManifestFileFilterer.cs
@@ -54,7 +54,7 @@ public class ManifestFileFilterer
             {
                 try
                 {
-                    string file = fileSystemUtils.JoinPaths(configuration.BuildDropPath.Value, manifestFile);
+                    var file = fileSystemUtils.JoinPaths(configuration.BuildDropPath.Value, manifestFile);
                     if (!rootPathFilter.IsValid(file))
                     {
                         // This path is filtered, remove from the manifest map.

--- a/src/Microsoft.Sbom.Api/Executors/ManifestFolderFilterer.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ManifestFolderFilterer.cs
@@ -35,7 +35,7 @@ public class ManifestFolderFilterer
 
         Task.Run(async () =>
         {
-            await foreach (string file in files.ReadAllAsync())
+            await foreach (var file in files.ReadAllAsync())
             {
                 await FilterFiles(file, errors, output);
             }

--- a/src/Microsoft.Sbom.Api/Executors/PackageInfoJsonWriter.cs
+++ b/src/Microsoft.Sbom.Api/Executors/PackageInfoJsonWriter.cs
@@ -42,7 +42,7 @@ public class PackageInfoJsonWriter
 
         Task.Run(async () =>
         {
-            await foreach (SbomPackage packageInfo in packageInfos.ReadAllAsync())
+            await foreach (var packageInfo in packageInfos.ReadAllAsync())
             {
                 await GenerateJson(packagesArraySupportingConfigs, packageInfo, result, errors);
             }
@@ -62,7 +62,7 @@ public class PackageInfoJsonWriter
     {
         try
         {
-            foreach (ISbomConfig sbomConfig in packagesArraySupportingConfigs)
+            foreach (var sbomConfig in packagesArraySupportingConfigs)
             {
                 var generationResult =
                     manifestGeneratorProvider.Get(sbomConfig.ManifestInfo).GenerateJsonDocument(packageInfo);

--- a/src/Microsoft.Sbom.Api/Executors/RelationshipGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Executors/RelationshipGenerator.cs
@@ -37,8 +37,8 @@ public class RelationshipGenerator
                 {
                     while (relationships.MoveNext())
                     {
-                        IManifestGenerator manifestGenerator = manifestGeneratorProvider.Get(manifestInfo);
-                        GenerationResult generationResult = manifestGenerator.GenerateJsonDocument(relationships.Current);
+                        var manifestGenerator = manifestGeneratorProvider.Get(manifestInfo);
+                        var generationResult = manifestGenerator.GenerateJsonDocument(relationships.Current);
                         await output.Writer.WriteAsync(generationResult?.Document);
                     }
                 }

--- a/src/Microsoft.Sbom.Api/Executors/SBOMFileToFileInfoConverter.cs
+++ b/src/Microsoft.Sbom.Api/Executors/SBOMFileToFileInfoConverter.cs
@@ -38,7 +38,7 @@ public class SbomFileToFileInfoConverter
 
         Task.Run(async () =>
         {
-            await foreach (SbomFile component in componentReader.ReadAllAsync())
+            await foreach (var component in componentReader.ReadAllAsync())
             {
                 await Convert(component, output, errors, fileLocation);
             }

--- a/src/Microsoft.Sbom.Api/Executors/SPDXSBOMReaderForExternalDocumentReference.cs
+++ b/src/Microsoft.Sbom.Api/Executors/SPDXSBOMReaderForExternalDocumentReference.cs
@@ -79,7 +79,7 @@ public class SPDXSBOMReaderForExternalDocumentReference : ISBOMReaderForExternal
         Task.Run(async () =>
         {
             IList<ExternalDocumentReferenceInfo> externalDocumentReferenceInfos = new List<ExternalDocumentReferenceInfo>();
-            await foreach (string file in sbomFileLocation.ReadAllAsync())
+            await foreach (var file in sbomFileLocation.ReadAllAsync())
             {
                 if (!file.EndsWith(Constants.SPDXFileExtension, StringComparison.OrdinalIgnoreCase))
                 {
@@ -143,15 +143,15 @@ public class SPDXSBOMReaderForExternalDocumentReference : ISBOMReaderForExternal
         checksums = hashCodeGenerator.GenerateHashes(file, HashAlgorithmNames);
 
         using (var openStream = fileSystemUtils.OpenRead(file))
-        using (JsonDocument doc = JsonDocument.Parse(openStream))
+        using (var doc = JsonDocument.Parse(openStream))
         {
-            JsonElement root = doc.RootElement;
+            var root = doc.RootElement;
             string nameValue;
             string documentNamespaceValue;
             string versionValue;
             string rootElementValue;
 
-            if (root.TryGetProperty(Constants.SpdxVersionString, out JsonElement version))
+            if (root.TryGetProperty(Constants.SpdxVersionString, out var version))
             {
                 versionValue = version.GetString();
             }
@@ -165,7 +165,7 @@ public class SPDXSBOMReaderForExternalDocumentReference : ISBOMReaderForExternal
                 throw new Exception($"The SPDX version ${versionValue} is not valid format in the referenced SBOM, we currently only support SPDX-2.2 SBOM format.");
             }
 
-            if (root.TryGetProperty(Constants.NameString, out JsonElement name))
+            if (root.TryGetProperty(Constants.NameString, out var name))
             {
                 nameValue = name.GetString();
             }
@@ -174,7 +174,7 @@ public class SPDXSBOMReaderForExternalDocumentReference : ISBOMReaderForExternal
                 throw new Exception($"{Constants.NameString} property could not be parsed from referenced SPDX Document '{file}'.");
             }
 
-            if (root.TryGetProperty(Constants.DocumentNamespaceString, out JsonElement documentNamespace))
+            if (root.TryGetProperty(Constants.DocumentNamespaceString, out var documentNamespace))
             {
                 documentNamespaceValue = documentNamespace.GetString();
             }
@@ -183,7 +183,7 @@ public class SPDXSBOMReaderForExternalDocumentReference : ISBOMReaderForExternal
                 throw new Exception($"{Constants.DocumentNamespaceString} property could not be parsed from referenced SPDX Document '{file}'.");
             }
 
-            if (root.TryGetProperty(Constants.DocumentDescribesString, out JsonElement rootElements))
+            if (root.TryGetProperty(Constants.DocumentDescribesString, out var rootElements))
             {
                 rootElementValue = rootElements.EnumerateArray().FirstOrDefault().ToString() ?? Constants.DefaultRootElement;
             }

--- a/src/Microsoft.Sbom.Api/Filters/DownloadedRootPathFilter.cs
+++ b/src/Microsoft.Sbom.Api/Filters/DownloadedRootPathFilter.cs
@@ -58,7 +58,7 @@ public class DownloadedRootPathFilter : IFilter<DownloadedRootPathFilter>
             return false;
         }
 
-        bool isValid = false;
+        var isValid = false;
         var normalizedPath = new FileInfo(filePath).FullName;
 
         foreach (var validPath in validPaths)
@@ -81,7 +81,7 @@ public class DownloadedRootPathFilter : IFilter<DownloadedRootPathFilter>
         {
             skipValidation = false;
             validPaths = new HashSet<string>();
-            string[] relativeRootPaths = configuration.RootPathFilter.Value.Split(';');
+            var relativeRootPaths = configuration.RootPathFilter.Value.Split(';');
 
             validPaths.UnionWith(relativeRootPaths.Select(r =>
                 new FileInfo(fileSystemUtils.JoinPaths(configuration.BuildDropPath.Value, r))

--- a/src/Microsoft.Sbom.Api/Hashing/HashAlgorithmProvider.cs
+++ b/src/Microsoft.Sbom.Api/Hashing/HashAlgorithmProvider.cs
@@ -39,7 +39,7 @@ public class HashAlgorithmProvider : IHashAlgorithmProvider
             throw new ArgumentException($"'{nameof(algorithmName)}' cannot be null or whitespace.", nameof(algorithmName));
         }
 
-        if (algorithmNameMap.TryGetValue(algorithmName.ToLowerInvariant(), out AlgorithmName value))
+        if (algorithmNameMap.TryGetValue(algorithmName.ToLowerInvariant(), out var value))
         {
             return value;
         }

--- a/src/Microsoft.Sbom.Api/Hashing/HashCodeGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Hashing/HashCodeGenerator.cs
@@ -31,7 +31,7 @@ public class HashCodeGenerator : IHashCodeGenerator
     public Checksum[] GenerateHashes(string filePath, AlgorithmName[] hashAlgorithmNames)
     {
         var fileHashes = new Checksum[hashAlgorithmNames.Length];
-        int i = 0;
+        var i = 0;
 
         using var bufferedStream = new BufferedStream(fileSystemUtils.OpenRead(filePath), 1024 * 32);
 

--- a/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfigProvider.cs
+++ b/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfigProvider.cs
@@ -36,7 +36,7 @@ public class SbomConfigProvider : ISbomConfigProvider
             configsDictionary = new Dictionary<ManifestInfo, ISbomConfig>();
             foreach (var configHandler in manifestConfigHandlers)
             {
-                if (configHandler.TryGetManifestConfig(out ISbomConfig sbomConfig))
+                if (configHandler.TryGetManifestConfig(out var sbomConfig))
                 {
                     configsDictionary.AddIfKeyNotPresentAndValueNotNull(sbomConfig.ManifestInfo, sbomConfig);
                     recorder.RecordSBOMFormat(sbomConfig.ManifestInfo, sbomConfig.ManifestJsonFilePath);
@@ -140,7 +140,7 @@ public class SbomConfigProvider : ISbomConfigProvider
 
     public object GetMetadata(MetadataKey key)
     {
-        if (MetadataDictionary.TryGetValue(key, out object value))
+        if (MetadataDictionary.TryGetValue(key, out var value))
         {
             logger.Debug($"Found value for header {key} in internal metadata.");
             return value;
@@ -177,7 +177,7 @@ public class SbomConfigProvider : ISbomConfigProvider
 
     public GenerationData GetGenerationData(ManifestInfo manifestInfo)
     {
-        if (ConfigsDictionary.TryGetValue(manifestInfo, out ISbomConfig sbomConfig))
+        if (ConfigsDictionary.TryGetValue(manifestInfo, out var sbomConfig))
         {
             return sbomConfig.Recorder.GetGenerationData();
         }
@@ -188,7 +188,7 @@ public class SbomConfigProvider : ISbomConfigProvider
     public string GetSBOMNamespaceUri()
     {
         IMetadataProvider provider = null;
-        if (MetadataDictionary.TryGetValue(MetadataKey.BuildEnvironmentName, out object buildEnvironmentName))
+        if (MetadataDictionary.TryGetValue(MetadataKey.BuildEnvironmentName, out var buildEnvironmentName))
         {
             provider = metadataProviders
                 .Where(p => p.BuildEnvironmentName != null && p.BuildEnvironmentName == buildEnvironmentName as string)

--- a/src/Microsoft.Sbom.Api/Manifest/ManifestGeneratorProvider.cs
+++ b/src/Microsoft.Sbom.Api/Manifest/ManifestGeneratorProvider.cs
@@ -39,7 +39,7 @@ public class ManifestGeneratorProvider
     public IManifestGenerator Get(ManifestInfo manifestInfo)
     {
         var key = $"{manifestInfo.Name}:{manifestInfo.Version}";
-        if (manifestMap.TryGetValue(key, out IManifestGenerator generator))
+        if (manifestMap.TryGetValue(key, out var generator))
         {
             return generator;
         }

--- a/src/Microsoft.Sbom.Api/Output/FileOutputWriter.cs
+++ b/src/Microsoft.Sbom.Api/Output/FileOutputWriter.cs
@@ -22,8 +22,8 @@ public class FileOutputWriter : IOutputWriter
 
     public async Task WriteAsync(string output)
     {
-        using FileStream fs = new FileStream(configuration.OutputPath.Value, FileMode.Create);
-        using StreamWriter outputFile = new StreamWriter(fs);
+        using var fs = new FileStream(configuration.OutputPath.Value, FileMode.Create);
+        using var outputFile = new StreamWriter(fs);
         await outputFile.WriteAsync(output);
     }
 }

--- a/src/Microsoft.Sbom.Api/Output/ManifestToolJsonSerializer.cs
+++ b/src/Microsoft.Sbom.Api/Output/ManifestToolJsonSerializer.cs
@@ -79,8 +79,8 @@ public sealed class ManifestToolJsonSerializer : IManifestToolJsonSerializer
     {
         if (!string.IsNullOrEmpty(jsonString))
         {
-            using JsonDocument document = JsonDocument.Parse(jsonString);
-            foreach (JsonProperty property in document.RootElement.EnumerateObject())
+            using var document = JsonDocument.Parse(jsonString);
+            foreach (var property in document.RootElement.EnumerateObject())
             {
                 property.WriteTo(jsonWriter);
             }

--- a/src/Microsoft.Sbom.Api/Output/Telemetry/TelemetryRecorder.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/TelemetryRecorder.cs
@@ -127,7 +127,7 @@ public class TelemetryRecorder : IRecorder
             throw new ArgumentException($"'{nameof(eventName)}' cannot be null or whitespace.", nameof(eventName));
         }
 
-        TimingRecorder timingRecorder = new TimingRecorder(eventName);
+        var timingRecorder = new TimingRecorder(eventName);
         timingRecorders.Add(timingRecorder);
         return timingRecorder;
     }

--- a/src/Microsoft.Sbom.Api/Providers/ExternalDocumentReferenceProviders/CGExternalDocumentReferenceProvider.cs
+++ b/src/Microsoft.Sbom.Api/Providers/ExternalDocumentReferenceProviders/CGExternalDocumentReferenceProvider.cs
@@ -76,7 +76,7 @@ public class CGExternalDocumentReferenceProvider : EntityToJsonProviderBase<Scan
     {
         var (output, cdErrors) = sbomComponentsWalker.GetComponents(Configuration.BuildComponentPath?.Value);
 
-        if (cdErrors.TryRead(out ComponentDetectorException e))
+        if (cdErrors.TryRead(out var e))
         {
             throw e;
         }

--- a/src/Microsoft.Sbom.Api/Providers/FilesProviders/CGScannedExternalDocumentReferenceFileProvider.cs
+++ b/src/Microsoft.Sbom.Api/Providers/FilesProviders/CGScannedExternalDocumentReferenceFileProvider.cs
@@ -66,7 +66,7 @@ public class CGScannedExternalDocumentReferenceFileProvider : PathBasedFileToJso
         var (sbomOutput, cdErrors) = SBOMComponentsWalker.GetComponents(Configuration.BuildComponentPath?.Value);
         IList<ChannelReader<FileValidationResult>> errors = new List<ChannelReader<FileValidationResult>>();
 
-        if (cdErrors.TryRead(out ComponentDetectorException e))
+        if (cdErrors.TryRead(out var e))
         {
             throw e;
         }

--- a/src/Microsoft.Sbom.Api/Providers/PackagesProviders/CGScannedPackagesProvider.cs
+++ b/src/Microsoft.Sbom.Api/Providers/PackagesProviders/CGScannedPackagesProvider.cs
@@ -77,7 +77,7 @@ public class CGScannedPackagesProvider : CommonPackagesProvider<ScannedComponent
     {
         var (output, cdErrors) = packagesWalker.GetComponents(Configuration.BuildComponentPath?.Value);
 
-        if (cdErrors.TryRead(out ComponentDetectorException e))
+        if (cdErrors.TryRead(out var e))
         {
             throw e;
         }

--- a/src/Microsoft.Sbom.Api/Providers/PackagesProviders/CommonPackagesProvider.cs
+++ b/src/Microsoft.Sbom.Api/Providers/PackagesProviders/CommonPackagesProvider.cs
@@ -54,7 +54,7 @@ public abstract class CommonPackagesProvider<T> : EntityToJsonProviderBase<T>
                     sbomConfigs.TryGetMetadata(MetadataKey.ImageVersion, out object imageVersionObj))
                 {
                     Log.Debug($"Adding the image OS package to the packages list as a dependency.");
-                    string name = $"Azure Pipelines Hosted Image {imageOsObj}";
+                    var name = $"Azure Pipelines Hosted Image {imageOsObj}";
                     await packageInfos.Writer.WriteAsync(new SbomPackage()
                     {
                         PackageName = name,

--- a/src/Microsoft.Sbom.Api/SBOMGenerator.cs
+++ b/src/Microsoft.Sbom.Api/SBOMGenerator.cs
@@ -74,7 +74,7 @@ public class SbomGenerator : ISBOMGenerator
         inputConfiguration.ToConfiguration();
 
         // This is the generate workflow
-        bool isSuccess = await generationWorkflow.RunAsync();
+        var isSuccess = await generationWorkflow.RunAsync();
 
         await recorder.FinalizeAndLogTelemetryAsync();
 
@@ -118,7 +118,7 @@ public class SbomGenerator : ISBOMGenerator
         inputConfiguration.ToConfiguration();
 
         // This is the generate workflow
-        bool result = await generationWorkflow.RunAsync();
+        var result = await generationWorkflow.RunAsync();
 
         return new SbomGenerationResult(result, new List<EntityError>());
     }

--- a/src/Microsoft.Sbom.Api/SBOMValidator.cs
+++ b/src/Microsoft.Sbom.Api/SBOMValidator.cs
@@ -24,7 +24,7 @@ public class SbomValidator : ISBOMValidator
 
     public async Task<bool> ValidateSbomAsync()
     {
-        bool isSuccess = await sbomParserBasedValidationWorkflow.RunAsync();
+        var isSuccess = await sbomParserBasedValidationWorkflow.RunAsync();
         await recorder.FinalizeAndLogTelemetryAsync();
 
         var entityErrors = recorder.Errors.Select(error => error.ToEntityError()).ToList();

--- a/src/Microsoft.Sbom.Api/SignValidator/SignValidationProvider.cs
+++ b/src/Microsoft.Sbom.Api/SignValidator/SignValidationProvider.cs
@@ -39,7 +39,7 @@ public class SignValidationProvider : ISignValidationProvider
 
     public ISignValidator Get()
     {
-        if (signValidatorsMap.TryGetValue(osUtils.GetCurrentOSPlatform(), out ISignValidator signValidator))
+        if (signValidatorsMap.TryGetValue(osUtils.GetCurrentOSPlatform(), out var signValidator))
         {
             return signValidator;
         }

--- a/src/Microsoft.Sbom.Api/Utils/AssemblyConfig.cs
+++ b/src/Microsoft.Sbom.Api/Utils/AssemblyConfig.cs
@@ -34,7 +34,7 @@ public class AssemblyConfig : IAssemblyConfig
 
     private static readonly Lazy<string> AssemblyDirectoryValue = new Lazy<string>(() =>
     {
-        string location = Assembly.GetExecutingAssembly().Location;
+        var location = Assembly.GetExecutingAssembly().Location;
         return Path.GetDirectoryName(location);
     });
 

--- a/src/Microsoft.Sbom.Api/Utils/ComponentDetectionCliArgumentBuilder.cs
+++ b/src/Microsoft.Sbom.Api/Utils/ComponentDetectionCliArgumentBuilder.cs
@@ -191,7 +191,7 @@ public class ComponentDetectionCliArgumentBuilder
         }
 
         var argArray = Args.Convert(args);
-        for (int i = 0; i < argArray.Length; i++)
+        for (var i = 0; i < argArray.Length; i++)
         {
             if (argArray[i].StartsWith("--", StringComparison.Ordinal) && i + 1 < argArray.Length && !argArray[i + 1].StartsWith("--", StringComparison.Ordinal))
             {

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/ExternalDocumentReferenceGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/ExternalDocumentReferenceGenerator.cs
@@ -46,7 +46,7 @@ public class ExternalDocumentReferenceGenerator : IJsonArrayGenerator<ExternalDo
         {
             IList<FileValidationResult> totalErrors = new List<FileValidationResult>();
 
-            IEnumerable<ISourcesProvider> sourcesProviders = this.sourcesProviders
+            var sourcesProviders = this.sourcesProviders
                 .Where(s => s.IsSupported(ProviderType.ExternalDocumentReference));
             if (!sourcesProviders.Any())
             {
@@ -59,7 +59,7 @@ public class ExternalDocumentReferenceGenerator : IJsonArrayGenerator<ExternalDo
             foreach (var manifestInfo in sbomConfigs.GetManifestInfos())
             {
                 var config = sbomConfigs.Get(manifestInfo);
-                if (config.MetadataBuilder.TryGetExternalRefArrayHeaderName(out string externalRefArrayHeaderName))
+                if (config.MetadataBuilder.TryGetExternalRefArrayHeaderName(out var externalRefArrayHeaderName))
                 {
                     externalRefArraySupportingConfigs.Add(config);
                     config.JsonSerializer.StartJsonArray(externalRefArrayHeaderName);
@@ -71,15 +71,15 @@ public class ExternalDocumentReferenceGenerator : IJsonArrayGenerator<ExternalDo
                 var (jsonDocResults, errors) = sourcesProvider.Get(externalRefArraySupportingConfigs);
 
                 // Collect all the json elements and write to the serializer.
-                int totalJsonDocumentsWritten = 0;
+                var totalJsonDocumentsWritten = 0;
 
-                await foreach (JsonDocWithSerializer jsonResults in jsonDocResults.ReadAllAsync())
+                await foreach (var jsonResults in jsonDocResults.ReadAllAsync())
                 {
                     jsonResults.Serializer.Write(jsonResults.Document);
                     totalJsonDocumentsWritten++;
                 }
 
-                await foreach (FileValidationResult error in errors.ReadAllAsync())
+                await foreach (var error in errors.ReadAllAsync())
                 {
                     totalErrors.Add(error);
                 }

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/FileArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/FileArrayGenerator.cs
@@ -53,7 +53,7 @@ public class FileArrayGenerator : IJsonArrayGenerator<FileArrayGenerator>
         {
             IList<FileValidationResult> totalErrors = new List<FileValidationResult>();
 
-            IEnumerable<ISourcesProvider> sourcesProviders = this.sourcesProviders
+            var sourcesProviders = this.sourcesProviders
                 .Where(s => s.IsSupported(ProviderType.Files));
 
             // Write the start of the array, if supported.
@@ -62,7 +62,7 @@ public class FileArrayGenerator : IJsonArrayGenerator<FileArrayGenerator>
             {
                 var config = sbomConfigs.Get(manifestInfo);
 
-                if (config.MetadataBuilder.TryGetFilesArrayHeaderName(out string filesArrayHeaderName))
+                if (config.MetadataBuilder.TryGetFilesArrayHeaderName(out var filesArrayHeaderName))
                 {
                     config.JsonSerializer.StartJsonArray(filesArrayHeaderName);
                     filesArraySupportingSBOMs.Add(config);
@@ -74,12 +74,12 @@ public class FileArrayGenerator : IJsonArrayGenerator<FileArrayGenerator>
             {
                 var (jsondDocResults, errors) = sourcesProvider.Get(filesArraySupportingSBOMs);
 
-                await foreach (JsonDocWithSerializer jsonResults in jsondDocResults.ReadAllAsync())
+                await foreach (var jsonResults in jsondDocResults.ReadAllAsync())
                 {
                     jsonResults.Serializer.Write(jsonResults.Document);
                 }
 
-                await foreach (FileValidationResult error in errors.ReadAllAsync())
+                await foreach (var error in errors.ReadAllAsync())
                 {
                     // TODO fix errors.
                     if (error.ErrorType != ErrorType.ManifestFolder)
@@ -90,7 +90,7 @@ public class FileArrayGenerator : IJsonArrayGenerator<FileArrayGenerator>
             }
 
             // Write the end of the array.
-            foreach (ISbomConfig config in filesArraySupportingSBOMs)
+            foreach (var config in filesArraySupportingSBOMs)
             {
                 config.JsonSerializer.EndJsonArray();
             }

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/FilesValidator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/FilesValidator.cs
@@ -70,16 +70,16 @@ public class FilesValidator
         results.AddRange(inSbomFileResults);
         errors.AddRange(inSbomFileErrors);
 
-        int successCount = 0;
-        ChannelReader<FileValidationResult> resultChannel = channelUtils.Merge(results.ToArray());
-        await foreach (FileValidationResult validationResult in resultChannel.ReadAllAsync())
+        var successCount = 0;
+        var resultChannel = channelUtils.Merge(results.ToArray());
+        await foreach (var validationResult in resultChannel.ReadAllAsync())
         {
             successCount++;
         }
 
-        ChannelReader<FileValidationResult> workflowErrors = channelUtils.Merge(errors.ToArray());
+        var workflowErrors = channelUtils.Merge(errors.ToArray());
 
-        await foreach (FileValidationResult error in workflowErrors.ReadAllAsync())
+        await foreach (var error in workflowErrors.ReadAllAsync())
         {
             failures.Add(error.Path, error);
         }

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/PackageArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/PackageArrayGenerator.cs
@@ -46,7 +46,7 @@ public class PackageArrayGenerator : IJsonArrayGenerator<PackageArrayGenerator>
         {
             IList<FileValidationResult> totalErrors = new List<FileValidationResult>();
 
-            ISourcesProvider sourcesProvider = sourcesProviders
+            var sourcesProvider = sourcesProviders
                 .Where(s => s.IsSupported(ProviderType.Packages))
                 .FirstOrDefault();
 
@@ -55,7 +55,7 @@ public class PackageArrayGenerator : IJsonArrayGenerator<PackageArrayGenerator>
             foreach (var manifestInfo in sbomConfigs.GetManifestInfos())
             {
                 var config = sbomConfigs.Get(manifestInfo);
-                if (config.MetadataBuilder.TryGetPackageArrayHeaderName(out string packagesArrayHeaderName))
+                if (config.MetadataBuilder.TryGetPackageArrayHeaderName(out var packagesArrayHeaderName))
                 {
                     packagesArraySupportingConfigs.Add(config);
                     config.JsonSerializer.StartJsonArray(packagesArrayHeaderName);
@@ -65,9 +65,9 @@ public class PackageArrayGenerator : IJsonArrayGenerator<PackageArrayGenerator>
             var (jsonDocResults, errors) = sourcesProvider.Get(packagesArraySupportingConfigs);
 
             // 6. Collect all the json elements and write to the serializer.
-            int totalJsonDocumentsWritten = 0;
+            var totalJsonDocumentsWritten = 0;
 
-            await foreach (JsonDocWithSerializer jsonDocResult in jsonDocResults.ReadAllAsync())
+            await foreach (var jsonDocResult in jsonDocResults.ReadAllAsync())
             {
                 jsonDocResult.Serializer.Write(jsonDocResult.Document);
                 totalJsonDocumentsWritten++;
@@ -82,15 +82,15 @@ public class PackageArrayGenerator : IJsonArrayGenerator<PackageArrayGenerator>
 
             // +1 is added to the totalJsonDocumentsWritten to account for the root package of the SBOM.
             recorder.RecordTotalNumberOfPackages(totalJsonDocumentsWritten + 1);
-            await foreach (FileValidationResult error in errors.ReadAllAsync())
+            await foreach (var error in errors.ReadAllAsync())
             {
                 totalErrors.Add(error);
             }
 
-            foreach (ISbomConfig sbomConfig in packagesArraySupportingConfigs)
+            foreach (var sbomConfig in packagesArraySupportingConfigs)
             {
                 // Write the root package information to the packages array.
-                if (sbomConfig.MetadataBuilder.TryGetRootPackageJson(sbomConfigs, out GenerationResult generationResult))
+                if (sbomConfig.MetadataBuilder.TryGetRootPackageJson(sbomConfigs, out var generationResult))
                 {
                     sbomConfig.JsonSerializer.Write(generationResult?.Document);
                     sbomConfig.Recorder.RecordRootPackageId(generationResult?.ResultMetadata?.EntityId);

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/RelationshipsArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/RelationshipsArrayGenerator.cs
@@ -54,7 +54,7 @@ public class RelationshipsArrayGenerator : IJsonArrayGenerator<RelationshipsArra
             foreach (var manifestInfo in sbomConfigs.GetManifestInfos())
             {
                 var sbomConfig = sbomConfigs.Get(manifestInfo);
-                if (sbomConfig.MetadataBuilder.TryGetRelationshipsHeaderName(out string relationshipArrayHeaderName))
+                if (sbomConfig.MetadataBuilder.TryGetRelationshipsHeaderName(out var relationshipArrayHeaderName))
                 {
                     sbomConfig.JsonSerializer.StartJsonArray(relationshipArrayHeaderName);
 
@@ -97,9 +97,9 @@ public class RelationshipsArrayGenerator : IJsonArrayGenerator<RelationshipsArra
                     };
 
                     // Collect all the json elements and write to the serializer.
-                    int count = 0;
+                    var count = 0;
 
-                    await foreach (JsonDocument jsonDoc in channelUtils.Merge(jsonChannelsArray).ReadAllAsync())
+                    await foreach (var jsonDoc in channelUtils.Merge(jsonChannelsArray).ReadAllAsync())
                     {
                         count++;
                         sbomConfig.JsonSerializer.Write(jsonDoc);

--- a/src/Microsoft.Sbom.Api/Workflows/SBOMGenerationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SBOMGenerationWorkflow.cs
@@ -75,7 +75,7 @@ public class SbomGenerationWorkflow : IWorkflow<SbomGenerationWorkflow>
     {
         IList<FileValidationResult> validErrors = new List<FileValidationResult>();
         string sbomDir = null;
-        bool deleteSBOMDir = false;
+        var deleteSBOMDir = false;
         using (recorder.TraceEvent(Events.SBOMGenerationWorkflow))
         {
             try
@@ -197,7 +197,7 @@ public class SbomGenerationWorkflow : IWorkflow<SbomGenerationWorkflow>
             return;
         }
 
-        string hashFileName = $"{manifestJsonFilePath}.sha256";
+        var hashFileName = $"{manifestJsonFilePath}.sha256";
 
         using var readStream = fileSystemUtils.OpenRead(manifestJsonFilePath);
         using var bufferedStream = new BufferedStream(readStream, 1024 * 32);
@@ -220,7 +220,7 @@ public class SbomGenerationWorkflow : IWorkflow<SbomGenerationWorkflow>
             {
                 bool.TryParse(
                     osUtils.GetEnvironmentVariable(Constants.DeleteManifestDirBoolVariableName),
-                    out bool deleteSbomDirSwitch);
+                    out var deleteSbomDirSwitch);
 
                 recorder.RecordSwitch(Constants.DeleteManifestDirBoolVariableName, deleteSbomDirSwitch);
 

--- a/src/Microsoft.Sbom.Api/Workflows/SBOMParserBasedValidationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SBOMParserBasedValidationWorkflow.cs
@@ -61,7 +61,7 @@ public class SbomParserBasedValidationWorkflow : IWorkflow<SbomParserBasedValida
     {
         ValidationResult validationResultOutput = null;
         IEnumerable<FileValidationResult> validFailures = null;
-        int totalNumberOfPackages = 0;
+        var totalNumberOfPackages = 0;
 
         using (recorder.TraceEvent(Events.SBOMValidationWorkflow))
         {
@@ -70,7 +70,7 @@ public class SbomParserBasedValidationWorkflow : IWorkflow<SbomParserBasedValida
                 var sw = Stopwatch.StartNew();
                 var sbomConfig = sbomConfigs.Get(configuration.ManifestInfo.Value.FirstOrDefault());
 
-                using Stream stream = fileSystemUtils.OpenRead(sbomConfig.ManifestJsonFilePath);
+                using var stream = fileSystemUtils.OpenRead(sbomConfig.ManifestJsonFilePath);
                 var manifestInterface = manifestParserProvider.Get(sbomConfig.ManifestInfo);
                 var sbomParser = manifestInterface.CreateParser(stream);
 
@@ -93,7 +93,7 @@ public class SbomParserBasedValidationWorkflow : IWorkflow<SbomParserBasedValida
                     }
                 }
 
-                int successfullyValidatedFiles = 0;
+                var successfullyValidatedFiles = 0;
                 List<FileValidationResult> fileValidationFailures = null;
 
                 while (sbomParser.Next() != Contracts.Enums.ParserState.FINISHED)

--- a/src/Microsoft.Sbom.Api/Workflows/SBOMValidationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SBOMValidationWorkflow.cs
@@ -84,7 +84,7 @@ public class SbomValidationWorkflow : IWorkflow<SbomValidationWorkflow>
             try
             {
                 log.Debug("Starting validation workflow.");
-                DateTime start = DateTime.Now;
+                var start = DateTime.Now;
 
                 IList<ChannelReader<FileValidationResult>> errors = new List<ChannelReader<FileValidationResult>>();
                 IList<ChannelReader<FileValidationResult>> results = new List<ChannelReader<FileValidationResult>>();
@@ -138,18 +138,18 @@ public class SbomValidationWorkflow : IWorkflow<SbomValidationWorkflow>
                 }
 
                 // 4. Wait for the pipeline to finish.
-                int successCount = 0;
+                var successCount = 0;
                 var failures = new List<FileValidationResult>();
 
-                ChannelReader<FileValidationResult> resultChannel = channelUtils.Merge(results.ToArray());
-                await foreach (FileValidationResult validationResult in resultChannel.ReadAllAsync())
+                var resultChannel = channelUtils.Merge(results.ToArray());
+                await foreach (var validationResult in resultChannel.ReadAllAsync())
                 {
                     successCount++;
                 }
 
-                ChannelReader<FileValidationResult> workflowErrors = channelUtils.Merge(errors.ToArray());
+                var workflowErrors = channelUtils.Merge(errors.ToArray());
 
-                await foreach (FileValidationResult error in workflowErrors.ReadAllAsync())
+                await foreach (var error in workflowErrors.ReadAllAsync())
                 {
                     failures.Add(error);
                 }
@@ -170,7 +170,7 @@ public class SbomValidationWorkflow : IWorkflow<SbomValidationWorkflow>
                     return false;
                 }
 
-                DateTime end = DateTime.Now;
+                var end = DateTime.Now;
                 log.Debug("Finished workflow, gathering results.");
 
                 // 6. Generate JSON output

--- a/src/Microsoft.Sbom.Common/FileSystemUtilsProvider.cs
+++ b/src/Microsoft.Sbom.Common/FileSystemUtilsProvider.cs
@@ -18,7 +18,7 @@ public static class FileSystemUtilsProvider
     /// <returns></returns>
     public static IFileSystemUtils CreateInstance()
     {
-        bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
         return isWindows ? new WindowsFileSystemUtils() : new UnixFileSystemUtils();
     }
 }

--- a/src/Microsoft.Sbom.Common/OSUtils.cs
+++ b/src/Microsoft.Sbom.Common/OSUtils.cs
@@ -38,7 +38,7 @@ public class OSUtils : IOSUtils
             environmentVariables.Add(de.Key.ToString(), de.Value.ToString());
         }
 
-        foreach (OSPlatform os in oSPlatforms)
+        foreach (var os in oSPlatforms)
         {
             if (RuntimeInformation.IsOSPlatform(os))
             {

--- a/src/Microsoft.Sbom.Contracts/Contracts/Checksum.cs
+++ b/src/Microsoft.Sbom.Contracts/Contracts/Checksum.cs
@@ -37,7 +37,7 @@ public class Checksum : IEquatable<Checksum>
 
     public override int GetHashCode()
     {
-        int hashCode = 1457973397;
+        var hashCode = 1457973397;
         hashCode = (hashCode * -1521134295) + Algorithm.GetHashCode();
         hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(ChecksumValue);
         return hashCode;

--- a/src/Microsoft.Sbom.Contracts/Contracts/SBOMSpecification.cs
+++ b/src/Microsoft.Sbom.Contracts/Contracts/SBOMSpecification.cs
@@ -95,7 +95,7 @@ public class SbomSpecification : IEquatable<SbomSpecification>
 
     public override int GetHashCode()
     {
-        int hashCode = 2112831277;
+        var hashCode = 2112831277;
         hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(Name);
         hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(Version);
         return hashCode;

--- a/src/Microsoft.Sbom.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Sbom.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -174,12 +174,12 @@ public static class ServiceCollectionExtensions
             .AddScoped<ISBOMGenerator, SbomGenerator>()
             .AddSingleton(x =>
             {
-                IFileSystemUtils fileSystemUtils = x.GetRequiredService<IFileSystemUtils>();
-                ISbomConfigProvider sbomConfigs = x.GetRequiredService<ISbomConfigProvider>();
-                IOSUtils osUtils = x.GetRequiredService<IOSUtils>();
-                IConfiguration configuration = x.GetRequiredService<IConfiguration>();
+                var fileSystemUtils = x.GetRequiredService<IFileSystemUtils>();
+                var sbomConfigs = x.GetRequiredService<ISbomConfigProvider>();
+                var osUtils = x.GetRequiredService<IOSUtils>();
+                var configuration = x.GetRequiredService<IConfiguration>();
 
-                ManifestData manifestData = new ManifestData();
+                var manifestData = new ManifestData();
 
                 if (!configuration.ManifestInfo.Value.Contains(Api.Utils.Constants.SPDX22ManifestInfo))
                 {

--- a/src/Microsoft.Sbom.Extensions/Entities/ManifestInfo.cs
+++ b/src/Microsoft.Sbom.Extensions/Entities/ManifestInfo.cs
@@ -72,7 +72,7 @@ public class ManifestInfo : IEquatable<ManifestInfo>
 
     public override int GetHashCode()
     {
-        int hashCode = 2112831277;
+        var hashCode = 2112831277;
         hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(Name.ToLowerInvariant());
         hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(Version.ToLowerInvariant());
         return hashCode;

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/ParserUtils.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/ParserUtils.cs
@@ -174,7 +174,7 @@ internal class ParserUtils
     {
         if (reader.TokenType == JsonTokenType.StartArray)
         {
-            int arrayCount = 1;
+            var arrayCount = 1;
             while (true)
             {
                 if (reader.TokenType == JsonTokenType.EndArray)
@@ -196,7 +196,7 @@ internal class ParserUtils
         }
         else if (reader.TokenType == JsonTokenType.StartObject)
         {
-            int objectCount = 1;
+            var objectCount = 1;
             while (true)
             {
                 if (reader.TokenType == JsonTokenType.EndObject)

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/SPDXParser.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/SPDXParser.cs
@@ -330,7 +330,7 @@ public class SPDXParser : ISbomParser
             throw new ParserException($"The parser is not currently enumerating references. Current state: {CurrentState}");
         }
 
-        while (GetExternalDocumentReferences(stream, out SpdxExternalDocumentReference spdxExternalDocumentReference) != 0)
+        while (GetExternalDocumentReferences(stream, out var spdxExternalDocumentReference) != 0)
         {
             yield return spdxExternalDocumentReference.ToSbomReference();
         }
@@ -393,7 +393,7 @@ public class SPDXParser : ISbomParser
             throw new ParserException($"The parser is not currently enumerating relationships. Current state: {CurrentState}");
         }
 
-        while (GetRelationships(stream, out SPDXRelationship sbomRelationship) != 0)
+        while (GetRelationships(stream, out var sbomRelationship) != 0)
         {
             yield return sbomRelationship.ToSbomRelationship();
         }
@@ -456,7 +456,7 @@ public class SPDXParser : ISbomParser
             throw new ParserException($"The parser is not currently enumerating packages. Current state: {CurrentState}");
         }
 
-        while (GetPackages(stream, out SPDXPackage sbomPackage) != 0)
+        while (GetPackages(stream, out var sbomPackage) != 0)
         {
             yield return sbomPackage.ToSbomPackage();
         }
@@ -519,7 +519,7 @@ public class SPDXParser : ISbomParser
             throw new ParserException($"The parser is not currently enumerating files. Current state: {CurrentState}");
         }
 
-        while (GetFiles(stream, out SPDXFile sbomFile) != 0)
+        while (GetFiles(stream, out var sbomFile) != 0)
         {
             yield return sbomFile.ToSbomFile();
         }

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/InternalMetadataProviderIdentityExtensions.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/InternalMetadataProviderIdentityExtensions.cs
@@ -175,16 +175,16 @@ public static class InternalMetadataProviderIdentityExtensions
             throw new ArgumentNullException(nameof(internalMetadataProvider));
         }
 
-        string rootPackageVersion = Uri.EscapeDataString(internalMetadataProvider.GetPackageVersion());
-        string packageSupplierFromMetadata = Uri.EscapeDataString(internalMetadataProvider.GetPackageSupplier());
-        string rootPackageName = Uri.EscapeDataString(internalMetadataProvider.GetPackageName());
+        var rootPackageVersion = Uri.EscapeDataString(internalMetadataProvider.GetPackageVersion());
+        var packageSupplierFromMetadata = Uri.EscapeDataString(internalMetadataProvider.GetPackageSupplier());
+        var rootPackageName = Uri.EscapeDataString(internalMetadataProvider.GetPackageName());
 
-        Uri namespaceUri = new Uri(internalMetadataProvider.GetSBOMNamespaceUri());
+        var namespaceUri = new Uri(internalMetadataProvider.GetSBOMNamespaceUri());
 
         // Generate a guid for the new swid tag Id.
-        string tagId = Guid.NewGuid().ToString();
+        var tagId = Guid.NewGuid().ToString();
 
-        string swidPurl = $"pkg:swid/{packageSupplierFromMetadata}/{namespaceUri.Host}/{rootPackageName}@{rootPackageVersion}?tag_id={tagId}";
+        var swidPurl = $"pkg:swid/{packageSupplierFromMetadata}/{namespaceUri.Host}/{rootPackageName}@{rootPackageVersion}?tag_id={tagId}";
 
         return swidPurl;
     }

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/SPDXExtensions.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/SPDXExtensions.cs
@@ -104,7 +104,7 @@ public static class SPDXExtensions
         }
 
         // Get package identity as package name and package version. If version is empty, just use package name
-        string packageIdentity = $"{packageInfo.Type}-{packageInfo.PackageName}";
+        var packageIdentity = $"{packageInfo.Type}-{packageInfo.PackageName}";
         if (!string.IsNullOrWhiteSpace(packageInfo.PackageVersion))
         {
             packageIdentity = string.Join("-", packageInfo.Type, packageInfo.PackageName, packageInfo.PackageVersion);
@@ -139,7 +139,7 @@ public static class SPDXExtensions
         }
 
         // Get the SHA1 for this file.
-        string sha1Value = checksums.Where(c => c.Algorithm == AlgorithmName.SHA1)
+        var sha1Value = checksums.Where(c => c.Algorithm == AlgorithmName.SHA1)
             .Select(s => s.ChecksumValue)
             .FirstOrDefault();
 
@@ -168,7 +168,7 @@ public static class SPDXExtensions
         }
 
         // Get the SHA1 for this file.
-        string sha1Value = checksums.Where(c => c.Algorithm == AlgorithmName.SHA1)
+        var sha1Value = checksums.Where(c => c.Algorithm == AlgorithmName.SHA1)
             .Select(s => s.ChecksumValue)
             .FirstOrDefault();
 

--- a/test/Microsoft.Sbom.Adapters.Tests/ComponentDetectionToSBOMPackageAdapterTests.cs
+++ b/test/Microsoft.Sbom.Adapters.Tests/ComponentDetectionToSBOMPackageAdapterTests.cs
@@ -107,7 +107,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
     {
         Assert.ThrowsException<ArgumentNullException>(() =>
         {
-            ComponentDetectionToSBOMPackageAdapter adapter = new ComponentDetectionToSBOMPackageAdapter();
+            var adapter = new ComponentDetectionToSBOMPackageAdapter();
             adapter.TryConvert("not/a/real/path");
         });
     }
@@ -272,7 +272,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         Directory.CreateDirectory(baseDirectory);
         File.WriteAllText(bcdeOutputPath, json);
 
-        ComponentDetectionToSBOMPackageAdapter adapter = new ComponentDetectionToSBOMPackageAdapter();
+        var adapter = new ComponentDetectionToSBOMPackageAdapter();
         var (errors, packages) = adapter.TryConvert(bcdeOutputPath);
         var output = packages.ToList();
 

--- a/test/Microsoft.Sbom.Api.Tests/ApiConfigurationBuilderTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/ApiConfigurationBuilderTests.cs
@@ -49,7 +49,7 @@ public class ApiConfigurationBuilderTests
     [TestMethod]
     public void GetConfiguration_PopulateAll()
     {
-        List<SbomSpecification> specs = new List<SbomSpecification>();
+        var specs = new List<SbomSpecification>();
         specs.Add(new SbomSpecification("spdx", "2.2"));
 
         var expectedManifestInfo = new ManifestInfo()

--- a/test/Microsoft.Sbom.Api.Tests/Converters/ComponentToExternalReferenceInfoConverterTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Converters/ComponentToExternalReferenceInfoConverterTests.cs
@@ -43,7 +43,7 @@ public class ComponentToExternalReferenceInfoConverterTests
 
         var refs = await results.ReadAllAsync().ToListAsync();
 
-        await foreach (FileValidationResult error in errors.ReadAllAsync())
+        await foreach (var error in errors.ReadAllAsync())
         {
             Assert.Fail($"Caught exception: {error.ErrorType}");
         }

--- a/test/Microsoft.Sbom.Api.Tests/Converters/ExternalReferenceInfoToPathConverterTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Converters/ExternalReferenceInfoToPathConverterTest.cs
@@ -57,13 +57,13 @@ public class ExternalReferenceInfoToPathConverterTest
 
         var paths = await results.ReadAllAsync().ToListAsync();
 
-        await foreach (FileValidationResult error in errors.ReadAllAsync())
+        await foreach (var error in errors.ReadAllAsync())
         {
             Assert.Fail($"Caught exception: {error.ErrorType}");
         }
 
         var count = 1;
-        await foreach (string path in results.ReadAllAsync())
+        await foreach (var path in results.ReadAllAsync())
         {
             Assert.Equals($"path{count}", path);
             count++;
@@ -108,7 +108,7 @@ public class ExternalReferenceInfoToPathConverterTest
         var paths = await results.ReadAllAsync().ToListAsync();
         var errorList = await errors.ReadAllAsync().ToListAsync();
 
-        await foreach (FileValidationResult error in errors.ReadAllAsync())
+        await foreach (var error in errors.ReadAllAsync())
         {
             Assert.Fail($"Caught exception: {error.ErrorType}");
         }

--- a/test/Microsoft.Sbom.Api.Tests/Entities/output/ValidationResultGeneratorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Entities/output/ValidationResultGeneratorTests.cs
@@ -22,7 +22,7 @@ public class ValidationResultGeneratorTests
     public void ValidationResultGenerator_ShouldGenerateReportWithoutFailures()
     {
         var manifestData = GetDefaultManifestData();
-        Mock<IConfiguration> configurationMock = GetDefaultConfigurationMock(ignoreMissing: false);
+        var configurationMock = GetDefaultConfigurationMock(ignoreMissing: false);
 
         var validationResultGenerator = new ValidationResultGenerator(configurationMock.Object);
         var failures = new List<FileValidationResult>();
@@ -58,7 +58,7 @@ public class ValidationResultGeneratorTests
     public void ValidationResultGenerator_ShouldGenerateReportWithoutFailuresIfIgnoreMissing()
     {
         var manifestData = GetDefaultManifestData();
-        Mock<IConfiguration> configurationMock = GetDefaultConfigurationMock(ignoreMissing: true);
+        var configurationMock = GetDefaultConfigurationMock(ignoreMissing: true);
 
         var validationResultGenerator = new ValidationResultGenerator(configurationMock.Object);
         var failures = new List<FileValidationResult>();
@@ -94,7 +94,7 @@ public class ValidationResultGeneratorTests
     public void ValidationResultGenerator_IncorrectHashShouldCauseFailure()
     {
         var manifestData = GetDefaultManifestData();
-        Mock<IConfiguration> configurationMock = GetDefaultConfigurationMock(ignoreMissing: false);
+        var configurationMock = GetDefaultConfigurationMock(ignoreMissing: false);
 
         var validationResultGenerator = new ValidationResultGenerator(configurationMock.Object);
         var failures = new List<FileValidationResult>();
@@ -136,7 +136,7 @@ public class ValidationResultGeneratorTests
     public void ValidationResultGenerator_MissingFileShouldCauseFailure()
     {
         var manifestData = GetDefaultManifestData();
-        Mock<IConfiguration> configurationMock = GetDefaultConfigurationMock(ignoreMissing: false);
+        var configurationMock = GetDefaultConfigurationMock(ignoreMissing: false);
 
         var validationResultGenerator = new ValidationResultGenerator(configurationMock.Object);
         var failures = new List<FileValidationResult>();
@@ -178,7 +178,7 @@ public class ValidationResultGeneratorTests
     public void ValidationResultGenerator_MissingFileShouldNotCauseFailureIfIgnoreMissing()
     {
         var manifestData = GetDefaultManifestData();
-        Mock<IConfiguration> configurationMock = GetDefaultConfigurationMock(ignoreMissing: true);
+        var configurationMock = GetDefaultConfigurationMock(ignoreMissing: true);
 
         var validationResultGenerator = new ValidationResultGenerator(configurationMock.Object);
         var failures = new List<FileValidationResult>();
@@ -220,7 +220,7 @@ public class ValidationResultGeneratorTests
     public void ValidationResultGenerator_ShouldFailOnlyOnWrongHashIfIgnoreMissing()
     {
         var manifestData = GetDefaultManifestData();
-        Mock<IConfiguration> configurationMock = GetDefaultConfigurationMock(ignoreMissing: true);
+        var configurationMock = GetDefaultConfigurationMock(ignoreMissing: true);
 
         var validationResultGenerator = new ValidationResultGenerator(configurationMock.Object);
         var failures = new List<FileValidationResult>();

--- a/test/Microsoft.Sbom.Api.Tests/Executors/ComponentToPackageInfoConverterTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/ComponentToPackageInfoConverterTests.cs
@@ -148,7 +148,7 @@ public class ComponentToPackageInfoConverterTests
             Component = new NpmComponent("nugetpackage", "1.0.0", author: new NpmAuthor("Suzy Author"))
         };
 
-        PackageInfo packageInfo = await ConvertScannedComponent(scannedComponent);
+        var packageInfo = await ConvertScannedComponent(scannedComponent);
 
         Assert.AreEqual($"Organization: {((NpmComponent)scannedComponent.Component).Author.Name}", packageInfo.Supplier);
     }
@@ -161,7 +161,7 @@ public class ComponentToPackageInfoConverterTests
             Component = new NpmComponent("nugetpackage", "1.0.0", author: new NpmAuthor("Suzy Author", "suzya@contoso.com"))
         };
 
-        PackageInfo packageInfo = await ConvertScannedComponent(scannedComponent);
+        var packageInfo = await ConvertScannedComponent(scannedComponent);
 
         Assert.AreEqual($"Organization: {((NpmComponent)scannedComponent.Component).Author.Name} ({((NpmComponent)scannedComponent.Component).Author.Email})", packageInfo.Supplier);
     }

--- a/test/Microsoft.Sbom.Api.Tests/Executors/DirectoryWalkerTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/DirectoryWalkerTests.cs
@@ -28,7 +28,7 @@ public class DirectoryWalkerTests
     [TestMethod]
     public async Task DirectoryWalkerTests_ValidRoot_SucceedsAsync()
     {
-        HashSet<string> files = new HashSet<string>
+        var files = new HashSet<string>
         {
             @"Test\Sample\NoRead.txt",
             @"Test\Sample\Sample.txt",
@@ -44,17 +44,17 @@ public class DirectoryWalkerTests
 
         var filesChannelReader = new DirectoryWalker(mockFSUtils.Object, mockLogger.Object, mockConfiguration.Object).GetFilesRecursively(@"Test");
 
-        await foreach (string file in filesChannelReader.file.ReadAllAsync())
+        await foreach (var file in filesChannelReader.file.ReadAllAsync())
         {
             Assert.IsTrue(files.Remove(file));
         }
 
-        await foreach (string file in filesChannelReader.file.ReadAllAsync())
+        await foreach (var file in filesChannelReader.file.ReadAllAsync())
         {
             Assert.IsTrue(files.Remove(file));
         }
 
-        await foreach (Entities.FileValidationResult error in filesChannelReader.errors.ReadAllAsync())
+        await foreach (var error in filesChannelReader.errors.ReadAllAsync())
         {
             Assert.Fail($"Error thrown for {error.Path}: {error.ErrorType}");
         }
@@ -76,7 +76,7 @@ public class DirectoryWalkerTests
     [TestMethod]
     public async Task DirectoryWalkerTests_UnreachableFile_FailsAsync()
     {
-        HashSet<string> files = new HashSet<string>
+        var files = new HashSet<string>
         {
             @"Test\SampleBadDir\Test.txt"
         };
@@ -90,14 +90,14 @@ public class DirectoryWalkerTests
         mockFSUtils.Setup(m => m.GetFilesInDirectory(It.Is<string>(d => d == "Failed"), true)).Throws(new UnauthorizedAccessException()).Verifiable();
 
         var filesChannelReader = new DirectoryWalker(mockFSUtils.Object, mockLogger.Object, mockConfiguration.Object).GetFilesRecursively(@"Test");
-        int errorCount = 0;
+        var errorCount = 0;
 
-        await foreach (Entities.FileValidationResult error in filesChannelReader.errors.ReadAllAsync())
+        await foreach (var error in filesChannelReader.errors.ReadAllAsync())
         {
             errorCount++;
         }
 
-        await foreach (string file in filesChannelReader.file.ReadAllAsync())
+        await foreach (var file in filesChannelReader.file.ReadAllAsync())
         {
             Assert.IsTrue(files.Remove(file));
         }

--- a/test/Microsoft.Sbom.Api.Tests/Executors/ExternalDocumentReferenceWriterTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/ExternalDocumentReferenceWriterTest.cs
@@ -50,7 +50,7 @@ public class ExternalDocumentReferenceWriterTest
             Recorder = new SbomPackageDetailsRecorder()
         };
 
-        ExternalDocumentReferenceInfo externalDocumentReferenceInfo = new ExternalDocumentReferenceInfo
+        var externalDocumentReferenceInfo = new ExternalDocumentReferenceInfo
         {
             ExternalDocumentName = "name",
             DocumentNamespace = "namespace"
@@ -76,11 +76,11 @@ public class ExternalDocumentReferenceWriterTest
 
         await foreach (var result in results.ReadAllAsync())
         {
-            JsonElement root = result.Document.RootElement;
+            var root = result.Document.RootElement;
 
             Assert.IsNotNull(root);
 
-            if (root.TryGetProperty("Document", out JsonElement documentNamespace))
+            if (root.TryGetProperty("Document", out var documentNamespace))
             {
                 Assert.AreEqual("namespace", documentNamespace.GetString());
             }
@@ -89,7 +89,7 @@ public class ExternalDocumentReferenceWriterTest
                 Assert.Fail("Document property not found");
             }
 
-            if (root.TryGetProperty("ExternalDocumentId", out JsonElement externalDocumentId))
+            if (root.TryGetProperty("ExternalDocumentId", out var externalDocumentId))
             {
                 Assert.AreEqual("name", externalDocumentId.GetString());
             }

--- a/test/Microsoft.Sbom.Api.Tests/Executors/FileHasherTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/FileHasherTests.cs
@@ -90,7 +90,7 @@ public class FileHasherTests
 
         files.Writer.Complete();
 
-        await foreach (InternalSbomFileInfo fileHash in fileHashes.file.ReadAllAsync())
+        await foreach (var fileHash in fileHashes.file.ReadAllAsync())
         {
             Assert.IsTrue(fileList.Remove(fileHash.Path));
             Assert.AreEqual("hash", fileHash.Checksum.First().ChecksumValue);
@@ -155,7 +155,7 @@ public class FileHasherTests
             filesCount++;
         }
 
-        await foreach (FileValidationResult error in fileHashes.error.ReadAllAsync())
+        await foreach (var error in fileHashes.error.ReadAllAsync())
         {
             Assert.AreEqual(Entities.ErrorType.Other, error.ErrorType);
             errorCount++;
@@ -217,7 +217,7 @@ public class FileHasherTests
         var errorCount = 0;
         var filesCount = 0;
 
-        await foreach (InternalSbomFileInfo fileHash in fileHashes.file.ReadAllAsync())
+        await foreach (var fileHash in fileHashes.file.ReadAllAsync())
         {
             Assert.IsTrue(fileList.Remove(fileHash.Path));
             Assert.AreEqual("hash", fileHash.Checksum.First().ChecksumValue);
@@ -225,7 +225,7 @@ public class FileHasherTests
             filesCount++;
         }
 
-        await foreach (FileValidationResult error in fileHashes.error.ReadAllAsync())
+        await foreach (var error in fileHashes.error.ReadAllAsync())
         {
             Assert.AreEqual(Entities.ErrorType.Other, error.ErrorType);
             errorCount++;
@@ -299,7 +299,7 @@ public class FileHasherTests
 
         files.Writer.Complete();
 
-        await foreach (InternalSbomFileInfo fileHash in fileHashes.file.ReadAllAsync())
+        await foreach (var fileHash in fileHashes.file.ReadAllAsync())
         {
             Assert.IsTrue(fileList.Remove(fileHash.Path));
             Assert.AreEqual("hash", fileHash.Checksum.First().ChecksumValue);

--- a/test/Microsoft.Sbom.Api.Tests/Executors/FileListEnumeratorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/FileListEnumeratorTests.cs
@@ -20,14 +20,14 @@ public class FileListEnumeratorTests
     [TestMethod]
     public async Task ListWalkerTests_ValidListFile_SucceedsAsync()
     {
-        List<string> files = new List<string>
+        var files = new List<string>
         {
             @"d:\directorya\directoryb\file1.txt",
             @"d:\directorya\directoryc\file3.txt",
         };
 
-        string fileText = string.Join(Environment.NewLine, files);
-        string testFileName = "somefile";
+        var fileText = string.Join(Environment.NewLine, files);
+        var testFileName = "somefile";
 
         var mockFSUtils = new Mock<IFileSystemUtils>();
         mockFSUtils.Setup(m => m.ReadAllText(It.Is<string>(d => d == testFileName))).Returns(fileText).Verifiable();
@@ -38,15 +38,15 @@ public class FileListEnumeratorTests
         mockFSUtils.Setup(m => m.AbsolutePath(It.Is<string>(d => d == files[1]))).Returns(files[1]);
 
         var filesChannelReader = new FileListEnumerator(mockFSUtils.Object, mockLogger.Object).GetFilesFromList(testFileName);
-        int errorCount = 0;
+        var errorCount = 0;
 
-        await foreach (Entities.FileValidationResult error in filesChannelReader.errors.ReadAllAsync())
+        await foreach (var error in filesChannelReader.errors.ReadAllAsync())
         {
             Assert.AreEqual(Entities.ErrorType.MissingFile, error.ErrorType);
             errorCount++;
         }
 
-        await foreach (string file in filesChannelReader.file.ReadAllAsync())
+        await foreach (var file in filesChannelReader.file.ReadAllAsync())
         {
             Assert.IsTrue(files.Remove(file));
         }
@@ -79,14 +79,14 @@ public class FileListEnumeratorTests
     [TestMethod]
     public async Task ListWalkerTests_UnreachableFile_FailsAsync()
     {
-        List<string> files = new List<string>
+        var files = new List<string>
         {
             @"d:\directorya\directoryb\file1.txt",
             @"d:\directorya\directoryc\file3.txt",
         };
 
-        string fileText = string.Join(Environment.NewLine, files);
-        string testFileName = "somefile";
+        var fileText = string.Join(Environment.NewLine, files);
+        var testFileName = "somefile";
 
         var mockFSUtils = new Mock<IFileSystemUtils>();
         mockFSUtils.Setup(m => m.ReadAllText(It.Is<string>(d => d == testFileName))).Returns(fileText).Verifiable();
@@ -97,15 +97,15 @@ public class FileListEnumeratorTests
         mockFSUtils.Setup(m => m.AbsolutePath(It.Is<string>(d => d == files[1]))).Returns(files[1]);
 
         var filesChannelReader = new FileListEnumerator(mockFSUtils.Object, mockLogger.Object).GetFilesFromList(testFileName);
-        int errorCount = 0;
+        var errorCount = 0;
 
-        await foreach (Entities.FileValidationResult error in filesChannelReader.errors.ReadAllAsync())
+        await foreach (var error in filesChannelReader.errors.ReadAllAsync())
         {
             Assert.AreEqual(Entities.ErrorType.MissingFile, error.ErrorType);
             errorCount++;
         }
 
-        await foreach (string file in filesChannelReader.file.ReadAllAsync())
+        await foreach (var file in filesChannelReader.file.ReadAllAsync())
         {
             Assert.IsTrue(files.Remove(file));
         }

--- a/test/Microsoft.Sbom.Api.Tests/Executors/HashValidatorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/HashValidatorTests.cs
@@ -30,7 +30,7 @@ public class HashValidatorTests
             "TEST2",
             "TEST3"
         };
-        ConcurrentDictionary<string, Checksum[]> hashDict = new ConcurrentDictionary<string, Checksum[]>(StringComparer.InvariantCultureIgnoreCase);
+        var hashDict = new ConcurrentDictionary<string, Checksum[]>(StringComparer.InvariantCultureIgnoreCase);
         foreach (var file in fileList)
         {
             hashDict[file.ToLower()] = new Checksum[] { new Checksum { Algorithm = AlgorithmName.SHA256, ChecksumValue = $"{file}_hash" } };
@@ -50,7 +50,7 @@ public class HashValidatorTests
         var validator = new HashValidator(configuration.Object, new ManifestData { HashesMap = hashDict });
         var validationResults = validator.Validate(files);
 
-        await foreach (FileValidationResult output in validationResults.output.ReadAllAsync())
+        await foreach (var output in validationResults.output.ReadAllAsync())
         {
             Assert.IsTrue(fileList.Remove(output.Path));
         }
@@ -69,7 +69,7 @@ public class HashValidatorTests
             "TEST3"
         };
 
-        ConcurrentDictionary<string, Checksum[]> hashDict = new ConcurrentDictionary<string, Checksum[]>(StringComparer.InvariantCultureIgnoreCase);
+        var hashDict = new ConcurrentDictionary<string, Checksum[]>(StringComparer.InvariantCultureIgnoreCase);
         foreach (var file in fileList)
         {
             hashDict[file.ToLower()] = new Checksum[] { new Checksum { Algorithm = AlgorithmName.SHA256, ChecksumValue = $"{file}_hashInvalid" } };
@@ -89,12 +89,12 @@ public class HashValidatorTests
         var validator = new HashValidator(configuration.Object, new ManifestData { HashesMap = hashDict });
         var validationResults = validator.Validate(files);
 
-        await foreach (FileValidationResult output in validationResults.output.ReadAllAsync())
+        await foreach (var output in validationResults.output.ReadAllAsync())
         {
             Assert.IsTrue(fileList.Remove(output.Path));
         }
 
-        await foreach (FileValidationResult error in validationResults.errors.ReadAllAsync())
+        await foreach (var error in validationResults.errors.ReadAllAsync())
         {
             Assert.AreEqual(ErrorType.InvalidHash, error.ErrorType);
             Assert.IsTrue(fileList.Remove(error.Path));
@@ -113,7 +113,7 @@ public class HashValidatorTests
             "TEST3"
         };
 
-        ConcurrentDictionary<string, Checksum[]> hashDict = new ConcurrentDictionary<string, Checksum[]>(StringComparer.InvariantCultureIgnoreCase);
+        var hashDict = new ConcurrentDictionary<string, Checksum[]>(StringComparer.InvariantCultureIgnoreCase);
         foreach (var file in fileList)
         {
             hashDict[file.ToLower()] = new Checksum[] { new Checksum { Algorithm = AlgorithmName.SHA256, ChecksumValue = $"{file}_hash" } };
@@ -139,13 +139,13 @@ public class HashValidatorTests
         var validator = new HashValidator(configuration.Object, new ManifestData { HashesMap = hashDict });
         var validationResults = validator.Validate(files);
 
-        await foreach (FileValidationResult error in validationResults.errors.ReadAllAsync())
+        await foreach (var error in validationResults.errors.ReadAllAsync())
         {
             Assert.AreEqual(ErrorType.AdditionalFile, error.ErrorType);
             Assert.AreEqual("TEST4", error.Path);
         }
 
-        await foreach (FileValidationResult output in validationResults.output.ReadAllAsync())
+        await foreach (var output in validationResults.output.ReadAllAsync())
         {
             Assert.IsTrue(fileList.Remove(output.Path));
         }

--- a/test/Microsoft.Sbom.Api.Tests/Executors/LicenseInformationFetcherTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/LicenseInformationFetcherTests.cs
@@ -22,9 +22,9 @@ public class LicenseInformationFetcherTests
     [TestMethod]
     public void ConvertComponentsToListForApi_Npm()
     {
-        LicenseInformationFetcher licenseInformationFetcher = new LicenseInformationFetcher(mockLogger.Object, mockRecorder.Object, mockLicenseInformationService.Object);
+        var licenseInformationFetcher = new LicenseInformationFetcher(mockLogger.Object, mockRecorder.Object, mockLicenseInformationService.Object);
 
-        List<ScannedComponent> scannedComponents = new List<ScannedComponent>
+        var scannedComponents = new List<ScannedComponent>
         {
             new ScannedComponent
             {
@@ -37,7 +37,7 @@ public class LicenseInformationFetcherTests
             },
         };
 
-        List<string> listOfComponentsForApi = licenseInformationFetcher.ConvertComponentsToListForApi(scannedComponents);
+        var listOfComponentsForApi = licenseInformationFetcher.ConvertComponentsToListForApi(scannedComponents);
 
         Assert.AreEqual("npm/npmjs/-/npmpackage/1.0.0", listOfComponentsForApi[0]);
         Assert.AreEqual("npm/npmjs/@npmpackagenamespace/testpackage/1.0.0", listOfComponentsForApi[1]);
@@ -46,9 +46,9 @@ public class LicenseInformationFetcherTests
     [TestMethod]
     public void ConvertComponentToListForApi_NuGet()
     {
-        LicenseInformationFetcher licenseInformationFetcher = new LicenseInformationFetcher(mockLogger.Object, mockRecorder.Object, mockLicenseInformationService.Object);
+        var licenseInformationFetcher = new LicenseInformationFetcher(mockLogger.Object, mockRecorder.Object, mockLicenseInformationService.Object);
 
-        List<ScannedComponent> scannedComponents = new List<ScannedComponent>
+        var scannedComponents = new List<ScannedComponent>
         {
             new ScannedComponent
             {
@@ -61,7 +61,7 @@ public class LicenseInformationFetcherTests
             },
         };
 
-        List<string> listOfComponentsForApi = licenseInformationFetcher.ConvertComponentsToListForApi(scannedComponents);
+        var listOfComponentsForApi = licenseInformationFetcher.ConvertComponentsToListForApi(scannedComponents);
 
         Assert.AreEqual("nuget/nuget/-/nugetpackage/1.0.0", listOfComponentsForApi[0]);
         Assert.AreEqual("nuget/nuget/@nugetpackage/testpackage/1.0.0", listOfComponentsForApi[1]);
@@ -70,9 +70,9 @@ public class LicenseInformationFetcherTests
     [TestMethod]
     public void ConvertComponentToListForApi_Pypi()
     {
-        LicenseInformationFetcher licenseInformationFetcher = new LicenseInformationFetcher(mockLogger.Object, mockRecorder.Object, mockLicenseInformationService.Object);
+        var licenseInformationFetcher = new LicenseInformationFetcher(mockLogger.Object, mockRecorder.Object, mockLicenseInformationService.Object);
 
-        List<ScannedComponent> scannedComponents = new List<ScannedComponent>
+        var scannedComponents = new List<ScannedComponent>
         {
             new ScannedComponent
             {
@@ -80,7 +80,7 @@ public class LicenseInformationFetcherTests
             }
         };
 
-        List<string> listOfComponentsForApi = licenseInformationFetcher.ConvertComponentsToListForApi(scannedComponents);
+        var listOfComponentsForApi = licenseInformationFetcher.ConvertComponentsToListForApi(scannedComponents);
 
         Assert.AreEqual("pypi/pypi/-/pippackage/1.0.0", listOfComponentsForApi[0]);
     }
@@ -88,9 +88,9 @@ public class LicenseInformationFetcherTests
     [TestMethod]
     public void ConvertComponentToListForApi_Gem()
     {
-        LicenseInformationFetcher licenseInformationFetcher = new LicenseInformationFetcher(mockLogger.Object, mockRecorder.Object, mockLicenseInformationService.Object);
+        var licenseInformationFetcher = new LicenseInformationFetcher(mockLogger.Object, mockRecorder.Object, mockLicenseInformationService.Object);
 
-        List<ScannedComponent> scannedComponents = new List<ScannedComponent>
+        var scannedComponents = new List<ScannedComponent>
         {
             new ScannedComponent
             {
@@ -98,7 +98,7 @@ public class LicenseInformationFetcherTests
             }
         };
 
-        List<string> listOfComponentsForApi = licenseInformationFetcher.ConvertComponentsToListForApi(scannedComponents);
+        var listOfComponentsForApi = licenseInformationFetcher.ConvertComponentsToListForApi(scannedComponents);
 
         Assert.AreEqual("gem/rubygems/-/gempackage/1.0.0", listOfComponentsForApi[0]);
     }
@@ -106,9 +106,9 @@ public class LicenseInformationFetcherTests
     [TestMethod]
     public void ConvertComponentToListForApi_Pod()
     {
-        LicenseInformationFetcher licenseInformationFetcher = new LicenseInformationFetcher(mockLogger.Object, mockRecorder.Object, mockLicenseInformationService.Object);
+        var licenseInformationFetcher = new LicenseInformationFetcher(mockLogger.Object, mockRecorder.Object, mockLicenseInformationService.Object);
 
-        List<ScannedComponent> scannedComponents = new List<ScannedComponent>
+        var scannedComponents = new List<ScannedComponent>
         {
             new ScannedComponent
             {
@@ -116,7 +116,7 @@ public class LicenseInformationFetcherTests
             }
         };
 
-        List<string> listOfComponentsForApi = licenseInformationFetcher.ConvertComponentsToListForApi(scannedComponents);
+        var listOfComponentsForApi = licenseInformationFetcher.ConvertComponentsToListForApi(scannedComponents);
 
         Assert.AreEqual("pod/cocoapods/-/podpackage/1.0.0", listOfComponentsForApi[0]);
     }
@@ -124,9 +124,9 @@ public class LicenseInformationFetcherTests
     [TestMethod]
     public void ConvertComponentToListForApi_Crate()
     {
-        LicenseInformationFetcher licenseInformationFetcher = new LicenseInformationFetcher(mockLogger.Object, mockRecorder.Object, mockLicenseInformationService.Object);
+        var licenseInformationFetcher = new LicenseInformationFetcher(mockLogger.Object, mockRecorder.Object, mockLicenseInformationService.Object);
 
-        List<ScannedComponent> scannedComponents = new List<ScannedComponent>
+        var scannedComponents = new List<ScannedComponent>
         {
             new ScannedComponent
             {
@@ -134,7 +134,7 @@ public class LicenseInformationFetcherTests
             }
         };
 
-        List<string> listOfComponentsForApi = licenseInformationFetcher.ConvertComponentsToListForApi(scannedComponents);
+        var listOfComponentsForApi = licenseInformationFetcher.ConvertComponentsToListForApi(scannedComponents);
 
         Assert.AreEqual("crate/cratesio/-/cratepackage/1.0.0", listOfComponentsForApi[0]);
     }
@@ -142,11 +142,11 @@ public class LicenseInformationFetcherTests
     [TestMethod]
     public void ConvertClearlyDefinedApiResponseToList_GoodResponse()
     {
-        string expectedKey = "json5@2.2.3";
-        string expectedValue = "MIT";
-        LicenseInformationFetcher licenseInformationFetcher = new LicenseInformationFetcher(mockLogger.Object, mockRecorder.Object, mockLicenseInformationService.Object);
+        var expectedKey = "json5@2.2.3";
+        var expectedValue = "MIT";
+        var licenseInformationFetcher = new LicenseInformationFetcher(mockLogger.Object, mockRecorder.Object, mockLicenseInformationService.Object);
 
-        Dictionary<string, string> licensesDictionary = licenseInformationFetcher.ConvertClearlyDefinedApiResponseToList(HttpRequestUtils.GoodClearlyDefinedAPIResponse);
+        var licensesDictionary = licenseInformationFetcher.ConvertClearlyDefinedApiResponseToList(HttpRequestUtils.GoodClearlyDefinedAPIResponse);
 
         CollectionAssert.Contains(licensesDictionary, new KeyValuePair<string, string>(expectedKey, expectedValue));
     }
@@ -154,9 +154,9 @@ public class LicenseInformationFetcherTests
     [TestMethod]
     public void ConvertClearlyDefinedApiResponseToList_BadResponse()
     {
-        LicenseInformationFetcher licenseInformationFetcher = new LicenseInformationFetcher(mockLogger.Object, mockRecorder.Object, mockLicenseInformationService.Object);
+        var licenseInformationFetcher = new LicenseInformationFetcher(mockLogger.Object, mockRecorder.Object, mockLicenseInformationService.Object);
 
-        Dictionary<string, string> licensesDictionary = licenseInformationFetcher.ConvertClearlyDefinedApiResponseToList(HttpRequestUtils.BadClearlyDefinedAPIResponse);
+        var licensesDictionary = licenseInformationFetcher.ConvertClearlyDefinedApiResponseToList(HttpRequestUtils.BadClearlyDefinedAPIResponse);
 
         Assert.AreEqual(0, licensesDictionary.Count);
     }

--- a/test/Microsoft.Sbom.Api.Tests/Executors/PackagesWalkerTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/PackagesWalkerTests.cs
@@ -46,7 +46,7 @@ public class PackagesWalkerTests
     public async Task ScanSuccessTestAsync()
     {
         var scannedComponents = new List<ScannedComponentWithLicense>();
-        for (int i = 1; i < 4; i++)
+        for (var i = 1; i < 4; i++)
         {
             var scannedComponent = new ScannedComponentWithLicense
             {
@@ -75,7 +75,7 @@ public class PackagesWalkerTests
         var walker = new PackagesWalker(mockLogger.Object, mockDetector.Object, mockConfiguration.Object, mockSbomConfigs.Object, mockFileSystemUtils.Object, mockLicenseInformationFetcher.Object);
         var packagesChannelReader = walker.GetComponents("root");
 
-        int countDistinctComponents = 0;
+        var countDistinctComponents = 0;
 
         await foreach (ScannedComponentWithLicense package in packagesChannelReader.output.ReadAllAsync())
         {
@@ -83,7 +83,7 @@ public class PackagesWalkerTests
             Assert.IsTrue(scannedComponents.Remove(package));
         }
 
-        await foreach (ComponentDetectorException error in packagesChannelReader.error.ReadAllAsync())
+        await foreach (var error in packagesChannelReader.error.ReadAllAsync())
         {
             Assert.Fail($"Caught exception: {error.Message}");
         }
@@ -97,7 +97,7 @@ public class PackagesWalkerTests
     public async Task ScanCombinePackagesWithSameNameDifferentCase()
     {
         var scannedComponents = new List<ScannedComponentWithLicense>();
-        for (int i = 1; i < 4; i++)
+        for (var i = 1; i < 4; i++)
         {
             var scannedComponent = new ScannedComponentWithLicense
             {
@@ -128,7 +128,7 @@ public class PackagesWalkerTests
         var walker = new PackagesWalker(mockLogger.Object, mockDetector.Object, mockConfiguration.Object, mockSbomConfigs.Object, mockFileSystemUtils.Object, mockLicenseInformationFetcher.Object);
         var packagesChannelReader = walker.GetComponents("root");
 
-        int countDistinctComponents = 0;
+        var countDistinctComponents = 0;
 
         await foreach (ScannedComponentWithLicense package in packagesChannelReader.output.ReadAllAsync())
         {
@@ -136,7 +136,7 @@ public class PackagesWalkerTests
             Assert.IsTrue(scannedComponents.Remove(package));
         }
 
-        await foreach (ComponentDetectorException error in packagesChannelReader.error.ReadAllAsync())
+        await foreach (var error in packagesChannelReader.error.ReadAllAsync())
         {
             Assert.Fail($"Caught exception: {error.Message}");
         }
@@ -174,12 +174,12 @@ public class PackagesWalkerTests
         var packagesChannelReader = walker.GetComponents("root");
         ComponentDetectorException actualError = null;
 
-        await foreach (ScannedComponent package in packagesChannelReader.output.ReadAllAsync())
+        await foreach (var package in packagesChannelReader.output.ReadAllAsync())
         {
             Assert.Fail("Packages were still returned when the detector failed.");
         }
 
-        await foreach (ComponentDetectorException error in packagesChannelReader.error.ReadAllAsync())
+        await foreach (var error in packagesChannelReader.error.ReadAllAsync())
         {
             actualError = error;
         }
@@ -192,7 +192,7 @@ public class PackagesWalkerTests
     public async Task ScanIgnoreSbomComponents()
     {
         var scannedComponents = new List<ScannedComponentWithLicense>();
-        for (int i = 1; i < 4; i++)
+        for (var i = 1; i < 4; i++)
         {
             var scannedComponent = new ScannedComponentWithLicense
             {
@@ -223,7 +223,7 @@ public class PackagesWalkerTests
 
         var discoveredComponents = await packagesChannelReader.output.ReadAllAsync().ToListAsync();
 
-        await foreach (ComponentDetectorException error in packagesChannelReader.error.ReadAllAsync())
+        await foreach (var error in packagesChannelReader.error.ReadAllAsync())
         {
             Assert.Fail($"Caught exception: {error.Message}");
         }

--- a/test/Microsoft.Sbom.Api.Tests/Executors/RelationshipGeneratorTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/RelationshipGeneratorTest.cs
@@ -24,7 +24,7 @@ public class RelationshipGeneratorTest
     [TestMethod]
     public async Task RunShouldHandleExceptionWithoutOrphaningChannel()
     {
-        Mock<IManifestGenerator> mock = new Mock<IManifestGenerator>();
+        var mock = new Mock<IManifestGenerator>();
         mock.Setup(m => m.RegisterManifest()).Returns(new Mock<ManifestInfo>().Object);
 
         var m = new ManifestGeneratorProvider(new IManifestGenerator[] { mock.Object });
@@ -43,7 +43,7 @@ public class RelationshipGeneratorTest
 
         mock.Setup(m => m.GenerateJsonDocument(It.IsAny<Relationship>())).Throws(new InvalidOperationException());
 
-        ChannelReader<JsonDocument> channel = rg.Run(rs.GetEnumerator(), mi);
+        var channel = rg.Run(rs.GetEnumerator(), mi);
 
         // This timeout will cause an OperationCanceledException to be thrown if the channel is orphaned
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
@@ -57,7 +57,7 @@ public class RelationshipGeneratorTest
     [TestMethod]
     public async Task RunShouldReturnTwoResults()
     {
-        Mock<IManifestGenerator> mock = new Mock<IManifestGenerator>();
+        var mock = new Mock<IManifestGenerator>();
         mock.Setup(m => m.RegisterManifest()).Returns(new Mock<ManifestInfo>().Object);
 
         var m = new ManifestGeneratorProvider(new IManifestGenerator[] { mock.Object });
@@ -84,10 +84,10 @@ public class RelationshipGeneratorTest
         mock.Setup(m => m.GenerateJsonDocument(It.Is<Relationship>(r => r.RelationshipType == RelationshipType.DEPENDS_ON))).Returns(g1);
         mock.Setup(m => m.GenerateJsonDocument(It.Is<Relationship>(r => r.RelationshipType == RelationshipType.CONTAINS))).Returns(g2);
 
-        ChannelReader<JsonDocument> channel = rg.Run(rs.GetEnumerator(), mi);
+        var channel = rg.Run(rs.GetEnumerator(), mi);
 
         var docs = new List<JsonDocument>();
-        await foreach (JsonDocument jsonDoc in channel.ReadAllAsync())
+        await foreach (var jsonDoc in channel.ReadAllAsync())
         {
             docs.Add(jsonDoc);
         }
@@ -100,7 +100,7 @@ public class RelationshipGeneratorTest
     [TestMethod]
     public async Task RunShouldNotFailWithNull()
     {
-        Mock<IManifestGenerator> mock = new Mock<IManifestGenerator>();
+        var mock = new Mock<IManifestGenerator>();
         mock.Setup(m => m.RegisterManifest()).Returns(new Mock<ManifestInfo>().Object);
 
         var m = new ManifestGeneratorProvider(new IManifestGenerator[] { mock.Object });
@@ -116,10 +116,10 @@ public class RelationshipGeneratorTest
         mock.Setup(m => m.RegisterManifest()).Returns(mi);
         m.Init();
 
-        ChannelReader<JsonDocument> channel = rg.Run(rs.GetEnumerator(), mi);
+        var channel = rg.Run(rs.GetEnumerator(), mi);
 
         var docs = new List<JsonDocument>();
-        await foreach (JsonDocument jsonDoc in channel.ReadAllAsync())
+        await foreach (var jsonDoc in channel.ReadAllAsync())
         {
             docs.Add(jsonDoc);
         }

--- a/test/Microsoft.Sbom.Api.Tests/Executors/SBOMComponentsWalkerTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/SBOMComponentsWalkerTests.cs
@@ -46,7 +46,7 @@ public class SBOMComponentsWalkerTests
     public async Task GetComponents()
     {
         var scannedComponents = new List<ScannedComponentWithLicense>();
-        for (int i = 1; i < 4; i++)
+        for (var i = 1; i < 4; i++)
         {
             var scannedComponent = new ScannedComponentWithLicense
             {
@@ -71,7 +71,7 @@ public class SBOMComponentsWalkerTests
 
         var discoveredComponents = await packagesChannelReader.output.ReadAllAsync().ToListAsync();
 
-        await foreach (ComponentDetectorException error in packagesChannelReader.error.ReadAllAsync())
+        await foreach (var error in packagesChannelReader.error.ReadAllAsync())
         {
             Assert.Fail($"Caught exception: {error.Message}");
         }
@@ -84,7 +84,7 @@ public class SBOMComponentsWalkerTests
     public async Task GetComponentsWithFiltering()
     {
         var scannedComponents = new List<ScannedComponentWithLicense>();
-        for (int i = 1; i < 4; i++)
+        for (var i = 1; i < 4; i++)
         {
             var scannedComponent = new ScannedComponentWithLicense
             {
@@ -116,7 +116,7 @@ public class SBOMComponentsWalkerTests
 
         var discoveredComponents = await packagesChannelReader.output.ReadAllAsync().ToListAsync();
 
-        await foreach (ComponentDetectorException error in packagesChannelReader.error.ReadAllAsync())
+        await foreach (var error in packagesChannelReader.error.ReadAllAsync())
         {
             Assert.Fail($"Caught exception: {error.Message}");
         }

--- a/test/Microsoft.Sbom.Api.Tests/Executors/SPDXSBOMReaderForExternalDocumentReferenceTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/SPDXSBOMReaderForExternalDocumentReferenceTests.cs
@@ -64,10 +64,10 @@ public class SPDXSBOMReaderForExternalDocumentReferenceTests
                         })
                     .ToArray());
 
-        string json = "{\"name\": \"docname\",\"documentNamespace\": \"namespace\", \"spdxVersion\": \"SPDX-2.2\", \"documentDescribes\":[\"SPDXRef - RootPackage\"]}";
+        var json = "{\"name\": \"docname\",\"documentNamespace\": \"namespace\", \"spdxVersion\": \"SPDX-2.2\", \"documentDescribes\":[\"SPDXRef - RootPackage\"]}";
         fileSystemMock.Setup(f => f.OpenRead(It.IsAny<string>())).Returns(TestUtils.GenerateStreamFromString(json));
 
-        List<string> sbomLocations = new List<string>
+        var sbomLocations = new List<string>
         {
             @"d:\directorya\directoryb\file1.spdx.json"
         };
@@ -82,7 +82,7 @@ public class SPDXSBOMReaderForExternalDocumentReferenceTests
 
         var spdxSBOMReaderForExternalDocumentReference = new SPDXSBOMReaderForExternalDocumentReference(mockHashGenerator.Object, mockLogger.Object, sbomConfigs, manifestGeneratorProvider, fileSystemMock.Object);
         var (output, errors) = spdxSBOMReaderForExternalDocumentReference.ParseSBOMFile(sbomLocationChannel);
-        await foreach (ExternalDocumentReferenceInfo externalDocumentReferenceInfo in output.ReadAllAsync())
+        await foreach (var externalDocumentReferenceInfo in output.ReadAllAsync())
         {
             Assert.AreEqual("namespace", externalDocumentReferenceInfo.DocumentNamespace);
         }
@@ -102,10 +102,10 @@ public class SPDXSBOMReaderForExternalDocumentReferenceTests
                             Algorithm = a
                         })
                     .ToArray());
-        string json = "{\"name\": ,\"documentNamespace\": \"namespace\"}";
+        var json = "{\"name\": ,\"documentNamespace\": \"namespace\"}";
         fileSystemMock.Setup(f => f.OpenRead(It.IsAny<string>())).Returns(TestUtils.GenerateStreamFromString(json));
 
-        List<string> sbomLocations = new List<string>
+        var sbomLocations = new List<string>
         {
             @"d:\directorya\directoryb\file1.spdx.json"
         };
@@ -128,7 +128,7 @@ public class SPDXSBOMReaderForExternalDocumentReferenceTests
     [TestMethod]
     public async Task When_ParseSBOMFile_WithNonSPDXFile_ThenDoNotReadFiles()
     {
-        List<string> nonSpdxSbomLocations = new List<string>
+        var nonSpdxSbomLocations = new List<string>
         {
             @"d:\directorya\directoryb\file1.json"
         };
@@ -171,7 +171,7 @@ public class SPDXSBOMReaderForExternalDocumentReferenceTests
 
         fileSystemMock.Setup(f => f.OpenRead(It.IsAny<string>())).Returns(TestUtils.GenerateStreamFromString(inputJson));
 
-        List<string> sbomLocations = new List<string>
+        var sbomLocations = new List<string>
         {
             @"d:\directorya\directoryb\file1.spdx.json"
         };

--- a/test/Microsoft.Sbom.Api.Tests/Hashing/HashCodeGeneratorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Hashing/HashCodeGeneratorTests.cs
@@ -20,7 +20,7 @@ public class HashCodeGeneratorTests
     {
         var hashAlgorithmNames = new
             AlgorithmName[] { AlgorithmName.SHA256, AlgorithmName.SHA512 };
-        Checksum[] expectedHashes = new Checksum[]
+        var expectedHashes = new Checksum[]
         {
             new Checksum { Algorithm = AlgorithmName.SHA256, ChecksumValue = "185F8DB32271FE25F561A6FC938B2E264306EC304EDA518007D1764826381969" },
             new Checksum { Algorithm = AlgorithmName.SHA512, ChecksumValue = "3615F80C9D293ED7402687F94B22D58E529B8CC7916F8FAC7FDDF7FBD5AF4CF777D3D795A7A00A16BF7E7F3FB9561EE9BAAE480DA9FE7A18769E71886B03F315" }
@@ -30,7 +30,7 @@ public class HashCodeGeneratorTests
         mockFileSystemUtils.Setup(f => f.OpenRead(It.IsAny<string>())).Returns(TestUtils.GenerateStreamFromString("Hello"));
 
         var hashCodeGenerator = new HashCodeGenerator(mockFileSystemUtils.Object);
-        Checksum[] fileHashes = hashCodeGenerator.GenerateHashes("/tmp/file", hashAlgorithmNames);
+        var fileHashes = hashCodeGenerator.GenerateHashes("/tmp/file", hashAlgorithmNames);
 
         Assert.AreEqual(2, fileHashes.Length);
         CollectionAssert.AreEqual(expectedHashes, fileHashes);
@@ -42,7 +42,7 @@ public class HashCodeGeneratorTests
     public void GenerateHashTest_FileReadFails_Throws()
     {
         var hashAlgorithmNames = new AlgorithmName[] { AlgorithmName.SHA256, AlgorithmName.SHA512 };
-        Checksum[] expectedHashes = new Checksum[]
+        var expectedHashes = new Checksum[]
         {
             new Checksum { Algorithm = AlgorithmName.SHA256, ChecksumValue = string.Empty },
             new Checksum { Algorithm = AlgorithmName.SHA512, ChecksumValue = string.Empty }

--- a/test/Microsoft.Sbom.Api.Tests/Metadata/LocalMetadataProviderTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Metadata/LocalMetadataProviderTest.cs
@@ -30,7 +30,7 @@ public class LocalMetadataProviderTest
         config.PackageName = new ConfigurationSetting<string>("name");
         config.PackageVersion = new ConfigurationSetting<string>("version");
 
-        LocalMetadataProvider localMetadataProvider = new LocalMetadataProvider(config);
+        var localMetadataProvider = new LocalMetadataProvider(config);
         Assert.AreEqual("http://sbom.microsoft/name/version/some-custom-value-here", localMetadataProvider.GetDocumentNamespaceUri());
     }
 
@@ -49,7 +49,7 @@ public class LocalMetadataProviderTest
         config.PackageSupplier = null;
         config.GenerationTimestamp = null;
 
-        LocalMetadataProvider localMetadataProvider = new LocalMetadataProvider(config);
+        var localMetadataProvider = new LocalMetadataProvider(config);
         Assert.AreEqual(4, localMetadataProvider.MetadataDictionary.Count);
         Assert.IsFalse(localMetadataProvider.MetadataDictionary.ContainsKey(MetadataKey.PackageSupplier));
         Assert.IsFalse(localMetadataProvider.MetadataDictionary.ContainsKey(MetadataKey.GenerationTimestamp));

--- a/test/Microsoft.Sbom.Api.Tests/Metadata/SbomApiMetadataProviderTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Metadata/SbomApiMetadataProviderTest.cs
@@ -40,21 +40,21 @@ public class SbomApiMetadataProviderTest
     {
         metadata.BuildEnvironmentName = "name";
 
-        SBOMApiMetadataProvider sbomApiMetadataProvider = new SBOMApiMetadataProvider(metadata, config);
+        var sbomApiMetadataProvider = new SBOMApiMetadataProvider(metadata, config);
         Assert.AreEqual("name", sbomApiMetadataProvider.BuildEnvironmentName);
     }
 
     [TestMethod]
     public void SbomApiMetadataProvider_BuildEnvironmentName_WithoutMetadata()
     {
-        SBOMApiMetadataProvider sbomApiMetadataProvider = new SBOMApiMetadataProvider(metadata, config);
+        var sbomApiMetadataProvider = new SBOMApiMetadataProvider(metadata, config);
         Assert.AreEqual(null, sbomApiMetadataProvider.BuildEnvironmentName);
     }
 
     [TestMethod]
     public void SbomApiMetadataProvider_GetDocumentNamespaceUri()
     {
-        SBOMApiMetadataProvider sbomApiMetadataProvider = new SBOMApiMetadataProvider(metadata, config);
+        var sbomApiMetadataProvider = new SBOMApiMetadataProvider(metadata, config);
         Assert.AreEqual("http://sbom.microsoft/packageName/packageVersion/some-custom-value-here", sbomApiMetadataProvider.GetDocumentNamespaceUri());
     }
 

--- a/test/Microsoft.Sbom.Api.Tests/TestUtils.cs
+++ b/test/Microsoft.Sbom.Api.Tests/TestUtils.cs
@@ -9,8 +9,8 @@ internal class TestUtils
 {
     public static Stream GenerateStreamFromString(string s)
     {
-        MemoryStream stream = new MemoryStream();
-        StreamWriter writer = new StreamWriter(stream);
+        var stream = new MemoryStream();
+        var writer = new StreamWriter(stream);
         writer.Write(s);
         writer.Flush();
         stream.Position = 0;

--- a/test/Microsoft.Sbom.Api.Tests/Utils/IdentifierUtilsTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Utils/IdentifierUtilsTests.cs
@@ -16,20 +16,20 @@ public class IdentifierUtilsTests
         var shortGuid = IdentifierUtils.GetShortGuid(Guid.NewGuid());
         Assert.IsNotNull(shortGuid);
 
-        Assert.IsTrue(IdentifierUtils.TryGetGuidFromShortGuid(shortGuid, out Guid guid));
+        Assert.IsTrue(IdentifierUtils.TryGetGuidFromShortGuid(shortGuid, out var guid));
         Assert.IsFalse(guid.Equals(Guid.Empty));
     }
 
     [TestMethod]
     public void TryGetGuidFromShortGuidTest_BadString_Fails_DoesntThrow()
     {
-        Assert.IsFalse(IdentifierUtils.TryGetGuidFromShortGuid(string.Empty, out Guid guid1));
+        Assert.IsFalse(IdentifierUtils.TryGetGuidFromShortGuid(string.Empty, out var guid1));
         Assert.IsTrue(guid1.Equals(Guid.Empty));
 
-        Assert.IsFalse(IdentifierUtils.TryGetGuidFromShortGuid(null, out Guid guid2));
+        Assert.IsFalse(IdentifierUtils.TryGetGuidFromShortGuid(null, out var guid2));
         Assert.IsTrue(guid2.Equals(Guid.Empty));
 
-        Assert.IsFalse(IdentifierUtils.TryGetGuidFromShortGuid("asdf", out Guid guid3));
+        Assert.IsFalse(IdentifierUtils.TryGetGuidFromShortGuid("asdf", out var guid3));
         Assert.IsTrue(guid3.Equals(Guid.Empty));
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/DropHashValidationWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/DropHashValidationWorkflowTests.cs
@@ -45,7 +45,7 @@ public class DropHashValidationWorkflowTests : ValidationWorkflowTestsBase
     [TestMethod]
     public async Task DropHashValidationWorkflowTestAsync_ReturnsSuccessAndValidationFailures_Succeeds()
     {
-        Mock<IFileSystemUtils> fileSystemMock = GetDefaultFileSystemMock();
+        var fileSystemMock = GetDefaultFileSystemMock();
         var manifestData = GetDefaultManifestData();
 
         fileSystemMock.Setup(f => f.GetRelativePath(It.IsAny<string>(), It.IsAny<string>()))
@@ -161,7 +161,7 @@ public class DropHashValidationWorkflowTests : ValidationWorkflowTestsBase
     [TestMethod]
     public async Task DropHashValidationWorkflowTestAsync_NoErrors()
     {
-        Mock<IFileSystemUtils> fileSystemMock = GetDefaultFileSystemMock();
+        var fileSystemMock = GetDefaultFileSystemMock();
 
         fileSystemMock.Setup(f => f.GetRelativePath(It.IsAny<string>(), It.IsAny<string>()))
             .Returns((string r, string p) => PathUtils.GetRelativePath(r, p));
@@ -274,7 +274,7 @@ public class DropHashValidationWorkflowTests : ValidationWorkflowTestsBase
     [TestMethod]
     public async Task DropHashValidationWorkflowTestAsync_IgnoreMissingTrue()
     {
-        Mock<IFileSystemUtils> fileSystemMock = GetDefaultFileSystemMock();
+        var fileSystemMock = GetDefaultFileSystemMock();
 
         fileSystemMock.Setup(f => f.GetRelativePath(It.IsAny<string>(), It.IsAny<string>()))
             .Returns((string r, string p) => PathUtils.GetRelativePath(r, p));
@@ -385,7 +385,7 @@ public class DropHashValidationWorkflowTests : ValidationWorkflowTestsBase
     [TestMethod]
     public async Task DropHashValidationWorkflowTestAsync_IgnoreMissingTrueAndInvalidHashShouldFail()
     {
-        Mock<IFileSystemUtils> fileSystemMock = GetDefaultFileSystemMock();
+        var fileSystemMock = GetDefaultFileSystemMock();
         fileSystemMock.Setup(f => f.GetRelativePath(It.IsAny<string>(), It.IsAny<string>()))
             .Returns((string r, string p) => PathUtils.GetRelativePath(r, p));
 
@@ -495,7 +495,7 @@ public class DropHashValidationWorkflowTests : ValidationWorkflowTestsBase
     [TestMethod]
     public async Task DropHashValidationWorkflowTestAsync_IgnoreMissingFalse()
     {
-        Mock<IFileSystemUtils> fileSystemMock = GetDefaultFileSystemMock();
+        var fileSystemMock = GetDefaultFileSystemMock();
         fileSystemMock.Setup(f => f.GetRelativePath(It.IsAny<string>(), It.IsAny<string>()))
             .Returns((string r, string p) => PathUtils.GetRelativePath(r, p));
 

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/ManifestGenerationWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/ManifestGenerationWorkflowTests.cs
@@ -184,7 +184,7 @@ public class ManifestGenerationWorkflowTests
         manifestFilterMock.Init();
 
         var scannedComponents = new List<ScannedComponent>();
-        for (int i = 1; i < 4; i++)
+        for (var i = 1; i < 4; i++)
         {
             var scannedComponent = new ScannedComponent
             {
@@ -332,8 +332,8 @@ public class ManifestGenerationWorkflowTests
         Assert.AreEqual(resultJson["Definition"], "test");
 
         var outputs = resultJson["Outputs"];
-        JArray sortedOutputs = new JArray(outputs.OrderBy(obj => (string)obj["Source"]));
-        JArray expectedSortedOutputs = new JArray(outputs.OrderBy(obj => (string)obj["Source"]));
+        var sortedOutputs = new JArray(outputs.OrderBy(obj => (string)obj["Source"]));
+        var expectedSortedOutputs = new JArray(outputs.OrderBy(obj => (string)obj["Source"]));
 
         var packages = resultJson["Packages"];
         Assert.IsTrue(packages.Count() == 4);

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomExternalDocumentReferenceParserTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomExternalDocumentReferenceParserTests.cs
@@ -18,7 +18,7 @@ public class SbomExternalDocumentReferenceParserTests
     [TestMethod]
     public void ParseSbomExternalDocumentReferenceTest()
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(ExternalDocumentReferenceStrings.GoodJsonWith2ExtDocumentRefsString);
+        var bytes = Encoding.UTF8.GetBytes(ExternalDocumentReferenceStrings.GoodJsonWith2ExtDocumentRefsString);
         using var stream = new MemoryStream(bytes);
         var count = 0;
 
@@ -47,7 +47,7 @@ public class SbomExternalDocumentReferenceParserTests
     [ExpectedException(typeof(ObjectDisposedException))]
     public void StreamClosedTestReturnsNull()
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(ExternalDocumentReferenceStrings.GoodJsonWith2ExtDocumentRefsString);
+        var bytes = Encoding.UTF8.GetBytes(ExternalDocumentReferenceStrings.GoodJsonWith2ExtDocumentRefsString);
         using var stream = new MemoryStream(bytes);
 
         SPDXParser parser = new(stream, Array.Empty<ParserState>(), ignoreValidation: true);
@@ -84,7 +84,7 @@ public class SbomExternalDocumentReferenceParserTests
     [ExpectedException(typeof(ParserException))]
     public void MissingPropertiesTest_Throws(string json)
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(json);
+        var bytes = Encoding.UTF8.GetBytes(json);
         using var stream = new MemoryStream(bytes);
 
         SPDXParser parser = new(stream, Array.Empty<ParserState>(), ignoreValidation: true);
@@ -103,7 +103,7 @@ public class SbomExternalDocumentReferenceParserTests
     [TestMethod]
     public void IgnoresAdditionalPropertiesTest(string json)
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(json);
+        var bytes = Encoding.UTF8.GetBytes(json);
         using var stream = new MemoryStream(bytes);
 
         SPDXParser parser = new(stream, Array.Empty<ParserState>(), ignoreValidation: true);
@@ -123,7 +123,7 @@ public class SbomExternalDocumentReferenceParserTests
     [ExpectedException(typeof(ParserException))]
     public void MalformedJsonTest_Throws(string json)
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(json);
+        var bytes = Encoding.UTF8.GetBytes(json);
         using var stream = new MemoryStream(bytes);
 
         SPDXParser parser = new(stream, Array.Empty<ParserState>(), ignoreValidation: true);
@@ -137,7 +137,7 @@ public class SbomExternalDocumentReferenceParserTests
     [TestMethod]
     public void EmptyArray_ValidJson()
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(ExternalDocumentReferenceStrings.EmptyArray);
+        var bytes = Encoding.UTF8.GetBytes(ExternalDocumentReferenceStrings.EmptyArray);
         using var stream = new MemoryStream(bytes);
 
         SPDXParser parser = new(stream, Array.Empty<ParserState>(), ignoreValidation: true);
@@ -152,7 +152,7 @@ public class SbomExternalDocumentReferenceParserTests
     [ExpectedException(typeof(ArgumentException))]
     public void NullOrEmptyBuffer_Throws()
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(SbomFileJsonStrings.MalformedJson);
+        var bytes = Encoding.UTF8.GetBytes(SbomFileJsonStrings.MalformedJson);
         using var stream = new MemoryStream(bytes);
 
         SPDXParser parser = new(stream, Array.Empty<ParserState>(), 0, ignoreValidation: true);

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomFileParserTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomFileParserTests.cs
@@ -18,7 +18,7 @@ public class SbomFileParserTests
     [TestMethod]
     public void SkipSbomFilesTest()
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(SbomFileJsonStrings.GoodJsonWith2FilesString);
+        var bytes = Encoding.UTF8.GetBytes(SbomFileJsonStrings.GoodJsonWith2FilesString);
         using var stream = new MemoryStream(bytes);
 
         SPDXParser parser = new(stream, new[] { ParserState.FILES }, ignoreValidation: true);
@@ -37,7 +37,7 @@ public class SbomFileParserTests
     [TestMethod]
     public void ParseSbomFilesTest()
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(SbomFileJsonStrings.GoodJsonWith2FilesString);
+        var bytes = Encoding.UTF8.GetBytes(SbomFileJsonStrings.GoodJsonWith2FilesString);
         using var stream = new MemoryStream(bytes);
 
         SPDXParser parser = new(stream, Array.Empty<ParserState>(), ignoreValidation: true);
@@ -74,7 +74,7 @@ public class SbomFileParserTests
     [ExpectedException(typeof(ObjectDisposedException))]
     public void StreamClosedTestReturnsNull()
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(SbomFileJsonStrings.GoodJsonWith2FilesString);
+        var bytes = Encoding.UTF8.GetBytes(SbomFileJsonStrings.GoodJsonWith2FilesString);
         using var stream = new MemoryStream(bytes);
 
         SPDXParser parser = new(stream, Array.Empty<ParserState>(), ignoreValidation: true);
@@ -116,7 +116,7 @@ public class SbomFileParserTests
     [ExpectedException(typeof(ParserException))]
     public void MissingPropertiesTest_Throws(string json)
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(json);
+        var bytes = Encoding.UTF8.GetBytes(json);
         using var stream = new MemoryStream(bytes);
 
         SPDXParser parser = new(stream, Array.Empty<ParserState>(), ignoreValidation: true);
@@ -135,7 +135,7 @@ public class SbomFileParserTests
     [TestMethod]
     public void IgnoresAdditionalPropertiesTest(string json)
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(json);
+        var bytes = Encoding.UTF8.GetBytes(json);
         using var stream = new MemoryStream(bytes);
 
         SPDXParser parser = new(stream, Array.Empty<ParserState>(), ignoreValidation: true);
@@ -157,7 +157,7 @@ public class SbomFileParserTests
     [ExpectedException(typeof(ParserException))]
     public void MalformedJsonTest_Throws(string json)
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(json);
+        var bytes = Encoding.UTF8.GetBytes(json);
         using var stream = new MemoryStream(bytes);
 
         SPDXParser parser = new(stream, Array.Empty<ParserState>(), ignoreValidation: true);
@@ -171,7 +171,7 @@ public class SbomFileParserTests
     [TestMethod]
     public void EmptyArray_ValidJson()
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(SbomFileJsonStrings.JsonEmptyArray);
+        var bytes = Encoding.UTF8.GetBytes(SbomFileJsonStrings.JsonEmptyArray);
         using var stream = new MemoryStream(bytes);
 
         SPDXParser parser = new(stream, Array.Empty<ParserState>(), ignoreValidation: true);
@@ -186,7 +186,7 @@ public class SbomFileParserTests
     [ExpectedException(typeof(ArgumentException))]
     public void NullOrEmptyBuffer_Throws()
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(SbomFileJsonStrings.MalformedJson);
+        var bytes = Encoding.UTF8.GetBytes(SbomFileJsonStrings.MalformedJson);
         using var stream = new MemoryStream(bytes);
 
         SPDXParser parser = new(stream, Array.Empty<ParserState>(), 0, ignoreValidation: true);

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomPackageParserTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomPackageParserTests.cs
@@ -18,7 +18,7 @@ public class SbomPackageParserTests
     [TestMethod]
     public void ParseSbomPackagesTest()
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(SbomPackageStrings.GoodJsonWith3PackagesString);
+        var bytes = Encoding.UTF8.GetBytes(SbomPackageStrings.GoodJsonWith3PackagesString);
         using var stream = new MemoryStream(bytes);
         var count = 0;
 
@@ -47,7 +47,7 @@ public class SbomPackageParserTests
     [ExpectedException(typeof(ObjectDisposedException))]
     public void StreamClosedTestReturnsNull()
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(SbomPackageStrings.GoodJsonWith3PackagesString);
+        var bytes = Encoding.UTF8.GetBytes(SbomPackageStrings.GoodJsonWith3PackagesString);
         using var stream = new MemoryStream(bytes);
 
         SPDXParser parser = new(stream, Array.Empty<ParserState>(), ignoreValidation: true);
@@ -80,7 +80,7 @@ public class SbomPackageParserTests
     [DataRow(SbomPackageStrings.PackageJsonWith1PackageMissingVersionInfo)]
     public void MissingPropertiesTest_DoesNotThrow(string json)
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(json);
+        var bytes = Encoding.UTF8.GetBytes(json);
         using var stream = new MemoryStream(bytes);
 
         SPDXParser parser = new(stream, Array.Empty<ParserState>(), ignoreValidation: true);
@@ -106,7 +106,7 @@ public class SbomPackageParserTests
     [ExpectedException(typeof(ParserException))]
     public void MissingPropertiesTest_Throws(string json)
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(json);
+        var bytes = Encoding.UTF8.GetBytes(json);
         using var stream = new MemoryStream(bytes);
 
         SPDXParser parser = new(stream, Array.Empty<ParserState>(), ignoreValidation: true);
@@ -124,7 +124,7 @@ public class SbomPackageParserTests
     [DataRow(SbomPackageStrings.PackageJsonWith1PackageAdditionalArrayNoKey)]
     public void IgnoresAdditionalPropertiesTest(string json)
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(json);
+        var bytes = Encoding.UTF8.GetBytes(json);
         using var stream = new MemoryStream(bytes);
 
         SPDXParser parser = new(stream, Array.Empty<ParserState>(), ignoreValidation: true);
@@ -146,7 +146,7 @@ public class SbomPackageParserTests
     [ExpectedException(typeof(ParserException))]
     public void MalformedJsonTest_Throws(string json)
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(json);
+        var bytes = Encoding.UTF8.GetBytes(json);
         using var stream = new MemoryStream(bytes);
 
         SPDXParser parser = new(stream, Array.Empty<ParserState>(), ignoreValidation: true);
@@ -160,7 +160,7 @@ public class SbomPackageParserTests
     [TestMethod]
     public void EmptyArray_ValidJson()
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(SbomPackageStrings.MalformedJsonEmptyArray);
+        var bytes = Encoding.UTF8.GetBytes(SbomPackageStrings.MalformedJsonEmptyArray);
         using var stream = new MemoryStream(bytes);
 
         SPDXParser parser = new(stream, Array.Empty<ParserState>(), ignoreValidation: true);
@@ -175,7 +175,7 @@ public class SbomPackageParserTests
     [ExpectedException(typeof(ArgumentException))]
     public void NullOrEmptyBuffer_Throws()
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(SbomFileJsonStrings.MalformedJson);
+        var bytes = Encoding.UTF8.GetBytes(SbomFileJsonStrings.MalformedJson);
         using var stream = new MemoryStream(bytes);
 
         SPDXParser parser = new(stream, Array.Empty<ParserState>(), 0, ignoreValidation: true);

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomParserTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomParserTests.cs
@@ -18,7 +18,7 @@ public class SbomParserTests
     public void ParseWithBOMTest()
     {
         var utf8BOM = Encoding.UTF8.GetString(Encoding.UTF8.Preamble);
-        byte[] bytes = Encoding.UTF8.GetBytes(utf8BOM + SbomParserStrings.JsonWithAll4Properties);
+        var bytes = Encoding.UTF8.GetBytes(utf8BOM + SbomParserStrings.JsonWithAll4Properties);
         using var stream = new MemoryStream(bytes);
 
         var parser = new SPDXParser(stream);
@@ -56,7 +56,7 @@ public class SbomParserTests
     [TestMethod]
     public void ParseMultiplePropertiesTest()
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(SbomParserStrings.JsonWithAll4Properties);
+        var bytes = Encoding.UTF8.GetBytes(SbomParserStrings.JsonWithAll4Properties);
         using var stream = new MemoryStream(bytes);
 
         SPDXParser parser = new(stream);
@@ -98,7 +98,7 @@ public class SbomParserTests
     [ExpectedException(typeof(ParserException))]
     public void MissingPropertyThrows(string json)
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(json);
+        var bytes = Encoding.UTF8.GetBytes(json);
         using var stream = new MemoryStream(bytes);
         IterateAllProperties(stream);
     }
@@ -112,7 +112,7 @@ public class SbomParserTests
     [ExpectedException(typeof(ParserException))]
     public void MalformedJsonThrows(string json)
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(json);
+        var bytes = Encoding.UTF8.GetBytes(json);
         using var stream = new MemoryStream(bytes);
         IterateAllProperties(stream);
     }
@@ -122,7 +122,7 @@ public class SbomParserTests
     [DataRow(SbomParserStrings.MalformedJsonEmptyArrayObject)]
     public void MalformedJsonEmptyValuesDoesntThrow(string json)
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(json);
+        var bytes = Encoding.UTF8.GetBytes(json);
         using var stream = new MemoryStream(bytes);
         IterateAllProperties(stream);
     }
@@ -130,7 +130,7 @@ public class SbomParserTests
     [TestMethod]
     public void MissingReferencesDoesntThrow()
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(SbomParserStrings.JsonWithMissingReferences);
+        var bytes = Encoding.UTF8.GetBytes(SbomParserStrings.JsonWithMissingReferences);
         using var stream = new MemoryStream(bytes);
         IterateAllProperties(stream);
     }

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomRelationshipParserTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomRelationshipParserTests.cs
@@ -18,7 +18,7 @@ public class SbomRelationshipParserTests
     [TestMethod]
     public void ParseSbomRelationshipsTest()
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(RelationshipStrings.GoodJsonWith2RelationshipsString);
+        var bytes = Encoding.UTF8.GetBytes(RelationshipStrings.GoodJsonWith2RelationshipsString);
         using var stream = new MemoryStream(bytes);
         var count = 0;
 
@@ -47,7 +47,7 @@ public class SbomRelationshipParserTests
     [ExpectedException(typeof(ObjectDisposedException))]
     public void StreamClosedTestReturnsNull()
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(RelationshipStrings.GoodJsonWith2RelationshipsString);
+        var bytes = Encoding.UTF8.GetBytes(RelationshipStrings.GoodJsonWith2RelationshipsString);
         using var stream = new MemoryStream(bytes);
 
         SPDXParser parser = new(stream, Array.Empty<ParserState>(), ignoreValidation: true);
@@ -83,7 +83,7 @@ public class SbomRelationshipParserTests
     [ExpectedException(typeof(ParserException))]
     public void MissingPropertiesTest_Throws(string json)
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(json);
+        var bytes = Encoding.UTF8.GetBytes(json);
         using var stream = new MemoryStream(bytes);
 
         SPDXParser parser = new(stream, Array.Empty<ParserState>(), 50);
@@ -102,7 +102,7 @@ public class SbomRelationshipParserTests
     [TestMethod]
     public void IgnoresAdditionalPropertiesTest(string json)
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(json);
+        var bytes = Encoding.UTF8.GetBytes(json);
         using var stream = new MemoryStream(bytes);
 
         SPDXParser parser = new(stream, Array.Empty<ParserState>(), ignoreValidation: true);
@@ -123,7 +123,7 @@ public class SbomRelationshipParserTests
     [ExpectedException(typeof(ParserException))]
     public void MalformedJsonTest_Throws(string json)
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(json);
+        var bytes = Encoding.UTF8.GetBytes(json);
         using var stream = new MemoryStream(bytes);
 
         SPDXParser parser = new(stream, Array.Empty<ParserState>(), ignoreValidation: true);
@@ -137,7 +137,7 @@ public class SbomRelationshipParserTests
     [TestMethod]
     public void EmptyArray_ValidJson()
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(RelationshipStrings.MalformedJsonEmptyArray);
+        var bytes = Encoding.UTF8.GetBytes(RelationshipStrings.MalformedJsonEmptyArray);
         using var stream = new MemoryStream(bytes);
 
         SPDXParser parser = new(stream, Array.Empty<ParserState>(), ignoreValidation: true);
@@ -152,7 +152,7 @@ public class SbomRelationshipParserTests
     [ExpectedException(typeof(ArgumentException))]
     public void NullOrEmptyBuffer_Throws()
     {
-        byte[] bytes = Encoding.UTF8.GetBytes(SbomFileJsonStrings.MalformedJson);
+        var bytes = Encoding.UTF8.GetBytes(SbomFileJsonStrings.MalformedJson);
         using var stream = new MemoryStream(bytes);
 
         SPDXParser parser = new(stream, Array.Empty<ParserState>(), 0, ignoreValidation: true);

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Utils/InternalMetadataProviderIdentityExtensionsTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Utils/InternalMetadataProviderIdentityExtensionsTests.cs
@@ -47,7 +47,7 @@ public class InternalMetadataProviderIdentityExtensionsTests
     public void GetPackageVersion_WherePackageVersionIsValid_ReturnPackageVersion()
     {
         var mdProviderMock = new Mock<IInternalMetadataProvider>();
-        string packageVersion = "version";
+        var packageVersion = "version";
 
         mdProviderMock.Setup(m => m.TryGetMetadata(MetadataKey.PackageVersion, out packageVersion))
             .Returns(true);
@@ -63,7 +63,7 @@ public class InternalMetadataProviderIdentityExtensionsTests
     [DataRow(" ", false)]
     public void GetPackageVersion_WherePackageVersionIsNullOrWhitespace_ReturnBuildId(string packageVersion, bool versionExist)
     {
-        string buildId = "buildId";
+        var buildId = "buildId";
         var mdProviderMock = new Mock<IInternalMetadataProvider>();
 
         mdProviderMock.Setup(m => m.TryGetMetadata(MetadataKey.PackageVersion, out packageVersion))
@@ -105,7 +105,7 @@ public class InternalMetadataProviderIdentityExtensionsTests
     public void GetPackageName_WherePackageNameIsValid_ReturnPackageName()
     {
         var mdProviderMock = new Mock<IInternalMetadataProvider>();
-        string packageName = "name";
+        var packageName = "name";
 
         mdProviderMock.Setup(m => m.TryGetMetadata(MetadataKey.PackageName, out packageName))
             .Returns(true);
@@ -121,7 +121,7 @@ public class InternalMetadataProviderIdentityExtensionsTests
     [DataRow(" ", false)]
     public void GetPackageName_WherePackageNameIsNullOrWhitespace_ReturnBuildDef(string packageName, bool nameExist)
     {
-        string buildDef = "buildDef";
+        var buildDef = "buildDef";
         var mdProviderMock = new Mock<IInternalMetadataProvider>();
 
         mdProviderMock.Setup(m => m.TryGetMetadata(MetadataKey.PackageVersion, out packageName))
@@ -163,13 +163,13 @@ public class InternalMetadataProviderIdentityExtensionsTests
     public void GetSwidPurl_Succeeds()
     {
         var mdProviderMock = new Mock<IInternalMetadataProvider>();
-        Guid tagId = Guid.NewGuid();
+        var tagId = Guid.NewGuid();
 
-        string packageName = "name";
-        string packageVersion = "1.0.0";
+        var packageName = "name";
+        var packageVersion = "1.0.0";
         object packageSupplier = "Microsoft";
-        Uri namespaceUri = new Uri("https://test.com/");
-        string expectedSwidPurlPattern = @"^pkg:swid\/Microsoft\/test.com\/name@1\.0\.0\?tag_id=.*";
+        var namespaceUri = new Uri("https://test.com/");
+        var expectedSwidPurlPattern = @"^pkg:swid\/Microsoft\/test.com\/name@1\.0\.0\?tag_id=.*";
 
         mdProviderMock.Setup(m => m.TryGetMetadata(MetadataKey.PackageSupplier, out packageSupplier))
             .Returns(true);


### PR DESCRIPTION
[IDE0007: Use `var` instead of explicit type][1]

Related to #340

[1]: https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0007-ide0008