### PR TITLE
chore: bump dotnet sdk to 8

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -811,10 +811,6 @@ dotnet_diagnostic.CA1852.severity = suggestion
 # CA1854: Prefer 'TryGetValue' over 'ContainsKey' and 'Item' when accessing dictionary items
 dotnet_diagnostic.CA1854.severity = suggestion
 
-# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1859
-# CA1859: Use culture-aware string operations
-dotnet_diagnostic.CA1859.severity = suggestion
-
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1860
 # CA1860: Avoid using 'Enumerable.Any()' extension method.
 dotnet_diagnostic.CA1860.severity = suggestion
@@ -822,6 +818,18 @@ dotnet_diagnostic.CA1860.severity = suggestion
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1861
 # CA1861: Prefer 'static readonly' fields over constant array arguments if the called method is called repeatedly
 dotnet_diagnostic.CA1861.severity = suggestion
+
+# https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1862
+# CA1862: Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison
+dotnet_diagnostic.CA1862.severity = suggestion
+
+# https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1865
+# CA1865: Use 'string.StartsWith(char)' instead of 'string.StartsWith(string)' when you have a string with a single char
+dotnet_diagnostic.CA1865.severity = suggestion
+
+# https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1869
+# CA1869: Avoid creating a new 'JsonSerializerOptions' instance for every serialization operation. Cache and reuse instances instead.
+dotnet_diagnostic.CA1869.severity = suggestion
 
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2000
 # CA2000: Dispose objects before losing scope
@@ -1034,6 +1042,14 @@ dotnet_diagnostic.IDE0220.severity = suggestion
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0251
 # IDE0251: Member can be made 'readonly'
 dotnet_diagnostic.IDE0251.severity = suggestion
+
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0290
+# IDE0290: Use primary constructor
+dotnet_diagnostic.IDE0290.severity = suggestion
+
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0300
+# IDE0290: Collection initialization can be simplified
+dotnet_diagnostic.IDE0300.severity = suggestion
 
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide1006
 # IDE1006: Naming rule violation: These words must begin with upper case characters: ...

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,6 +11,7 @@
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <NoWarn>$(NoWarn);CA1014;CS8002</NoWarn>
+        <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     </PropertyGroup>
 
     <PropertyGroup Label="Package">

--- a/global.json
+++ b/global.json
@@ -1,7 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.400",
-    "rollForward": "latestMajor",
-    "allowPrerelease": false
+    "version": "8.0.100-rc.1.23463.5",
+    "rollForward": "latestMajor"
   }
 }


### PR DESCRIPTION
This change bumps the SDK required to build `sbom-tool` from `7.0.400` to `8.0.100-rc.1.23463.5` (The latest .NET 8 release at time of writing). This change does **NOT** require .NET 8 to run `sbom-tool`, but only to build it. There is no impact for users.

Release candidates of .NET are considered go-live releases, and are supported for production workloads[^1]:

> ### Go-live
>
> Go-live releases are supported by Microsoft in production. These are typically our release candidate builds, just before the generally available (GA) release.

This change also silences the build warning

> You are working with a preview version of the .NET Core SDK. You can define the SDK version via a global.json file in the current project

by setting the `SuppressNETCoreSdkPreviewMessage` MSBuild property.

Finally, the newly introduced Roslyn analyzers have been silenced:

- [CA1862: Prefer using 'string.Equals(string, StringComparison)' to perform a case-insensitive comparison][1]
- [CA1865: Use 'string.StartsWith(char)' instead of 'string.StartsWith(string)' when you have a string with a single char][2]
- [CA1869: Avoid creating a new 'JsonSerializerOptions' instance for every serialization operation. Cache and reuse instances instead.][3]
- [IDE0290: Use primary constructor][4]
- [IDE0300: Collection initialization can be simplified][5]

These can be addressed by #340 

[1]: https://github.com/dotnet/roslyn-analyzers/blob/main/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.md#ca1862-use-the-stringcomparison-method-overloads-to-perform-case-insensitive-string-comparisons
[2]: https://github.com/dotnet/roslyn-analyzers/blob/main/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.md#ca1865-use-char-overload
[3]: https://github.com/dotnet/roslyn-analyzers/blob/main/src/NetAnalyzers/Microsoft.CodeAnalysis.NetAnalyzers.md#ca1869-cache-and-reuse-jsonserializeroptions-instances
[4]: https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0290
[5]: https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0300

[^1]: https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core#servicing