### PR TITLE
Users/segomez/add package details factory

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
         <AnalysisLevel>latest</AnalysisLevel>
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <NoWarn>$(NoWarn);CA1014;CS8002</NoWarn>
+        <NoWarn>$(NoWarn);CA1014;CS8002;IDE0290;IDE0300;JSON002</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup Label="Package">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,52 +1,53 @@
 <!-- All csproj package references should not include version numbers. The version numbers are set using this props file. -->
 <Project>
-    <ItemDefinitionGroup>
-        <PackageVersion>
-            <!-- Do not share compile-time dependencies transitively.  This requires that all projects reference all packages -->
-            <PrivateAssets>Compile</PrivateAssets>
-        </PackageVersion>
-    </ItemDefinitionGroup>
-    <PropertyGroup>
-        <ComponentDetectionPackageVersion>3.6.4</ComponentDetectionPackageVersion>
-    </PropertyGroup>
-    <ItemGroup>
-        <PackageVersion Include="AutoMapper" Version="10.1.1" />
-        <PackageVersion Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
-        <PackageVersion Include="coverlet.collector" Version="6.0.0" />
-        <PackageVersion Include="FluentAssertions" Version="6.12.0" />
-        <PackageVersion Include="MSTest.TestAdapter" Version="3.1.1" />
-        <PackageVersion Include="MSTest.TestFramework" Version="3.1.1" />
-        <PackageVersion Include="Microsoft.ComponentDetection.Common" Version="$(ComponentDetectionPackageVersion)" />
-        <PackageVersion Include="Microsoft.ComponentDetection.Contracts" Version="$(ComponentDetectionPackageVersion)" />
-        <PackageVersion Include="Microsoft.ComponentDetection.Detectors" Version="$(ComponentDetectionPackageVersion)" />
-        <PackageVersion Include="Microsoft.ComponentDetection.Orchestrator" Version="$(ComponentDetectionPackageVersion)" />
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-        <PackageVersion Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
-        <PackageVersion Include="Microsoft.Extensions.Http" Version="7.0.0" />
-        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-        <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30" />
-        <PackageVersion Include="MinVer" Version="4.3.0" />
-        <PackageVersion Include="Mono.Posix.NETStandard" Version="1.0.0" />
-        <PackageVersion Include="Moq" Version="4.17.2" />
-        <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageVersion Include="NuGet.Frameworks" Version="6.7.0" />
-        <PackageVersion Include="packageurl-dotnet" Version="1.1.0" />
-        <PackageVersion Include="PowerArgs" Version="3.6.0" />
-        <PackageVersion Include="Scrutor" Version="4.2.0" />
-        <PackageVersion Include="Serilog.Extensions.Hosting" Version="7.0.0" />
-        <PackageVersion Include="Serilog.Sinks.Console" Version="4.1.0" />
-        <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.507" />
-        <PackageVersion Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
-        <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
-        <PackageVersion Include="System.Memory" Version="4.5.5" />
-        <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
-        <PackageVersion Include="System.Reactive" Version="5.0.0" />
-        <PackageVersion Include="System.Runtime.Loader" Version="4.3.0" />
-        <PackageVersion Include="System.Text.Json" Version="7.0.3" />
-        <PackageVersion Include="System.Threading.Channels" Version="6.0.0" />
-        <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="4.11.1" />
-        <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    </ItemGroup>
+  <ItemDefinitionGroup>
+    <PackageVersion>
+      <!-- Do not share compile-time dependencies transitively.  This requires that all projects reference all packages -->
+      <PrivateAssets>Compile</PrivateAssets>
+    </PackageVersion>
+  </ItemDefinitionGroup>
+  <PropertyGroup>
+    <ComponentDetectionPackageVersion>3.6.4</ComponentDetectionPackageVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="AutoMapper" Version="10.1.1" />
+    <PackageVersion Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageVersion Include="Microsoft.ComponentDetection.Common" Version="$(ComponentDetectionPackageVersion)" />
+    <PackageVersion Include="Microsoft.ComponentDetection.Contracts" Version="$(ComponentDetectionPackageVersion)" />
+    <PackageVersion Include="Microsoft.ComponentDetection.Detectors" Version="$(ComponentDetectionPackageVersion)" />
+    <PackageVersion Include="Microsoft.ComponentDetection.Orchestrator" Version="$(ComponentDetectionPackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.7.30" />
+    <PackageVersion Include="MinVer" Version="4.3.0" />
+    <PackageVersion Include="Mono.Posix.NETStandard" Version="1.0.0" />
+    <PackageVersion Include="Moq" Version="4.17.2" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="NuGet.Configuration" Version="6.7.0" />
+    <PackageVersion Include="NuGet.Frameworks" Version="6.7.0" />
+    <PackageVersion Include="packageurl-dotnet" Version="1.1.0" />
+    <PackageVersion Include="PowerArgs" Version="3.6.0" />
+    <PackageVersion Include="Scrutor" Version="4.2.0" />
+    <PackageVersion Include="Serilog.Extensions.Hosting" Version="7.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.507" />
+    <PackageVersion Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
+    <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
+    <PackageVersion Include="System.Memory" Version="4.5.5" />
+    <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
+    <PackageVersion Include="System.Reactive" Version="5.0.0" />
+    <PackageVersion Include="System.Runtime.Loader" Version="4.3.0" />
+    <PackageVersion Include="System.Text.Json" Version="7.0.3" />
+    <PackageVersion Include="System.Threading.Channels" Version="6.0.0" />
+    <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="4.11.1" />
+    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+  </ItemGroup>
 </Project>

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/CargoComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/CargoComponentExtensions.cs
@@ -17,15 +17,15 @@ internal static class CargoComponentExtensions
     /// <param name="cargoComponent">The <see cref="CargoComponent" /> to convert.</param>
     /// <param name="license">The license to use for the <see cref="SbomPackage" />.</param>
     /// <returns>The converted <see cref="SbomPackage" />.</returns>
-    public static SbomPackage ToSbomPackage(this CargoComponent cargoComponent, string? license = null) => new()
+    public static SbomPackage ToSbomPackage(this CargoComponent cargoComponent, string? licenseConcluded = null) => new()
     {
         Id = cargoComponent.Id,
         PackageUrl = cargoComponent.PackageUrl?.ToString(),
         PackageName = cargoComponent.Name,
         PackageVersion = cargoComponent.Version,
-        LicenseInfo = string.IsNullOrWhiteSpace(license) ? null : new LicenseInfo
+        LicenseInfo = string.IsNullOrWhiteSpace(licenseConcluded) ? null : new LicenseInfo
         {
-            Concluded = license,
+            Concluded = licenseConcluded,
         },
         FilesAnalyzed = false,
         Type = "cargo",

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/ExtendedScannedComponent.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/ExtendedScannedComponent.cs
@@ -10,13 +10,13 @@ using Microsoft.Sbom.Contracts;
 /// <summary>
 /// A <see cref="ScannedComponent" /> with license information.
 /// </summary>
-public class ScannedComponentWithLicense : ScannedComponent
+public class ExtendedScannedComponent : ScannedComponent
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="ScannedComponentWithLicense" /> class.
+    /// Initializes a new instance of the <see cref="ExtendedScannedComponent" /> class.
     /// </summary>
     /// <param name="other">The <see cref="ScannedComponent" /> to copy properties from.</param>
-    public ScannedComponentWithLicense(ScannedComponent? other = null)
+    public ExtendedScannedComponent(ScannedComponent? other = null)
     {
         if (other == null)
         {
@@ -35,12 +35,22 @@ public class ScannedComponentWithLicense : ScannedComponent
     }
 
     /// <summary>
-    /// Gets or sets the license.
+    /// Gets or sets the license concluded.
     /// </summary>
-    public string? License { get; set; }
+    public string? LicenseConcluded { get; set; }
 
     /// <summary>
-    /// Converts a <see cref="ScannedComponentWithLicense" /> to an <see cref="SbomPackage" />.
+    /// Gets or sets the license declared (This is what is found in the package files).
+    /// </summary>
+    public string? LicenseDeclared { get; set; }
+
+    /// <summary>
+    /// Gets or sets the supplier.
+    /// </summary>
+    public string? Supplier { get; set; }
+
+    /// <summary>
+    /// Converts a <see cref="ExtendedScannedComponent" /> to an <see cref="SbomPackage" />.
     /// </summary>
     /// <param name="report">The <see cref="AdapterReport" /> to use.</param>
     /// <returns>The converted <see cref="SbomPackage" />.</returns>

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/MavenComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/MavenComponentExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Adapters.ComponentDetection;
@@ -16,13 +16,18 @@ internal static class MavenComponentExtensions
     /// </summary>
     /// <param name="mavenComponent">The <see cref="MavenComponent" /> to convert.</param>
     /// <returns>The converted <see cref="SbomPackage" />.</returns>
-    public static SbomPackage? ToSbomPackage(this MavenComponent mavenComponent) => new()
+    public static SbomPackage? ToSbomPackage(this MavenComponent mavenComponent, string? licenseDeclared = null, string? supplier = null) => new()
     {
         Id = mavenComponent.Id,
         PackageName = $"{mavenComponent.GroupId}.{mavenComponent.ArtifactId}",
         PackageUrl = mavenComponent.PackageUrl?.ToString(),
         PackageVersion = mavenComponent.Version,
         FilesAnalyzed = false,
+        Supplier = string.IsNullOrEmpty(supplier) ? null : supplier,
+        LicenseInfo = string.IsNullOrEmpty(licenseDeclared) ? null : new LicenseInfo
+        {
+            Declared = licenseDeclared
+        },
         Type = "maven",
     };
 }

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/NpmComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/NpmComponentExtensions.cs
@@ -19,7 +19,7 @@ internal static class NpmComponentExtensions
     /// <param name="npmComponent">The <see cref="NpmComponent" /> to convert.</param>
     /// <param name="license"> License information for the package that component that is being converted.</param>
     /// <returns>The converted <see cref="SbomPackage" />.</returns>
-    public static SbomPackage ToSbomPackage(this NpmComponent npmComponent, string? license = null) => new()
+    public static SbomPackage ToSbomPackage(this NpmComponent npmComponent, string? licenseConcluded = null) => new()
     {
         Id = npmComponent.Id,
         PackageUrl = npmComponent.PackageUrl?.ToString(),
@@ -33,9 +33,9 @@ internal static class NpmComponentExtensions
             },
         },
         Supplier = npmComponent.Author?.AsSupplier(),
-        LicenseInfo = string.IsNullOrWhiteSpace(license) ? null : new LicenseInfo
+        LicenseInfo = string.IsNullOrWhiteSpace(licenseConcluded) ? null : new LicenseInfo
         {
-            Concluded = license,
+            Concluded = licenseConcluded,
         },
         FilesAnalyzed = false,
         Type = "npm",

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/NuGetComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/NuGetComponentExtensions.cs
@@ -18,16 +18,17 @@ internal static class NuGetComponentExtensions
     /// <param name="nuGetComponent">The <see cref="NuGetComponent" /> to convert.</param>
     /// <param name="license"> License information for the package that component that is being converted.</param>
     /// <returns>The converted <see cref="SbomPackage" />.</returns>
-    public static SbomPackage ToSbomPackage(this NuGetComponent nuGetComponent, string? license = null) => new()
+    public static SbomPackage ToSbomPackage(this NuGetComponent nuGetComponent, string? licenseConcluded = null, string? licenseDeclared = null, string? supplier = null) => new()
     {
         Id = nuGetComponent.Id,
         PackageUrl = nuGetComponent.PackageUrl?.ToString(),
         PackageName = nuGetComponent.Name,
         PackageVersion = nuGetComponent.Version,
-        Supplier = nuGetComponent.Authors?.Any() == true ? $"Organization: {nuGetComponent.Authors.First()}" : null,
-        LicenseInfo = string.IsNullOrWhiteSpace(license) ? null : new LicenseInfo
+        Supplier = nuGetComponent.Authors?.Any() == true ? $"Organization: {nuGetComponent.Authors.First()}" : supplier,
+        LicenseInfo = string.IsNullOrWhiteSpace(licenseConcluded) && string.IsNullOrEmpty(licenseDeclared) ? null : new LicenseInfo
         {
-            Concluded = license,
+            Concluded = licenseConcluded,
+            Declared = licenseDeclared,
         },
         FilesAnalyzed = false,
         Type = "nuget",

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/PipComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/PipComponentExtensions.cs
@@ -17,15 +17,15 @@ internal static class PipComponentExtensions
     /// <param name="pipComponent">The <see cref="PipComponent" /> to convert.</param>
     /// <param name="license">The license to use.</param>
     /// <returns>The converted <see cref="SbomPackage" />.</returns>
-    public static SbomPackage ToSbomPackage(this PipComponent pipComponent, string? license = null) => new()
+    public static SbomPackage ToSbomPackage(this PipComponent pipComponent, string? licenseConcluded = null) => new()
     {
         Id = pipComponent.Id,
         PackageUrl = pipComponent.PackageUrl?.ToString(),
         PackageName = pipComponent.Name,
         PackageVersion = pipComponent.Version,
-        LicenseInfo = string.IsNullOrWhiteSpace(license) ? null : new LicenseInfo
+        LicenseInfo = string.IsNullOrWhiteSpace(licenseConcluded) ? null : new LicenseInfo
         {
-            Concluded = license,
+            Concluded = licenseConcluded,
         },
         FilesAnalyzed = false,
         Type = "python",

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/PodComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/PodComponentExtensions.cs
@@ -17,16 +17,16 @@ internal static class PodComponentExtensions
     /// <param name="podComponent">The <see cref="PodComponent" /> to convert.</param>
     /// <param name="license">The license to use.</param>
     /// <returns>The converted <see cref="SbomPackage" />.</returns>
-    public static SbomPackage? ToSbomPackage(this PodComponent podComponent, string? license = null) => new()
+    public static SbomPackage? ToSbomPackage(this PodComponent podComponent, string? licenseConcluded = null) => new()
     {
         Id = podComponent.Id,
         PackageUrl = podComponent.PackageUrl?.ToString(),
         PackageName = podComponent.Name,
         PackageVersion = podComponent.Version,
         PackageSource = podComponent.SpecRepo,
-        LicenseInfo = string.IsNullOrWhiteSpace(license) ? null : new LicenseInfo
+        LicenseInfo = string.IsNullOrWhiteSpace(licenseConcluded) ? null : new LicenseInfo
         {
-            Concluded = license,
+            Concluded = licenseConcluded,
         },
         FilesAnalyzed = false,
         Type = "pod",

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/RubyGemsComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/RubyGemsComponentExtensions.cs
@@ -17,16 +17,16 @@ internal static class RubyGemsComponentExtensions
     /// <param name="rubyGemsComponent">The <see cref="RubyGemsComponent" /> to convert.</param>
     /// <param name="license">The license to use.</param>
     /// <returns>The converted <see cref="SbomPackage" />.</returns>
-    public static SbomPackage ToSbomPackage(this RubyGemsComponent rubyGemsComponent, string? license = null) => new()
+    public static SbomPackage ToSbomPackage(this RubyGemsComponent rubyGemsComponent, string? licenseConcluded = null) => new()
     {
         Id = rubyGemsComponent.Id,
         PackageUrl = rubyGemsComponent.PackageUrl?.ToString(),
         PackageName = rubyGemsComponent.Name,
         PackageVersion = rubyGemsComponent.Version,
         PackageSource = rubyGemsComponent.Source,
-        LicenseInfo = string.IsNullOrWhiteSpace(license) ? null : new LicenseInfo
+        LicenseInfo = string.IsNullOrWhiteSpace(licenseConcluded) ? null : new LicenseInfo
         {
-            Concluded = license,
+            Concluded = licenseConcluded,
         },
         FilesAnalyzed = false,
         Type = "ruby",

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/ScanResultWithExtendedComponent.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/ScanResultWithExtendedComponent.cs
@@ -12,10 +12,10 @@ using Newtonsoft.Json.Serialization;
 /// A <see cref="ScanResult" /> with license information.
 /// </summary>
 [JsonObject(MemberSerialization.OptOut, NamingStrategyType = typeof(CamelCaseNamingStrategy))]
-public sealed class ScanResultWithLicense : ScanResult
+public sealed class ScanResultWithExtendedComponent : ScanResult
 {
     /// <summary>
     /// Gets or sets the scanned components with license information.
     /// </summary>
-    public new IEnumerable<ScannedComponentWithLicense>? ComponentsFound { get; init; }
+    public new IEnumerable<ExtendedScannedComponent>? ComponentsFound { get; init; }
 }

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/ScannedComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/ScannedComponentExtensions.cs
@@ -10,30 +10,30 @@ using Microsoft.Sbom.Contracts;
 namespace Microsoft.Sbom.Adapters.ComponentDetection;
 
 /// <summary>
-/// Extensions methods for <see cref="ScannedComponentWithLicense"/>.
+/// Extensions methods for <see cref="ExtendedScannedComponent"/>.
 /// </summary>
 public static class ScannedComponentExtensions
 {
     /// <summary>
-    /// Converts a <see cref="ScannedComponentWithLicense"/> to an <see cref="SbomPackage"/>.
+    /// Converts a <see cref="ExtendedScannedComponent"/> to an <see cref="SbomPackage"/>.
     /// </summary>
-    public static SbomPackage? ToSbomPackage(this ScannedComponentWithLicense component, AdapterReport report)
+    public static SbomPackage? ToSbomPackage(this ExtendedScannedComponent component, AdapterReport report)
     {
         return component.Component switch
         {
-            CargoComponent cargoComponent => cargoComponent.ToSbomPackage(component?.License),
+            CargoComponent cargoComponent => cargoComponent.ToSbomPackage(component?.LicenseConcluded),
             CondaComponent condaComponent => condaComponent.ToSbomPackage(),
             DockerImageComponent dockerImageComponent => dockerImageComponent.ToSbomPackage(),
             GitComponent gitComponent => gitComponent.ToSbomPackage(),
             GoComponent goComponent => goComponent.ToSbomPackage(),
             LinuxComponent linuxComponent => linuxComponent.ToSbomPackage(),
-            MavenComponent mavenComponent => mavenComponent.ToSbomPackage(),
-            NpmComponent npmComponent => npmComponent.ToSbomPackage(component?.License),
-            NuGetComponent nuGetComponent => nuGetComponent.ToSbomPackage(component?.License),
+            MavenComponent mavenComponent => mavenComponent.ToSbomPackage(component?.LicenseDeclared, component?.Supplier),
+            NpmComponent npmComponent => npmComponent.ToSbomPackage(component?.LicenseConcluded),
+            NuGetComponent nuGetComponent => nuGetComponent.ToSbomPackage(component?.LicenseConcluded, component?.LicenseDeclared, component?.Supplier),
             OtherComponent otherComponent => otherComponent.ToSbomPackage(),
-            PipComponent pipComponent => pipComponent.ToSbomPackage(component?.License),
-            PodComponent podComponent => podComponent.ToSbomPackage(component?.License),
-            RubyGemsComponent rubyGemsComponent => rubyGemsComponent.ToSbomPackage(component?.License),
+            PipComponent pipComponent => pipComponent.ToSbomPackage(component?.LicenseConcluded),
+            PodComponent podComponent => podComponent.ToSbomPackage(component?.LicenseConcluded),
+            RubyGemsComponent rubyGemsComponent => rubyGemsComponent.ToSbomPackage(component?.LicenseConcluded),
             null => Error(report => report.LogNullComponent(nameof(ToSbomPackage))),
             _ => Error(report => report.LogNoConversionFound(component.Component.GetType(), component.Component))
         };

--- a/src/Microsoft.Sbom.Adapters/ComponentDetectionToSBOMPackageAdapter.cs
+++ b/src/Microsoft.Sbom.Adapters/ComponentDetectionToSBOMPackageAdapter.cs
@@ -34,7 +34,7 @@ public class ComponentDetectionToSBOMPackageAdapter
 
         try
         {
-            var componentDetectionScanResult = JsonConvert.DeserializeObject<ScanResultWithLicense>(File.ReadAllText(bcdeOutputPath));
+            var componentDetectionScanResult = JsonConvert.DeserializeObject<ScanResultWithExtendedComponent>(File.ReadAllText(bcdeOutputPath));
 
             if (componentDetectionScanResult == null)
             {

--- a/src/Microsoft.Sbom.Api/Executors/ComponentDetectionBaseWalker.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ComponentDetectionBaseWalker.cs
@@ -35,8 +35,10 @@ public abstract class ComponentDetectionBaseWalker
     private readonly ISbomConfigProvider sbomConfigs;
     private readonly IFileSystemUtils fileSystemUtils;
     private readonly ILicenseInformationFetcher licenseInformationFetcher;
+    private readonly IPackageDetailsFactory packageDetailsFactory;
 
     public ConcurrentDictionary<string, string> LicenseDictionary = new ConcurrentDictionary<string, string>();
+    public ConcurrentDictionary<(string, string), PackageDetailsObject> PackageDetailsDictionary = new ConcurrentDictionary<(string, string), PackageDetailsObject>();
     private bool licenseInformationRetrieved = false;
 
     private ComponentDetectionCliArgumentBuilder cliArgumentBuilder;
@@ -47,6 +49,7 @@ public abstract class ComponentDetectionBaseWalker
         IConfiguration configuration,
         ISbomConfigProvider sbomConfigs,
         IFileSystemUtils fileSystemUtils,
+        IPackageDetailsFactory packageDetailsFactory,
         ILicenseInformationFetcher licenseInformationFetcher)
     {
         this.log = log ?? throw new ArgumentNullException(nameof(log));
@@ -54,6 +57,7 @@ public abstract class ComponentDetectionBaseWalker
         this.configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         this.sbomConfigs = sbomConfigs ?? throw new ArgumentNullException(nameof(sbomConfigs));
         this.fileSystemUtils = fileSystemUtils ?? throw new ArgumentNullException(nameof(fileSystemUtils));
+        this.packageDetailsFactory = packageDetailsFactory ?? throw new ArgumentNullException(nameof(packageDetailsFactory));
         this.licenseInformationFetcher = licenseInformationFetcher ?? throw new ArgumentNullException(nameof(licenseInformationFetcher));
     }
 
@@ -121,6 +125,8 @@ public abstract class ComponentDetectionBaseWalker
             {
                 var listOfComponentsForApi = licenseInformationFetcher.ConvertComponentsToListForApi(uniqueComponents);
 
+                PackageDetailsDictionary = packageDetailsFactory.GetPackageDetailsDictionary(uniqueComponents);
+
                 // Check that an API call hasn't already been made. During the first execution of this class this list is empty (because we are detecting the files section of the SBOM). During the second execution we have all the components in the project. There are subsequent executions but not important in this scenario.
                 if (!licenseInformationRetrieved && listOfComponentsForApi?.Count > 0)
                 {
@@ -150,21 +156,27 @@ public abstract class ComponentDetectionBaseWalker
                 var componentName = scannedComponent.Component.PackageUrl?.Name;
                 var componentVersion = scannedComponent.Component.PackageUrl?.Version;
 
-                ScannedComponentWithLicense extendedComponent;
+                ExtendedScannedComponent extendedComponent;
 
-                if (scannedComponent is ScannedComponentWithLicense existingExtendedComponent)
+                if (scannedComponent is ExtendedScannedComponent existingExtendedScannedComponent)
                 {
-                    extendedComponent = existingExtendedComponent;
+                    extendedComponent = existingExtendedScannedComponent;
                 }
                 else
                 {
-                    // Use copy constructor to pass over all the properties to the ScanndedComponentWithLicense.
-                    extendedComponent = new ScannedComponentWithLicense(scannedComponent);
+                    // Use copy constructor to pass over all the properties to the ExtendedScannedComponent.
+                    extendedComponent = new ExtendedScannedComponent(scannedComponent);
                 }
 
                 if (LicenseDictionary != null && LicenseDictionary.ContainsKey($"{componentName}@{componentVersion}"))
                 {
-                    extendedComponent.License = LicenseDictionary[$"{componentName}@{componentVersion}"];
+                    extendedComponent.LicenseConcluded = LicenseDictionary[$"{componentName}@{componentVersion}"];
+                }
+
+                if (PackageDetailsDictionary != null && PackageDetailsDictionary.ContainsKey((componentName, componentVersion)))
+                {
+                    extendedComponent.Supplier = PackageDetailsDictionary[(componentName, componentVersion)].Supplier;
+                    extendedComponent.LicenseDeclared = PackageDetailsDictionary[(componentName, componentVersion)].License;
                 }
 
                 await output.Writer.WriteAsync(extendedComponent);

--- a/src/Microsoft.Sbom.Api/Executors/ComponentToPackageInfoConverter.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ComponentToPackageInfoConverter.cs
@@ -40,7 +40,7 @@ public class ComponentToPackageInfoConverter
         Task.Run(async () =>
         {
             var report = new AdapterReport();
-            await foreach (ScannedComponentWithLicense scannedComponent in componentReader.ReadAllAsync())
+            await foreach (ExtendedScannedComponent scannedComponent in componentReader.ReadAllAsync())
             {
                 await ConvertComponentToPackage(scannedComponent, output, errors);
             }
@@ -48,7 +48,7 @@ public class ComponentToPackageInfoConverter
             output.Writer.Complete();
             errors.Writer.Complete();
 
-            async Task ConvertComponentToPackage(ScannedComponentWithLicense scannedComponent, Channel<SbomPackage> output, Channel<FileValidationResult> errors)
+            async Task ConvertComponentToPackage(ExtendedScannedComponent scannedComponent, Channel<SbomPackage> output, Channel<FileValidationResult> errors)
             {
                 try
                 {

--- a/src/Microsoft.Sbom.Api/Executors/LicenseInformationFetcher.cs
+++ b/src/Microsoft.Sbom.Api/Executors/LicenseInformationFetcher.cs
@@ -120,7 +120,7 @@ public class LicenseInformationFetcher : ILicenseInformationFetcher
             }
 
             // Filter out undefined licenses.
-            foreach (var kvp in extractedLicenses.Where(kvp => kvp.Value.ToLower() == "noassertion" || kvp.Value.ToLower() == "unlicense" || kvp.Value.ToLower() == "other").ToList())
+            foreach (var kvp in extractedLicenses.Where(kvp => kvp.Value.Equals("noassertion", StringComparison.InvariantCultureIgnoreCase) || kvp.Value.Equals("unlicense", StringComparison.InvariantCultureIgnoreCase) || kvp.Value.Equals("other", StringComparison.InvariantCultureIgnoreCase)).ToList())
             {
                 extractedLicenses.Remove(kvp.Key);
             }

--- a/src/Microsoft.Sbom.Api/Executors/PackagesWalker.cs
+++ b/src/Microsoft.Sbom.Api/Executors/PackagesWalker.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Sbom.Api.Executors;
 /// </summary>
 public class PackagesWalker : ComponentDetectionBaseWalker
 {
-    public PackagesWalker(ILogger log, ComponentDetectorCachedExecutor componentDetector, IConfiguration configuration, ISbomConfigProvider sbomConfigs, IFileSystemUtils fileSystemUtils, ILicenseInformationFetcher licenseInformationFetcher)
-        : base(log, componentDetector, configuration, sbomConfigs, fileSystemUtils, licenseInformationFetcher)
+    public PackagesWalker(ILogger log, ComponentDetectorCachedExecutor componentDetector, IConfiguration configuration, ISbomConfigProvider sbomConfigs, IFileSystemUtils fileSystemUtils, IPackageDetailsFactory packageDetailsFactory, ILicenseInformationFetcher licenseInformationFetcher)
+        : base(log, componentDetector, configuration, sbomConfigs, fileSystemUtils, packageDetailsFactory, licenseInformationFetcher)
     {
     }
 

--- a/src/Microsoft.Sbom.Api/Executors/SBOMComponentsWalker.cs
+++ b/src/Microsoft.Sbom.Api/Executors/SBOMComponentsWalker.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Sbom.Api.Executors;
 /// </summary>
 public class SBOMComponentsWalker : ComponentDetectionBaseWalker
 {
-    public SBOMComponentsWalker(ILogger log, ComponentDetectorCachedExecutor componentDetector, IConfiguration configuration, ISbomConfigProvider sbomConfigs, IFileSystemUtils fileSystemUtils, ILicenseInformationFetcher licenseInformationFetcher)
-        : base(log, componentDetector, configuration, sbomConfigs, fileSystemUtils, licenseInformationFetcher)
+    public SBOMComponentsWalker(ILogger log, ComponentDetectorCachedExecutor componentDetector, IConfiguration configuration, ISbomConfigProvider sbomConfigs, IFileSystemUtils fileSystemUtils, IPackageDetailsFactory packageDetailsFactory, ILicenseInformationFetcher licenseInformationFetcher)
+        : base(log, componentDetector, configuration, sbomConfigs, fileSystemUtils, packageDetailsFactory, licenseInformationFetcher)
     {
     }
 

--- a/src/Microsoft.Sbom.Api/Microsoft.Sbom.Api.csproj
+++ b/src/Microsoft.Sbom.Api/Microsoft.Sbom.Api.csproj
@@ -17,6 +17,7 @@
         <PackageReference Include="Microsoft.ComponentDetection.Orchestrator" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
         <PackageReference Include="Newtonsoft.Json" />
+        <PackageReference Include="NuGet.Configuration" />
         <PackageReference Include="packageurl-dotnet" />
         <PackageReference Include="PowerArgs" />
         <PackageReference Include="Serilog.Extensions.Hosting" />

--- a/src/Microsoft.Sbom.Api/Providers/PackagesProviders/CGScannedPackagesProvider.cs
+++ b/src/Microsoft.Sbom.Api/Providers/PackagesProviders/CGScannedPackagesProvider.cs
@@ -9,6 +9,7 @@ using Microsoft.ComponentDetection.Contracts.BcdeModels;
 using Microsoft.Sbom.Api.Entities;
 using Microsoft.Sbom.Api.Exceptions;
 using Microsoft.Sbom.Api.Executors;
+using Microsoft.Sbom.Api.Utils;
 using Microsoft.Sbom.Common.Config;
 using Microsoft.Sbom.Extensions;
 using Serilog;
@@ -34,8 +35,9 @@ public class CGScannedPackagesProvider : CommonPackagesProvider<ScannedComponent
         PackageInfoJsonWriter packageInfoJsonWriter,
         ComponentToPackageInfoConverter packageInfoConverter,
         PackagesWalker packagesWalker,
+        IPackageDetailsFactory packageDetailsFactory,
         ILicenseInformationFetcher licenseInformationFetcher)
-        : base(configuration, channelUtils, logger, sbomConfigs, packageInfoJsonWriter, licenseInformationFetcher)
+        : base(configuration, channelUtils, logger, sbomConfigs, packageInfoJsonWriter, packageDetailsFactory, licenseInformationFetcher)
     {
         this.packageInfoConverter = packageInfoConverter ?? throw new ArgumentNullException(nameof(packageInfoConverter));
         this.packagesWalker = packagesWalker ?? throw new ArgumentNullException(nameof(packagesWalker));

--- a/src/Microsoft.Sbom.Api/Providers/PackagesProviders/CommonPackagesProvider.cs
+++ b/src/Microsoft.Sbom.Api/Providers/PackagesProviders/CommonPackagesProvider.cs
@@ -7,6 +7,7 @@ using System.Threading.Channels;
 using System.Threading.Tasks;
 using Microsoft.Sbom.Api.Entities;
 using Microsoft.Sbom.Api.Executors;
+using Microsoft.Sbom.Api.Utils;
 using Microsoft.Sbom.Common.Config;
 using Microsoft.Sbom.Contracts;
 using Microsoft.Sbom.Extensions;
@@ -31,6 +32,7 @@ public abstract class CommonPackagesProvider<T> : EntityToJsonProviderBase<T>
         ILogger logger,
         ISbomConfigProvider sbomConfigs,
         PackageInfoJsonWriter packageInfoJsonWriter,
+        IPackageDetailsFactory packageDetailsFactory,
         ILicenseInformationFetcher licenseInformationFetcher)
         : base(configuration, channelUtils, logger)
     {

--- a/src/Microsoft.Sbom.Api/Providers/PackagesProviders/SBOMPackagesProvider.cs
+++ b/src/Microsoft.Sbom.Api/Providers/PackagesProviders/SBOMPackagesProvider.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Channels;
 using Microsoft.Sbom.Api.Entities;
 using Microsoft.Sbom.Api.Executors;
+using Microsoft.Sbom.Api.Utils;
 using Microsoft.Sbom.Common.Config;
 using Microsoft.Sbom.Contracts;
 using Microsoft.Sbom.Extensions;
@@ -24,8 +25,9 @@ public class SBOMPackagesProvider : CommonPackagesProvider<SbomPackage>
         ILogger logger,
         ISbomConfigProvider sbomConfigs,
         PackageInfoJsonWriter packageInfoJsonWriter,
+        IPackageDetailsFactory packageDetailsFactory,
         ILicenseInformationFetcher licenseInformationFetcher)
-        : base(configuration, channelUtils, logger, sbomConfigs, packageInfoJsonWriter, licenseInformationFetcher)
+        : base(configuration, channelUtils, logger, sbomConfigs, packageInfoJsonWriter, packageDetailsFactory, licenseInformationFetcher)
     {
     }
 

--- a/src/Microsoft.Sbom.Api/SBOMValidator.cs
+++ b/src/Microsoft.Sbom.Api/SBOMValidator.cs
@@ -45,7 +45,7 @@ public class SbomValidator : ISBOMValidator
         return isSuccess;
     }
 
-    public async Task<EntityError> ValidateSbomAsync(
+    public async Task<IList<EntityError>> ValidateSbomAsync(
         string buildDropPath,
         string outputPath,
         IList<SbomSpecification> specifications,

--- a/src/Microsoft.Sbom.Api/SBOMValidator.cs
+++ b/src/Microsoft.Sbom.Api/SBOMValidator.cs
@@ -45,7 +45,7 @@ public class SbomValidator : ISBOMValidator
         return isSuccess;
     }
 
-    public async Task<bool> ValidateSbomAsync(
+    public async Task<EntityError> ValidateSbomAsync(
         string buildDropPath,
         string outputPath,
         IList<SbomSpecification> specifications,
@@ -80,9 +80,7 @@ public class SbomValidator : ISBOMValidator
         var isSuccess = await sbomParserBasedValidationWorkflow.RunAsync();
         await recorder.FinalizeAndLogTelemetryAsync();
 
-        var entityErrors = recorder.Errors.Select(error => error.ToEntityError()).ToList();
-
-        return isSuccess;
+        return recorder.Errors.Select(error => error.ToEntityError()).ToList();
     }
 
     private InputConfiguration ValidateConfig(InputConfiguration config)

--- a/src/Microsoft.Sbom.Api/Utils/IPackageDetailsFactory.cs
+++ b/src/Microsoft.Sbom.Api/Utils/IPackageDetailsFactory.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Sbom.Api.Utils;
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using Microsoft.ComponentDetection.Contracts.BcdeModels;
+
+public interface IPackageDetailsFactory
+{
+    ConcurrentDictionary<(string, string), PackageDetailsObject> GetPackageDetailsDictionary(IEnumerable<ScannedComponent> scannedComponents);
+}

--- a/src/Microsoft.Sbom.Api/Utils/PackageDetailsFactory.cs
+++ b/src/Microsoft.Sbom.Api/Utils/PackageDetailsFactory.cs
@@ -1,0 +1,256 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Xml;
+using Microsoft.ComponentDetection.Contracts.BcdeModels;
+using Microsoft.Sbom.Api.Output.Telemetry;
+using Microsoft.Sbom.Api.Utils;
+using Microsoft.Sbom.Common;
+using NuGet.Configuration;
+using Serilog;
+
+namespace Microsoft.Sbom.Api.Executors;
+
+public class PackageDetailsFactory : IPackageDetailsFactory
+{
+    private readonly IFileSystemUtils fileSystemUtils;
+    private readonly ILogger log;
+    private readonly IRecorder recorder;
+
+    public PackageDetailsFactory(IFileSystemUtils fileSystemUtils, ILogger log, IRecorder recorder)
+    {
+        this.fileSystemUtils = fileSystemUtils ?? throw new ArgumentNullException(nameof(fileSystemUtils));
+        this.log = log ?? throw new ArgumentNullException(nameof(log));
+        this.recorder = recorder ?? throw new ArgumentNullException(nameof(recorder));
+    }
+
+    public ConcurrentDictionary<(string, string), PackageDetailsObject> GetPackageDetailsDictionary(IEnumerable<ScannedComponent> scannedComponents)
+    {
+        var packageDetailsLocations = GetPackageDetailsLocations(scannedComponents);
+
+        return ExtractPackageDetailsFromFiles(packageDetailsLocations);
+    }
+
+    private List<string> GetPackageDetailsLocations(IEnumerable<ScannedComponent> scannedComponents)
+    {
+        var packageDetailsConfirmedLocations = new List<string>();
+
+        foreach (var scannedComponent in scannedComponents)
+        {
+            var componentType = scannedComponent.Component.PackageUrl?.Type.ToLower();
+
+            if (componentType == "nuget")
+            {
+                packageDetailsConfirmedLocations.Add(GetNuspecLocation(scannedComponent));
+            }
+
+            if (componentType == "maven")
+            {
+                packageDetailsConfirmedLocations.Add(GetPomLocation(scannedComponent));
+            }
+        }
+
+        return packageDetailsConfirmedLocations;
+    }
+
+    private ConcurrentDictionary<(string, string), PackageDetailsObject> ExtractPackageDetailsFromFiles(List<string> packageDetailsPaths)
+    {
+        // Create a var called packageDetailsDictionary where the key is a tuple of the package name and version and the value is a PackageDetailsObject
+        var packageDetailsDictionary = new ConcurrentDictionary<(string, string), PackageDetailsObject>();
+
+        foreach (var path in packageDetailsPaths)
+        {
+            // If path ends in .nuspec then it is a nuspec file
+            if (!string.IsNullOrEmpty(path) && path.EndsWith(".nuspec", StringComparison.OrdinalIgnoreCase))
+            {
+                var nuspecDetails = ParseNuspec(path);
+                packageDetailsDictionary.TryAdd((nuspecDetails.Item1, nuspecDetails.Item2), nuspecDetails.Item3);
+            }
+
+            if (!string.IsNullOrEmpty(path) && path.EndsWith(".pom", StringComparison.OrdinalIgnoreCase))
+            {
+                var pomDetails = ParsePom(path);
+                packageDetailsDictionary.TryAdd((pomDetails.Item1, pomDetails.Item2), pomDetails.Item3);
+            }
+        }
+
+        return packageDetailsDictionary;
+    }
+
+    // Takes in a scanned component and attempts to find the associated pom file. If it is not found then it returns null.
+    private string GetPomLocation(ScannedComponent scannedComponent)
+    {
+        var envHome = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "HOMEPATH" : "HOME";
+        var home = Environment.GetEnvironmentVariable(envHome);
+
+        var mavenPackagesPath = $"{home}/.m2/repository";
+        var pomLocation = mavenPackagesPath;
+
+        var componentName = scannedComponent.Component.PackageUrl?.Name.ToLower();
+        var componentNamespace = scannedComponent.Component.PackageUrl?.Namespace?.ToLower();
+        var componentVersion = scannedComponent.Component.PackageUrl?.Version;
+
+        // Take the component namespace and split it by "." in order to get the correct path to the .pom
+        var componentNamespaceParts = componentNamespace.Split('.'); // Example: "org.apache.commons.commons-lang3"
+
+        for (var i = 0; i < componentNamespaceParts.Length; i++)
+        {
+            if (i == 0)
+            {
+                pomLocation += $"/{componentNamespaceParts[i]}";
+            }
+            else
+            {
+                pomLocation += $"/{componentNamespaceParts[i]}";
+            }
+        }
+
+        pomLocation += $"/{componentName}/{componentVersion}/{componentName}-{componentVersion}.pom";
+
+        // Check for file permissions on the .m2 directory before attempting to check if the file exists
+        if (fileSystemUtils.DirectoryHasReadPermissions(mavenPackagesPath))
+        {
+            if (fileSystemUtils.FileExists(pomLocation))
+            {
+                return pomLocation;
+            }
+        }
+
+        return null;
+    }
+
+    // Takes in a scanned component and attempts to find the associated nuspec file. If it is not found then it returns null.
+    private string GetNuspecLocation(ScannedComponent scannedComponent)
+    {
+        var nuspecLocation = string.Empty;
+        var nugetPackagesPath = SettingsUtility.GetGlobalPackagesFolder(new NullSettings());
+
+        var componentName = scannedComponent.Component.PackageUrl?.Name.ToLower();
+        var componentVersion = scannedComponent.Component.PackageUrl?.Version;
+        var componentType = scannedComponent.Component.PackageUrl?.Type.ToLower();
+
+        if (componentType == "nuget")
+        {
+            nuspecLocation = $"{nugetPackagesPath}/{componentName}/{componentVersion}/{componentName}.nuspec";
+        }
+
+        // Check for file permissions on the .nuget directory before attempting to check if every file exists
+        if (fileSystemUtils.DirectoryHasReadPermissions(nugetPackagesPath))
+        {
+            if (fileSystemUtils.FileExists(nuspecLocation))
+            {
+                return nuspecLocation;
+            }
+        }
+
+        return null;
+    }
+
+    // Get the developers section of the pom file
+    private (string, string, PackageDetailsObject) ParsePom(string pomLocation)
+    {
+        var pomInfo = new PackageDetailsObject();
+
+        try
+        {
+            var pomBytes = File.ReadAllBytes(pomLocation);
+            using var pomStream = new MemoryStream(pomBytes, false);
+
+            var doc = new XmlDocument();
+            doc.Load(pomStream);
+
+            XmlNode developersNode = doc["project"]?["developers"];
+            XmlNode licensesNode = doc["project"]?["licenses"];
+
+            var name = doc["project"]?["artifactId"]?.InnerText;
+            var version = doc["project"]?["version"]?.InnerText;
+
+            if (developersNode != null)
+            {
+                foreach (XmlNode developerNode in developersNode.ChildNodes)
+                {
+                    var developerName = developerNode["name"]?.InnerText;
+                    var developerEmail = developerNode["email"]?.InnerText;
+
+                    if (!string.IsNullOrEmpty(developerName))
+                    {
+                        pomInfo.Supplier += $"{developerName}";
+                    }
+
+                    if (!string.IsNullOrEmpty(developerEmail))
+                    {
+                        pomInfo.Supplier += $" ({developerEmail}) ";
+                    }
+                }
+            }
+
+            if (licensesNode != null)
+            {
+                foreach (XmlNode licenseNode in licensesNode.ChildNodes)
+                {
+                    var licenseName = licenseNode["name"]?.InnerText;
+
+                    if (!string.IsNullOrEmpty(licenseName))
+                    {
+                        pomInfo.License = licenseName;
+                    }
+                }
+            }
+
+            return (name, version, pomInfo);
+        }
+        catch (Exception e)
+        {
+            log.Error("Error encountered while extracting supplier info from pom file. Supplier information may be incomplete.", e);
+
+            // TODO: Add Exceptions to identify when the PackageDetailsFactory is failing.
+            recorder.RecordAPIException(e);
+            return (null, null, null);
+        }
+    }
+
+    // Private method that returns an object that is composed of a Tuple of the package name and version and a PackageDetailsObject
+    private (string, string, PackageDetailsObject) ParseNuspec(string nuspecPath)
+    {
+        var nuspecInfo = new PackageDetailsObject();
+
+        try
+        {
+            var nuspecBytes = File.ReadAllBytes(nuspecPath);
+            using var nuspecStream = new MemoryStream(nuspecBytes, false);
+
+            var doc = new XmlDocument();
+            doc.Load(nuspecStream);
+
+            XmlNode packageNode = doc["package"];
+            XmlNode metadataNode = packageNode["metadata"];
+
+            var name = metadataNode["id"]?.InnerText;
+            var version = metadataNode["version"]?.InnerText;
+            var authors = metadataNode["authors"]?.InnerText;
+            var license = metadataNode["license"];
+
+            if (license != null && license.Attributes["type"].Value != "file")
+            {
+                nuspecInfo.License = license.InnerText;
+            }
+
+            nuspecInfo.Supplier = authors;
+
+            return (name, version, nuspecInfo);
+        }
+        catch (Exception e)
+        {
+            log.Error("Error encountered while extracting supplier info from nuspec file. Supplier information may be incomplete.", e);
+
+            // TODO: Add Exceptions to identify when the PackageDetailsFactory is failing.
+            recorder.RecordAPIException(e);
+            return (null, null, null);
+        }
+    }
+}

--- a/src/Microsoft.Sbom.Api/Utils/PackageDetailsObject.cs
+++ b/src/Microsoft.Sbom.Api/Utils/PackageDetailsObject.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Sbom.Api.Utils;
+
+public class PackageDetailsObject
+{
+    // Define an object that has 2 properties - License and Supplier
+    public string License { get; set; }
+
+    public string Supplier { get; set; }
+}

--- a/src/Microsoft.Sbom.Api/Workflows/SBOMParserBasedValidationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SBOMParserBasedValidationWorkflow.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -171,6 +171,13 @@ public class SbomParserBasedValidationWorkflow : IWorkflow<SbomParserBasedValida
                 recorder.RecordException(e);
                 log.Error("Encountered an error while validating the drop.");
                 log.Error($"Error details: {e.Message}");
+
+                if (e is FileNotFoundException || e is DirectoryNotFoundException)
+                {
+                    // Bubble up exception if user provided an invalid path/SBOM wasn't found
+                    throw;
+                }
+
                 return false;
             }
             finally

--- a/src/Microsoft.Sbom.Api/Workflows/SBOMParserBasedValidationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SBOMParserBasedValidationWorkflow.cs
@@ -69,7 +69,6 @@ public class SbomParserBasedValidationWorkflow : IWorkflow<SbomParserBasedValida
             {
                 var sw = Stopwatch.StartNew();
                 var sbomConfig = sbomConfigs.Get(configuration.ManifestInfo.Value.FirstOrDefault());
-
                 using var stream = fileSystemUtils.OpenRead(sbomConfig.ManifestJsonFilePath);
                 var manifestInterface = manifestParserProvider.Get(sbomConfig.ManifestInfo);
                 var sbomParser = manifestInterface.CreateParser(stream);
@@ -171,13 +170,6 @@ public class SbomParserBasedValidationWorkflow : IWorkflow<SbomParserBasedValida
                 recorder.RecordException(e);
                 log.Error("Encountered an error while validating the drop.");
                 log.Error($"Error details: {e.Message}");
-
-                if (e is FileNotFoundException || e is DirectoryNotFoundException)
-                {
-                    // Bubble up exception if user provided an invalid path/SBOM wasn't found
-                    throw;
-                }
-
                 return false;
             }
             finally

--- a/src/Microsoft.Sbom.Contracts/Contracts/SBOMValidationSuccess.cs
+++ b/src/Microsoft.Sbom.Contracts/Contracts/SBOMValidationSuccess.cs
@@ -6,6 +6,6 @@ namespace Microsoft.Sbom.Contracts;
 /// <summary>
 /// Represents a successful SBOM validation result.
 /// </summary>
-public class SbomValidationSuccess : SBOMValidationResult
+public class SBOMValidationSuccess : SBOMValidationResult
 {
 }

--- a/src/Microsoft.Sbom.Contracts/ISBOMValidator.cs
+++ b/src/Microsoft.Sbom.Contracts/ISBOMValidator.cs
@@ -30,7 +30,7 @@ public interface ISBOMValidator
     /// <param name="runtimeConfiguration">The runtime configuration to use for validation.</param>
     /// <param name="algorithmName">The algorithm to use for hashing.</param>
     /// </summary>
-    Task<IList<EntityError>> ValidateSbomAsync(
+    Task<SBOMValidationResult> ValidateSbomAsync(
         string buildDropPath,
         string outputPath,
         IList<SbomSpecification> specifications,

--- a/src/Microsoft.Sbom.Contracts/ISBOMValidator.cs
+++ b/src/Microsoft.Sbom.Contracts/ISBOMValidator.cs
@@ -30,7 +30,7 @@ public interface ISBOMValidator
     /// <param name="runtimeConfiguration">The runtime configuration to use for validation.</param>
     /// <param name="algorithmName">The algorithm to use for hashing.</param>
     /// </summary>
-    Task<EntityError> ValidateSbomAsync(
+    Task<IList<EntityError>> ValidateSbomAsync(
         string buildDropPath,
         string outputPath,
         IList<SbomSpecification> specifications,

--- a/src/Microsoft.Sbom.Contracts/ISBOMValidator.cs
+++ b/src/Microsoft.Sbom.Contracts/ISBOMValidator.cs
@@ -30,7 +30,7 @@ public interface ISBOMValidator
     /// <param name="runtimeConfiguration">The runtime configuration to use for validation.</param>
     /// <param name="algorithmName">The algorithm to use for hashing.</param>
     /// </summary>
-    Task<bool> ValidateSbomAsync(
+    Task<EntityError> ValidateSbomAsync(
         string buildDropPath,
         string outputPath,
         IList<SbomSpecification> specifications,

--- a/src/Microsoft.Sbom.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Sbom.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -152,6 +152,7 @@ public static class ServiceCollectionExtensions
             .AddSingleton<IAssemblyConfig, AssemblyConfig>()
             .AddSingleton<ComponentDetectorCachedExecutor>()
             .AddSingleton<ILicenseInformationFetcher, LicenseInformationFetcher>()
+            .AddSingleton<IPackageDetailsFactory, PackageDetailsFactory>()
             .AddSingleton<InternalSBOMFileInfoDeduplicator>()
             .AddSingleton<ExternalReferenceInfoToPathConverter>()
             .AddSingleton<ExternalReferenceDeduplicator>()

--- a/test/Microsoft.Sbom.Adapters.Tests/ComponentDetectionToSBOMPackageAdapterTests.cs
+++ b/test/Microsoft.Sbom.Adapters.Tests/ComponentDetectionToSBOMPackageAdapterTests.cs
@@ -118,7 +118,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
     public void CargoComponent_ToSbomPackage()
     {
         var cargoComponent = new CargoComponent("name", "version");
-        var scannedComponent = new ScannedComponentWithLicense() { Component = cargoComponent };
+        var scannedComponent = new ExtendedScannedComponent() { Component = cargoComponent };
 
         var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
 
@@ -132,7 +132,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
     public void CondaComponent_ToSbomPackage()
     {
         var condaComponent = new CondaComponent("name", "version", "build", "channel", "subdir", "namespace", "http://microsoft.com", "md5");
-        var scannedComponent = new ScannedComponentWithLicense() { Component = condaComponent };
+        var scannedComponent = new ExtendedScannedComponent() { Component = condaComponent };
 
         var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
 
@@ -148,7 +148,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
     public void DockerImageComponent_ToSbomPackage()
     {
         var dockerImageComponent = new DockerImageComponent("name", "version", "tag") { Digest = "digest" };
-        var scannedComponent = new ScannedComponentWithLicense() { Component = dockerImageComponent };
+        var scannedComponent = new ExtendedScannedComponent() { Component = dockerImageComponent };
 
         var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
 
@@ -163,7 +163,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
     public void NpmComponent_ToSbomPackage()
     {
         var npmComponent = new NpmComponent("name", "verison", author: new NpmAuthor("name", "email@contoso.com"));
-        var scannedComponent = new ScannedComponentWithLicense() { Component = npmComponent };
+        var scannedComponent = new ExtendedScannedComponent() { Component = npmComponent };
 
         var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
 
@@ -178,7 +178,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
     public void NpmComponent_ToSbomPackage_NoAuthor()
     {
         var npmComponent = new NpmComponent("name", "verison");
-        var scannedComponent = new ScannedComponentWithLicense() { Component = npmComponent };
+        var scannedComponent = new ExtendedScannedComponent() { Component = npmComponent };
 
         var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
 
@@ -193,7 +193,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
     public void NuGetComponent_ToSbomPackage()
     {
         var nuGetComponent = new NuGetComponent("name", "version", new string[] { "Author Name1, Another Author" });
-        var scannedComponent = new ScannedComponentWithLicense() { Component = nuGetComponent };
+        var scannedComponent = new ExtendedScannedComponent() { Component = nuGetComponent };
 
         var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
 
@@ -208,7 +208,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
     public void NuGetComponent_ToSbomPackage_NoAuthor()
     {
         var nuGetComponent = new NuGetComponent("name", "version");
-        var scannedComponent = new ScannedComponentWithLicense() { Component = nuGetComponent };
+        var scannedComponent = new ExtendedScannedComponent() { Component = nuGetComponent };
 
         var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
 
@@ -223,7 +223,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
     public void PipComponent_ToSbomPackage()
     {
         var pipComponent = new PipComponent("name", "version");
-        var scannedComponent = new ScannedComponentWithLicense() { Component = pipComponent };
+        var scannedComponent = new ExtendedScannedComponent() { Component = pipComponent };
 
         var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
 
@@ -238,7 +238,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
     {
         var uri = new Uri("https://microsoft.com");
         var gitComponent = new GitComponent(uri, "version");
-        var scannedComponent = new ScannedComponentWithLicense() { Component = gitComponent };
+        var scannedComponent = new ExtendedScannedComponent() { Component = gitComponent };
 
         var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
 

--- a/test/Microsoft.Sbom.Api.Tests/Executors/ComponentToPackageInfoConverterTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/ComponentToPackageInfoConverterTests.cs
@@ -50,24 +50,24 @@ public class ComponentToPackageInfoConverterTests
     [TestMethod]
     public async Task ConvertTestAsync()
     {
-        var scannedComponents = new List<ScannedComponentWithLicense>()
+        var scannedComponents = new List<ExtendedScannedComponent>()
         {
-            new ScannedComponentWithLicense
+            new ExtendedScannedComponent
             {
                 LocationsFoundAt = "test".Split(),
                 Component = new NuGetComponent("nugetpackage", "1.0.0")
             },
-            new ScannedComponentWithLicense
+            new ExtendedScannedComponent
             {
                 LocationsFoundAt = "test".Split(),
                 Component = new NuGetComponent("nugetpackage2", "1.0.0")
             },
-            new ScannedComponentWithLicense
+            new ExtendedScannedComponent
             {
                 LocationsFoundAt = "test".Split(),
                 Component = new GitComponent(new Uri("http://test.uri"), "hash")
             },
-            new ScannedComponentWithLicense
+            new ExtendedScannedComponent
             {
                 LocationsFoundAt = "test".Split(),
                 Component = new MavenComponent("groupId", "artifactId", "1.0.0")
@@ -89,7 +89,7 @@ public class ComponentToPackageInfoConverterTests
     [TestMethod]
     public async Task ConvertNuGet_AuthorPopulated()
     {
-        var scannedComponent = new ScannedComponentWithLicense
+        var scannedComponent = new ExtendedScannedComponent
         {
             Component = new NuGetComponent("nugetpackage", "1.0.0")
             {
@@ -105,7 +105,7 @@ public class ComponentToPackageInfoConverterTests
     [TestMethod]
     public async Task ConvertNuGet_AuthorNotPopulated()
     {
-        var scannedComponent = new ScannedComponentWithLicense
+        var scannedComponent = new ExtendedScannedComponent
         {
             Component = new NuGetComponent("nugetpackage", "1.0.0") { Authors = null }
         };
@@ -116,23 +116,39 @@ public class ComponentToPackageInfoConverterTests
     }
 
     [TestMethod]
-    public async Task ConvertNuGet_LicensePopulated()
+    public async Task ConvertNuGet_LicenseConcludedPopulated()
     {
-        var scannedComponent = new ScannedComponentWithLicense
+        var scannedComponent = new ExtendedScannedComponent
         {
             Component = new NuGetComponent("nugetpackage", "1.0.0") { Authors = null },
-            License = "MIT"
+            LicenseConcluded = "MIT"
         };
 
         var packageInfo = await ConvertScannedComponent(scannedComponent);
 
         Assert.AreEqual("MIT", packageInfo.LicenseInfo.Concluded);
+        Assert.IsNull(packageInfo.LicenseInfo?.Declared);
     }
 
     [TestMethod]
-    public async Task ConvertNuGet_LicenseNotPopulated()
+    public async Task ConvertNuGet_LicenseDeclaredPopulated()
     {
-        var scannedComponent = new ScannedComponentWithLicense
+        var scannedComponent = new ExtendedScannedComponent
+        {
+            Component = new NuGetComponent("nugetpackage", "1.0.0") { Authors = null },
+            LicenseDeclared = "MIT"
+        };
+
+        var packageInfo = await ConvertScannedComponent(scannedComponent);
+
+        Assert.AreEqual("MIT", packageInfo.LicenseInfo.Declared);
+        Assert.IsNull(packageInfo.LicenseInfo?.Concluded);
+    }
+
+    [TestMethod]
+    public async Task ConvertNuGet_LicensesNotPopulated()
+    {
+        var scannedComponent = new ExtendedScannedComponent
         {
             Component = new NuGetComponent("nugetpackage", "1.0.0") { Authors = null },
         };
@@ -140,12 +156,13 @@ public class ComponentToPackageInfoConverterTests
         var packageInfo = await ConvertScannedComponent(scannedComponent);
 
         Assert.IsNull(packageInfo.LicenseInfo?.Concluded);
+        Assert.IsNull(packageInfo.LicenseInfo?.Declared);
     }
 
     [TestMethod]
     public async Task ConvertNpm_AuthorPopulated_Name()
     {
-        var scannedComponent = new ScannedComponentWithLicense
+        var scannedComponent = new ExtendedScannedComponent
         {
             Component = new NpmComponent("nugetpackage", "1.0.0", author: new NpmAuthor("Suzy Author"))
         };
@@ -158,7 +175,7 @@ public class ComponentToPackageInfoConverterTests
     [TestMethod]
     public async Task ConvertNpm_AuthorPopulated_NameAndEmail()
     {
-        var scannedComponent = new ScannedComponentWithLicense
+        var scannedComponent = new ExtendedScannedComponent
         {
             Component = new NpmComponent("nugetpackage", "1.0.0", author: new NpmAuthor("Suzy Author", "suzya@contoso.com"))
         };
@@ -171,7 +188,7 @@ public class ComponentToPackageInfoConverterTests
     [TestMethod]
     public async Task ConvertNpm_AuthorNotPopulated()
     {
-        var scannedComponent = new ScannedComponentWithLicense
+        var scannedComponent = new ExtendedScannedComponent
         {
             Component = new NpmComponent("npmpackage", "1.0.0") { Author = null }
         };
@@ -184,10 +201,10 @@ public class ComponentToPackageInfoConverterTests
     [TestMethod]
     public async Task ConvertNpm_LicensePopulated()
     {
-        var scannedComponent = new ScannedComponentWithLicense
+        var scannedComponent = new ExtendedScannedComponent
         {
             Component = new NpmComponent("npmpackage", "1.0.0") { Author = null },
-            License = "MIT"
+            LicenseConcluded = "MIT"
         };
 
         var packageInfo = await ConvertScannedComponent(scannedComponent);
@@ -198,7 +215,7 @@ public class ComponentToPackageInfoConverterTests
     [TestMethod]
     public async Task ConvertNpm_LicenseNotPopulated()
     {
-        var scannedComponent = new ScannedComponentWithLicense
+        var scannedComponent = new ExtendedScannedComponent
         {
             Component = new NpmComponent("npmpackage", "1.0.0") { Author = null },
         };
@@ -211,21 +228,21 @@ public class ComponentToPackageInfoConverterTests
     [TestMethod]
     public async Task ConvertWorksWithBuildComponentPathNull()
     {
-        var scannedComponents = new List<ScannedComponentWithLicense>()
+        var scannedComponents = new List<ExtendedScannedComponent>()
         {
-            new ScannedComponentWithLicense
+            new ExtendedScannedComponent
             {
                 Component = new NuGetComponent("nugetpackage", "1.0.0")
             },
-            new ScannedComponentWithLicense
+            new ExtendedScannedComponent
             {
                 Component = new NuGetComponent("nugetpackage2", "1.0.0")
             },
-            new ScannedComponentWithLicense
+            new ExtendedScannedComponent
             {
                 Component = new GitComponent(new Uri("http://test.uri"), "hash")
             },
-            new ScannedComponentWithLicense
+            new ExtendedScannedComponent
             {
                 Component = new MavenComponent("groupId", "artifactId", "1.0.0")
             }
@@ -243,7 +260,7 @@ public class ComponentToPackageInfoConverterTests
         Assert.IsFalse(errors?.Any());
     }
 
-    private async Task<PackageInfo> ConvertScannedComponent(ScannedComponentWithLicense scannedComponent)
+    private async Task<PackageInfo> ConvertScannedComponent(ExtendedScannedComponent scannedComponent)
     {
         var componentsChannel = Channel.CreateUnbounded<ScannedComponent>();
         await componentsChannel.Writer.WriteAsync(scannedComponent);

--- a/test/Microsoft.Sbom.Api.Tests/Executors/PackagesWalkerTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/PackagesWalkerTests.cs
@@ -33,6 +33,7 @@ public class PackagesWalkerTests
     private readonly Mock<ISbomConfigProvider> mockSbomConfigs = new Mock<ISbomConfigProvider>();
     private readonly Mock<IFileSystemUtils> mockFileSystemUtils = new Mock<IFileSystemUtils>();
     private readonly Mock<ILicenseInformationFetcher> mockLicenseInformationFetcher = new Mock<ILicenseInformationFetcher>();
+    private readonly Mock<IPackageDetailsFactory> mockPackageDetailsFactory = new Mock<IPackageDetailsFactory>();
 
     public PackagesWalkerTests()
     {
@@ -47,10 +48,10 @@ public class PackagesWalkerTests
     [TestMethod]
     public async Task ScanSuccessTestAsync()
     {
-        var scannedComponents = new List<ScannedComponentWithLicense>();
+        var scannedComponents = new List<ExtendedScannedComponent>();
         for (var i = 1; i < 4; i++)
         {
-            var scannedComponent = new ScannedComponentWithLicense
+            var scannedComponent = new ExtendedScannedComponent
             {
                 Component = new NpmComponent("componentName", $"{i}")
             };
@@ -58,7 +59,7 @@ public class PackagesWalkerTests
             scannedComponents.Add(scannedComponent);
         }
 
-        var scannedComponentOther = new ScannedComponentWithLicense
+        var scannedComponentOther = new ExtendedScannedComponent
         {
             Component = new NpmComponent("componentName", "3")
         };
@@ -74,12 +75,12 @@ public class PackagesWalkerTests
         };
 
         mockDetector.Setup(o => o.ScanAsync(It.IsAny<string[]>())).Returns(Task.FromResult(scanResult));
-        var walker = new PackagesWalker(mockLogger.Object, mockDetector.Object, mockConfiguration.Object, mockSbomConfigs.Object, mockFileSystemUtils.Object, mockLicenseInformationFetcher.Object);
+        var walker = new PackagesWalker(mockLogger.Object, mockDetector.Object, mockConfiguration.Object, mockSbomConfigs.Object, mockFileSystemUtils.Object, mockPackageDetailsFactory.Object, mockLicenseInformationFetcher.Object);
         var packagesChannelReader = walker.GetComponents("root");
 
         var countDistinctComponents = 0;
 
-        await foreach (ScannedComponentWithLicense package in packagesChannelReader.output.ReadAllAsync())
+        await foreach (ExtendedScannedComponent package in packagesChannelReader.output.ReadAllAsync())
         {
             countDistinctComponents++;
             Assert.IsTrue(scannedComponents.Remove(package));
@@ -98,10 +99,10 @@ public class PackagesWalkerTests
     [TestMethod]
     public async Task ScanCombinePackagesWithSameNameDifferentCase()
     {
-        var scannedComponents = new List<ScannedComponentWithLicense>();
+        var scannedComponents = new List<ExtendedScannedComponent>();
         for (var i = 1; i < 4; i++)
         {
-            var scannedComponent = new ScannedComponentWithLicense
+            var scannedComponent = new ExtendedScannedComponent
             {
                 Component = new NpmComponent("componentName", $"{i}")
             };
@@ -109,7 +110,7 @@ public class PackagesWalkerTests
             scannedComponents.Add(scannedComponent);
         }
 
-        var scannedComponentOther = new ScannedComponentWithLicense
+        var scannedComponentOther = new ExtendedScannedComponent
         {
             // Component with changed case. should also match 'componentName' and
             // thus only 3 components should be detected.
@@ -127,12 +128,12 @@ public class PackagesWalkerTests
         };
 
         mockDetector.Setup(o => o.ScanAsync(It.IsAny<string[]>())).Returns(Task.FromResult(scanResult));
-        var walker = new PackagesWalker(mockLogger.Object, mockDetector.Object, mockConfiguration.Object, mockSbomConfigs.Object, mockFileSystemUtils.Object, mockLicenseInformationFetcher.Object);
+        var walker = new PackagesWalker(mockLogger.Object, mockDetector.Object, mockConfiguration.Object, mockSbomConfigs.Object, mockFileSystemUtils.Object, mockPackageDetailsFactory.Object, mockLicenseInformationFetcher.Object);
         var packagesChannelReader = walker.GetComponents("root");
 
         var countDistinctComponents = 0;
 
-        await foreach (ScannedComponentWithLicense package in packagesChannelReader.output.ReadAllAsync())
+        await foreach (ExtendedScannedComponent package in packagesChannelReader.output.ReadAllAsync())
         {
             countDistinctComponents++;
             Assert.IsTrue(scannedComponents.Remove(package));
@@ -153,7 +154,7 @@ public class PackagesWalkerTests
     {
         var mockDetector = new Mock<ComponentDetectorCachedExecutor>(new Mock<ILogger>().Object, new Mock<IComponentDetector>().Object);
 
-        var walker = new PackagesWalker(mockLogger.Object, mockDetector.Object, mockConfiguration.Object, mockSbomConfigs.Object, mockFileSystemUtils.Object, mockLicenseInformationFetcher.Object);
+        var walker = new PackagesWalker(mockLogger.Object, mockDetector.Object, mockConfiguration.Object, mockSbomConfigs.Object, mockFileSystemUtils.Object, mockPackageDetailsFactory.Object, mockLicenseInformationFetcher.Object);
         walker.GetComponents(null);
         walker.GetComponents(string.Empty);
 
@@ -172,7 +173,7 @@ public class PackagesWalkerTests
         };
 
         mockDetector.Setup(o => o.ScanAsync(It.IsAny<string[]>())).Returns(Task.FromResult(scanResult));
-        var walker = new PackagesWalker(mockLogger.Object, mockDetector.Object, mockConfiguration.Object, mockSbomConfigs.Object, mockFileSystemUtils.Object, mockLicenseInformationFetcher.Object);
+        var walker = new PackagesWalker(mockLogger.Object, mockDetector.Object, mockConfiguration.Object, mockSbomConfigs.Object, mockFileSystemUtils.Object, mockPackageDetailsFactory.Object, mockLicenseInformationFetcher.Object);
         var packagesChannelReader = walker.GetComponents("root");
         ComponentDetectorException actualError = null;
 
@@ -193,10 +194,10 @@ public class PackagesWalkerTests
     [TestMethod]
     public async Task ScanIgnoreSbomComponents()
     {
-        var scannedComponents = new List<ScannedComponentWithLicense>();
+        var scannedComponents = new List<ExtendedScannedComponent>();
         for (var i = 1; i < 4; i++)
         {
-            var scannedComponent = new ScannedComponentWithLicense
+            var scannedComponent = new ExtendedScannedComponent
             {
                 Component = new NpmComponent("componentName", $"{i}")
             };
@@ -204,7 +205,7 @@ public class PackagesWalkerTests
             scannedComponents.Add(scannedComponent);
         }
 
-        var scannedComponentOther = new ScannedComponentWithLicense
+        var scannedComponentOther = new ExtendedScannedComponent
         {
             Component = new SpdxComponent("SPDX-2.2", new Uri("http://test.com"), "componentName", "123", "abcdf", "path1")
         };
@@ -220,7 +221,7 @@ public class PackagesWalkerTests
         };
 
         mockDetector.Setup(o => o.ScanAsync(It.IsAny<string[]>())).Returns(Task.FromResult(scanResult));
-        var walker = new PackagesWalker(mockLogger.Object, mockDetector.Object, mockConfiguration.Object, mockSbomConfigs.Object, mockFileSystemUtils.Object, mockLicenseInformationFetcher.Object);
+        var walker = new PackagesWalker(mockLogger.Object, mockDetector.Object, mockConfiguration.Object, mockSbomConfigs.Object, mockFileSystemUtils.Object, mockPackageDetailsFactory.Object, mockLicenseInformationFetcher.Object);
         var packagesChannelReader = walker.GetComponents("root");
 
         var discoveredComponents = await packagesChannelReader.output.ReadAllAsync().ToListAsync();

--- a/test/Microsoft.Sbom.Api.Tests/Executors/SBOMComponentsWalkerTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/SBOMComponentsWalkerTests.cs
@@ -32,6 +32,7 @@ public class SBOMComponentsWalkerTests
     private readonly Mock<IConfiguration> mockConfiguration = new Mock<IConfiguration>();
     private readonly Mock<ISbomConfigProvider> mockSbomConfigs = new Mock<ISbomConfigProvider>();
     private readonly Mock<IFileSystemUtils> mockFileSystem = new Mock<IFileSystemUtils>();
+    private readonly Mock<IPackageDetailsFactory> mockPackageDetailsFactory = new Mock<IPackageDetailsFactory>();
     private readonly Mock<ILicenseInformationFetcher> mockLicenseInformationFetcher = new Mock<ILicenseInformationFetcher>();
 
     public SBOMComponentsWalkerTests()
@@ -47,10 +48,10 @@ public class SBOMComponentsWalkerTests
     [TestMethod]
     public async Task GetComponents()
     {
-        var scannedComponents = new List<ScannedComponentWithLicense>();
+        var scannedComponents = new List<ExtendedScannedComponent>();
         for (var i = 1; i < 4; i++)
         {
-            var scannedComponent = new ScannedComponentWithLicense
+            var scannedComponent = new ExtendedScannedComponent
             {
                 Component = new SpdxComponent("SPDX-2.2", new Uri("http://test.uri"), "componentName", $"123{i}", "abcdef", $"path{i}"),
                 DetectorId = "SPDX22SBOM"
@@ -68,7 +69,7 @@ public class SBOMComponentsWalkerTests
         };
 
         mockDetector.Setup(o => o.ScanAsync(It.IsAny<string[]>())).Returns(Task.FromResult(scanResult));
-        var walker = new SBOMComponentsWalker(mockLogger.Object, mockDetector.Object, mockConfiguration.Object, mockSbomConfigs.Object, mockFileSystem.Object, mockLicenseInformationFetcher.Object);
+        var walker = new SBOMComponentsWalker(mockLogger.Object, mockDetector.Object, mockConfiguration.Object, mockSbomConfigs.Object, mockFileSystem.Object, mockPackageDetailsFactory.Object, mockLicenseInformationFetcher.Object);
         var packagesChannelReader = walker.GetComponents("root");
 
         var discoveredComponents = await packagesChannelReader.output.ReadAllAsync().ToListAsync();
@@ -85,10 +86,10 @@ public class SBOMComponentsWalkerTests
     [TestMethod]
     public async Task GetComponentsWithFiltering()
     {
-        var scannedComponents = new List<ScannedComponentWithLicense>();
+        var scannedComponents = new List<ExtendedScannedComponent>();
         for (var i = 1; i < 4; i++)
         {
-            var scannedComponent = new ScannedComponentWithLicense
+            var scannedComponent = new ExtendedScannedComponent
             {
                 Component = new SpdxComponent("SPDX-2.2", new Uri("http://test.uri"), "componentName", $"123{i}", "abcdef", $"path{i}"),
                 DetectorId = "SPDX22SBOM"
@@ -97,7 +98,7 @@ public class SBOMComponentsWalkerTests
             scannedComponents.Add(scannedComponent);
         }
 
-        var nonSbomComponent = new ScannedComponentWithLicense
+        var nonSbomComponent = new ExtendedScannedComponent
         {
             Component = new NpmComponent("componentName", "123"),
             DetectorId = "notSPDX22SBOM"
@@ -113,7 +114,7 @@ public class SBOMComponentsWalkerTests
         };
 
         mockDetector.Setup(o => o.ScanAsync(It.IsAny<string[]>())).Returns(Task.FromResult(scanResult));
-        var walker = new SBOMComponentsWalker(mockLogger.Object, mockDetector.Object, mockConfiguration.Object, mockSbomConfigs.Object, mockFileSystem.Object, mockLicenseInformationFetcher.Object);
+        var walker = new SBOMComponentsWalker(mockLogger.Object, mockDetector.Object, mockConfiguration.Object, mockSbomConfigs.Object, mockFileSystem.Object, mockPackageDetailsFactory.Object, mockLicenseInformationFetcher.Object);
         var packagesChannelReader = walker.GetComponents("root");
 
         var discoveredComponents = await packagesChannelReader.output.ReadAllAsync().ToListAsync();

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/ManifestGenerationWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/ManifestGenerationWorkflowTests.cs
@@ -63,6 +63,7 @@ public class ManifestGenerationWorkflowTests
     private readonly Mock<ISBOMReaderForExternalDocumentReference> sBOMReaderForExternalDocumentReferenceMock = new Mock<ISBOMReaderForExternalDocumentReference>();
     private readonly Mock<IFileSystemUtilsExtension> fileSystemUtilsExtensionMock = new Mock<IFileSystemUtilsExtension>();
     private readonly Mock<ILicenseInformationFetcher> licenseInformationFetcherMock = new Mock<ILicenseInformationFetcher>();
+    private readonly Mock<IPackageDetailsFactory> mockPackageDetailsFactory = new Mock<IPackageDetailsFactory>();
 
     [TestInitialize]
     public void Setup()
@@ -278,7 +279,8 @@ public class ManifestGenerationWorkflowTests
                 manifestGeneratorProvider,
                 mockLogger.Object),
             packageInfoConverterMock.Object,
-            new PackagesWalker(mockLogger.Object, mockDetector.Object, configurationMock.Object, sbomConfigs, fileSystemMock.Object, licenseInformationFetcherMock.Object),
+            new PackagesWalker(mockLogger.Object, mockDetector.Object, configurationMock.Object, sbomConfigs, fileSystemMock.Object, mockPackageDetailsFactory.Object, licenseInformationFetcherMock.Object),
+            mockPackageDetailsFactory.Object,
             licenseInformationFetcherMock.Object);
 
         var externalDocumentReferenceProvider = new ExternalDocumentReferenceProvider(


### PR DESCRIPTION
The key changes here are:

- Rename ScannedComponentWithLicense -> ExtendedScannedComponent. This object will now hold more information than just licenses.
- Correctly name licenses as either LicenseDeclared (coming from local file) or LicenseConcluded (coming from ClearlyDefined API)
- Add a PackageDetailsFactory that handles finding local files for each type of packages and parsing them. This factory will return a dictionary containing all the details found in the packages.
- At the moment the PackageDetailsFactory will only be executed if license fetching is enabled using the -li parameter.

What's missing:
- More unit tests still need to be added
- Adding new Exception types to be able to identify when the PackageDetailsFactory is failing.