### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/sbom-tool-cli-reference.md
+++ b/docs/sbom-tool-cli-reference.md
@@ -30,7 +30,7 @@ In this scenario, the user configured the sbom tool to generate an SBOM for all 
 
 By default, the tool will place the generated SBOM inside the `_manifest\spdx_2.2\` subfolder under the path which the -b argument specifies. In this example, the SBOM will be located here: `c:\outputDrop\_manifest\spdx_2.2\manifest.spdx.json`
 
-Successful runs of the tool require full write permissions for the path specified in the -b argument.  User encountering errors when the tool is attempting to write the `_manifest\spdx_2.2\` subfolder should consider these steps:
+Successful runs of the tool require full write permissions for the path specified in the -b argument.  Users encountering errors when the tool is attempting to write the `_manifest\spdx_2.2\` subfolder should consider these steps:
 1. If someone else controls the user's network or hardware settings (such as employer-owned infrastructure), contact the respective network administrator(s) for assistance.
 2. If the user controls their own infrastructure, review and (as needed) update folder security and attribute settings.  Consult the hardware manufacturer or user support communities as needed for further assistance.
 3. Update the path specified in the -b argument to an externally connected hard drive or another alternate folder located off-device. 

--- a/docs/setting-up-ado-pipelines.md
+++ b/docs/setting-up-ado-pipelines.md
@@ -27,7 +27,7 @@ steps:
     publishLocation: 'Container'
 ```
 
-In this pipeline, the user first builds the dotnet project.  The generated binaries are stored in the artifacts staging directory. In the final step, upload these artifacts to the pipline artifacts. Any dependent pipeline or release can now consume these binaries using this pipeline artifact.  Check the build pipeline artifacts in the project in order to see the commplete set of binaries generated for the Demo project.
+In this pipeline, the user first builds the dotnet project.  The generated binaries are stored in the artifacts staging directory. In the final step, upload these artifacts to the pipeline artifacts. Any dependent pipeline or release can now consume these binaries using this pipeline artifact.  Check the build pipeline artifacts in the project in order to see the commplete set of binaries generated for the Demo project.
 
 ![ado-artifact-without-sbom](./images/ado-artifacts-without-sbom.png)
 
@@ -62,7 +62,7 @@ steps:
     publishLocation: 'Container'
 ```
 
-This process added the SBOM generation task after the build ran and produced artifacts in the `$(Build.ArtifactStagingDirectory)` directory.  Since the `$(Build.SourcesDirectory)` folder contains the `Demo.csproj` file that contains the dependencies for our project, the user passes the parameter to the build components path. The package name, version and namespace base URI are static strings for the tool. Set the verbosity to `Verbose` at this point in time so tht the user can see additional output while testing the SBOM generation.
+This process added the SBOM generation task after the build ran and produced artifacts in the `$(Build.ArtifactStagingDirectory)` directory.  Since the `$(Build.SourcesDirectory)` folder contains the `Demo.csproj` file that contains the dependencies for our project, the user passes the parameter to the build components path. The package name, version and namespace base URI are static strings for the tool. Set the verbosity to `Verbose` at this point in time so that the user can see additional output while testing the SBOM generation.
 
 Since the sbom tool will place the generated SBOM file into the build drop folder (`$(Build.ArtifactStagingDirectory)` folder in this case), this original artifact upload task now also uploads the SBOM to the Actions artifacts as seen below.
 

--- a/docs/setting-up-github-actions.md
+++ b/docs/setting-up-github-actions.md
@@ -74,9 +74,9 @@ jobs:
         path: buildOutput
 ```
 
-The SBOM generation task occured after the build ran, thus producing artifacts in the `buildOutput` folder.  Since the source folder contains the `Sample.csproj` file that holds the project's dependencies items, the build components path is an important parameter. The package name, version and namespace base URI are static string in the sbomtool.  The verbosity paramater is set to `Verbose` at this point in order to provide the desired output during the SBOM generation test runs.
+The SBOM generation task occurred after the build ran, thus producing artifacts in the `buildOutput` folder.  Since the source folder contains the `Sample.csproj` file that holds the project's dependencies items, the build components path is an important parameter. The package name, version and namespace base URI are static strings in the sbomtool.  The verbosity parameter is set to `Verbose` at this point in order to provide the desired output during the SBOM generation test runs.
 
-Since the sbom tool will place the final SBOM file in the build drop folder (buildOutput folder in this scenario), the original artifact upload task now also uploads the SBOM to the Actions artifacts as seen below.
+Since the sbom tool will place the final SBOM file in the build drop folder (`buildOutput` folder in this scenario), the original artifact upload task now also uploads the SBOM to the Actions artifacts as seen below.
 
 ![actions-artifact-with-sbom](./images/github-downloaded-folder-with-sbom.png)
 


### PR DESCRIPTION
Saw some typos in the documentation, so this is a very small typo fix.