### PR TITLE
Argument spelling corrections

### DIFF
--- a/docs/sbom-tool-arguments.md
+++ b/docs/sbom-tool-arguments.md
@@ -14,7 +14,7 @@ Help (-?, -h)   Prints this help message
 
 Actions
 
-  Validate -options - Validate a build artifact using the manifest. Optionally also verify the signing certificate of the manfiest.
+  Validate -options - Validate a build artifact using the manifest. Optionally also verify the signing certificate of the manifest.
 
     Option                   Description
     BuildDropPath (-b)       The root folder of the drop directory to validate.

--- a/docs/sbom-tool-arguments.md
+++ b/docs/sbom-tool-arguments.md
@@ -57,7 +57,7 @@ BuildDropPath (-b)                        The root folder of the drop directory 
 BuildComponentPath (-bc)                  The folder containing the build components and packages.
 BuildListFile (-bl)                       The file path to a file containing a list of files one file per line for
                                           which the manifest file will be generated. Only files listed in the file
-                                          will be inlcuded in the generated manifest.
+                                          will be included in the generated manifest.
 ManifestDirPath (-m)                      The path of the directory where the generated manifest files will be
                                           placed. If this parameter is not specified, the files will be placed in
                                           {BuildDropPath}/_manifest directory.

--- a/docs/sbom-tool-arguments.md
+++ b/docs/sbom-tool-arguments.md
@@ -73,7 +73,7 @@ DockerImagesToScan (-di)                  Comma separated list of docker image n
                                           f24c91d6fa298369ab.
 AdditionalComponentDetectorArgs (-cd)     Additional set of arguments for Component Detector.  An appropriate usage
                                           of this would be a space-delimited list of `--key value` pairs,
-                                          respresenting command-line switches.
+                                          representing command-line switches.
 ExternalDocumentReferenceListFile (-er)   The path to a file containing a list of external SBOMs that will be
                                           included as external document reference in the output SBOM. SPDX 2.2 is
                                           the only supported format for now.

--- a/docs/sbom-tool-arguments.md
+++ b/docs/sbom-tool-arguments.md
@@ -23,7 +23,7 @@ Actions
                              directory.
     OutputPath (-o)          The path where the output json should be written.
     CatalogFilePath (-C)     This parameter is deprecated and will not be used, we will automatically detect the
-                             catalog file using our standard directory structure.The path of signed catalog     
+                             catalog file using our standard directory structure. The path of signed catalog     
                              file that is used to verify the signature of the manifest json file.
     ValidateSignature (-s)   If set, will validate the manifest using the signed catalog file.
     IgnoreMissing (-im)      If set, will not fail validation on the files presented in Manifest but missing on 

--- a/src/Microsoft.Sbom.Api/Config/Args/GenerationArgs.cs
+++ b/src/Microsoft.Sbom.Api/Config/Args/GenerationArgs.cs
@@ -31,7 +31,7 @@ public class GenerationArgs : CommonArgs
     /// </summary>
     [ArgShortcut("bl")]
     [ArgDescription("The file path to a file containing a list of files one file per line for which the SBOM" +
-                    " file will be generated. Only files listed in the file will be inlcuded in the generated SBOM.")]
+                    " file will be generated. Only files listed in the file will be included in the generated SBOM.")]
     public string BuildListFile { get; set; }
 
     /// <summary>
@@ -67,7 +67,7 @@ public class GenerationArgs : CommonArgs
     public string DockerImagesToScan { get; set; }
 
     [ArgShortcut("cd")]
-    [ArgDescription("Additional set of arguments for Component Detector.  An appropriate usage of this would be a space-delimited list of `--key value` pairs, respresenting command-line switches.")]
+    [ArgDescription("Additional set of arguments for Component Detector.  An appropriate usage of this would be a space-delimited list of `--key value` pairs, representing command-line switches.")]
     public string AdditionalComponentDetectorArgs { get; set; }
 
     /// <summary>

--- a/src/Microsoft.Sbom.Api/Config/Args/ValidationArgs.cs
+++ b/src/Microsoft.Sbom.Api/Config/Args/ValidationArgs.cs
@@ -41,7 +41,7 @@ public class ValidationArgs : CommonArgs
     /// Gets or sets the path of the signed catalog file used to validate the manifest.json.
     /// </summary>
     [ArgDescription("This parameter is deprecated and will not be used, we will automatically detect the catalog file " +
-                    "using our standard directory structure." +
+                    "using our standard directory structure. " +
                     "The path of signed catalog file that is used to verify the signature of the manifest json file.")]
     [Obsolete]
     public string CatalogFilePath { get; set; }

--- a/src/Microsoft.Sbom.Api/Config/SbomToolCmdRunner.cs
+++ b/src/Microsoft.Sbom.Api/Config/SbomToolCmdRunner.cs
@@ -32,12 +32,12 @@ public class SbomToolCmdRunner
     public bool Help { get; set; }
 
     /// <summary>
-    /// Validate a build artifact using the manifest. Optionally also verify the signing certificate of the manfiest.
+    /// Validate a build artifact using the manifest. Optionally also verify the signing certificate of the manifest.
     /// </summary>
     /// <param name="validationArgs"></param>
     [ArgActionMethod]
     [ArgDescription("Validate a build artifact using the manifest. " +
-                    "Optionally also verify the signing certificate of the manfiest.")]
+                    "Optionally also verify the signing certificate of the manifest.")]
     public ValidationArgs Validate(ValidationArgs validationArgs)
     {
         return validationArgs;


### PR DESCRIPTION
The SBOM arguments markdown file contains several spelling issues. Proposing the following changes:
 
Closes #412 

```diff
Line 17: Validate section - manifest
- ...certificate of the manfiest.
+ ...certificate of the manifest.
 
Line 26: CatalogFilePath section - Add a space after sentence
- ...standard directory structure.The path
+ ...standard directory structure. The path
 
Line 60: BuildListFile - included
- ...will be inlcuded in the generated manifest.
+ ...will be included in the generated manifest.
 
Line 76: AdditionalComponentDetectorArgs - representing
- respresenting command-line switches.
+ representing command-line switches.
```