### PR TITLE
Remove BOM from .cs and csproj files

### DIFF
--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/CondaComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/CondaComponentExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Adapters.ComponentDetection;

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/DockerImageComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/DockerImageComponentExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Adapters.ComponentDetection;

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/DockerReferenceComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/DockerReferenceComponentExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Adapters.ComponentDetection;

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/GitComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/GitComponentExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Adapters.ComponentDetection;

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/GoComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/GoComponentExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Adapters.ComponentDetection;

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/LinuxComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/LinuxComponentExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Adapters.ComponentDetection;

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/Logging/LoggingHelper.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/Logging/LoggingHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/MavenComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/MavenComponentExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Adapters.ComponentDetection;

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/OtherComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/OtherComponentExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Adapters.ComponentDetection;

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/SpdxComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/SpdxComponentExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Adapters.ComponentDetection;

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/VcpkgComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/VcpkgComponentExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Adapters.ComponentDetection;

--- a/src/Microsoft.Sbom.Adapters/Microsoft.Sbom.Adapters.csproj
+++ b/src/Microsoft.Sbom.Adapters/Microsoft.Sbom.Adapters.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AssemblyName>Microsoft.Sbom.Adapters</AssemblyName>

--- a/src/Microsoft.Sbom.Adapters/Report/AdapterReport.cs
+++ b/src/Microsoft.Sbom.Adapters/Report/AdapterReport.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/Microsoft.Sbom.Adapters/Report/AdapterReportItem.cs
+++ b/src/Microsoft.Sbom.Adapters/Report/AdapterReportItem.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Config/ArgRevivers.cs
+++ b/src/Microsoft.Sbom.Api/Config/ArgRevivers.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Config/Args/CommonArgs.cs
+++ b/src/Microsoft.Sbom.Api/Config/Args/CommonArgs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/Microsoft.Sbom.Api/Config/Args/ValidationArgs.cs
+++ b/src/Microsoft.Sbom.Api/Config/Args/ValidationArgs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Config/ConfigFileParser.cs
+++ b/src/Microsoft.Sbom.Api/Config/ConfigFileParser.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Config/ConfigPostProcessor.cs
+++ b/src/Microsoft.Sbom.Api/Config/ConfigPostProcessor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Config/ConfigSanitizer.cs
+++ b/src/Microsoft.Sbom.Api/Config/ConfigSanitizer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Config/ConfigurationBuilder.cs
+++ b/src/Microsoft.Sbom.Api/Config/ConfigurationBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Threading.Tasks;

--- a/src/Microsoft.Sbom.Api/Config/Generator.cs
+++ b/src/Microsoft.Sbom.Api/Config/Generator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Config/ISbomService.cs
+++ b/src/Microsoft.Sbom.Api/Config/ISbomService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Sbom.Api.Config.Args;

--- a/src/Microsoft.Sbom.Api/Config/SbomToolCmdRunner.cs
+++ b/src/Microsoft.Sbom.Api/Config/SbomToolCmdRunner.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Config/Validators/ConfigValidator.cs
+++ b/src/Microsoft.Sbom.Api/Config/Validators/ConfigValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Config/Validators/DirectoryPathIsWritableValidator.cs
+++ b/src/Microsoft.Sbom.Api/Config/Validators/DirectoryPathIsWritableValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Config/Validators/FileExistsValidator.cs
+++ b/src/Microsoft.Sbom.Api/Config/Validators/FileExistsValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Config/Validators/IntRangeValidator.cs
+++ b/src/Microsoft.Sbom.Api/Config/Validators/IntRangeValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Config/Validators/UriValidator.cs
+++ b/src/Microsoft.Sbom.Api/Config/Validators/UriValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Config/Validators/ValueRequiredValidator.cs
+++ b/src/Microsoft.Sbom.Api/Config/Validators/ValueRequiredValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Config/ValueConverters/BoolConfigurationSettingAddingConverter.cs
+++ b/src/Microsoft.Sbom.Api/Config/ValueConverters/BoolConfigurationSettingAddingConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using AutoMapper;

--- a/src/Microsoft.Sbom.Api/Config/ValueConverters/HashAlgorithmNameConfigurationSettingAddingConverter.cs
+++ b/src/Microsoft.Sbom.Api/Config/ValueConverters/HashAlgorithmNameConfigurationSettingAddingConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using AutoMapper;

--- a/src/Microsoft.Sbom.Api/Config/ValueConverters/IntConfigurationSettingAddingConverter.cs
+++ b/src/Microsoft.Sbom.Api/Config/ValueConverters/IntConfigurationSettingAddingConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using AutoMapper;

--- a/src/Microsoft.Sbom.Api/Config/ValueConverters/LogEventLevelConfigurationSettingAddingConverter.cs
+++ b/src/Microsoft.Sbom.Api/Config/ValueConverters/LogEventLevelConfigurationSettingAddingConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using AutoMapper;

--- a/src/Microsoft.Sbom.Api/Config/ValueConverters/ManifestInfoConfigurationSettingAddingConverter.cs
+++ b/src/Microsoft.Sbom.Api/Config/ValueConverters/ManifestInfoConfigurationSettingAddingConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/Microsoft.Sbom.Api/Config/ValueConverters/NullableBoolConfigurationSettingAddingConverter.cs
+++ b/src/Microsoft.Sbom.Api/Config/ValueConverters/NullableBoolConfigurationSettingAddingConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using AutoMapper;

--- a/src/Microsoft.Sbom.Api/Config/ValueConverters/StringConfigurationSettingAddingConverter.cs
+++ b/src/Microsoft.Sbom.Api/Config/ValueConverters/StringConfigurationSettingAddingConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using AutoMapper;

--- a/src/Microsoft.Sbom.Api/ConfigurationProfile.cs
+++ b/src/Microsoft.Sbom.Api/ConfigurationProfile.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Converters/ComponentToExternalReferenceInfoConverter.cs
+++ b/src/Microsoft.Sbom.Api/Converters/ComponentToExternalReferenceInfoConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Converters/ExternalReferenceInfoToPathConverter.cs
+++ b/src/Microsoft.Sbom.Api/Converters/ExternalReferenceInfoToPathConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Converters/IManifestPathConverter.cs
+++ b/src/Microsoft.Sbom.Api/Converters/IManifestPathConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Api.Convertors;

--- a/src/Microsoft.Sbom.Api/Converters/SbomToolManifestPathConverter.cs
+++ b/src/Microsoft.Sbom.Api/Converters/SbomToolManifestPathConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Converters/SerilogLoggerConverter.cs
+++ b/src/Microsoft.Sbom.Api/Converters/SerilogLoggerConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Entities/ErrorType.cs
+++ b/src/Microsoft.Sbom.Api/Entities/ErrorType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.Serialization;

--- a/src/Microsoft.Sbom.Api/Entities/ExitCode.cs
+++ b/src/Microsoft.Sbom.Api/Entities/ExitCode.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Api;

--- a/src/Microsoft.Sbom.Api/Entities/FileValidationResult.cs
+++ b/src/Microsoft.Sbom.Api/Entities/FileValidationResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Sbom.Contracts;

--- a/src/Microsoft.Sbom.Api/Entities/JsonDocWithSerializer.cs
+++ b/src/Microsoft.Sbom.Api/Entities/JsonDocWithSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Entities/output/ErrorContainer.cs
+++ b/src/Microsoft.Sbom.Api/Entities/output/ErrorContainer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/Microsoft.Sbom.Api/Entities/output/Result.cs
+++ b/src/Microsoft.Sbom.Api/Entities/output/Result.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.Serialization;

--- a/src/Microsoft.Sbom.Api/Entities/output/Summary.cs
+++ b/src/Microsoft.Sbom.Api/Entities/output/Summary.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Sbom.Common.Config;

--- a/src/Microsoft.Sbom.Api/Entities/output/ValidationResult.cs
+++ b/src/Microsoft.Sbom.Api/Entities/output/ValidationResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Api.Entities.Output;

--- a/src/Microsoft.Sbom.Api/Entities/output/ValidationResultGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Entities/output/ValidationResultGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Entities/output/ValidationTelemetry.cs
+++ b/src/Microsoft.Sbom.Api/Entities/output/ValidationTelemetry.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Api.Entities.Output;

--- a/src/Microsoft.Sbom.Api/Exceptions/AccessDeniedValidationArgException.cs
+++ b/src/Microsoft.Sbom.Api/Exceptions/AccessDeniedValidationArgException.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Executors/ChannelUtils.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ChannelUtils.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/Microsoft.Sbom.Api/Executors/ConcurrentSha256HashValidator.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ConcurrentSha256HashValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Executors/DirectoryWalker.cs
+++ b/src/Microsoft.Sbom.Api/Executors/DirectoryWalker.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Executors/EnumeratorChannel.cs
+++ b/src/Microsoft.Sbom.Api/Executors/EnumeratorChannel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Executors/ExternalDocumentReferenceWriter.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ExternalDocumentReferenceWriter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Executors/FileFilterer.cs
+++ b/src/Microsoft.Sbom.Api/Executors/FileFilterer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Executors/FileHasher.cs
+++ b/src/Microsoft.Sbom.Api/Executors/FileHasher.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Executors/FileInfoWriter.cs
+++ b/src/Microsoft.Sbom.Api/Executors/FileInfoWriter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Executors/FileListEnumerator.cs
+++ b/src/Microsoft.Sbom.Api/Executors/FileListEnumerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Executors/HashValidator.cs
+++ b/src/Microsoft.Sbom.Api/Executors/HashValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Linq;

--- a/src/Microsoft.Sbom.Api/Executors/ISBOMReaderForExternalDocumentReference.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ISBOMReaderForExternalDocumentReference.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Threading.Channels;

--- a/src/Microsoft.Sbom.Api/Executors/ListWalker.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ListWalker.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Executors/ManifestFileFilterer.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ManifestFileFilterer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Executors/ManifestFolderFilterer.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ManifestFolderFilterer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Executors/PackageInfoJsonWriter.cs
+++ b/src/Microsoft.Sbom.Api/Executors/PackageInfoJsonWriter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Executors/RelationshipGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Executors/RelationshipGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Executors/SBOMFileToFileInfoConverter.cs
+++ b/src/Microsoft.Sbom.Api/Executors/SBOMFileToFileInfoConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Executors/SPDXSBOMReaderForExternalDocumentReference.cs
+++ b/src/Microsoft.Sbom.Api/Executors/SPDXSBOMReaderForExternalDocumentReference.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Filters/DownloadedRootPathFilter.cs
+++ b/src/Microsoft.Sbom.Api/Filters/DownloadedRootPathFilter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Filters/IFilter.cs
+++ b/src/Microsoft.Sbom.Api/Filters/IFilter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Api.Filters;

--- a/src/Microsoft.Sbom.Api/Filters/ManifestFolderFilter.cs
+++ b/src/Microsoft.Sbom.Api/Filters/ManifestFolderFilter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Hashing/Algorithms/IHashAlgorithm.cs
+++ b/src/Microsoft.Sbom.Api/Hashing/Algorithms/IHashAlgorithm.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;

--- a/src/Microsoft.Sbom.Api/Hashing/Algorithms/Sha1HashAlgorithm.cs
+++ b/src/Microsoft.Sbom.Api/Hashing/Algorithms/Sha1HashAlgorithm.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;

--- a/src/Microsoft.Sbom.Api/Hashing/Algorithms/Sha256HashAlgorithm.cs
+++ b/src/Microsoft.Sbom.Api/Hashing/Algorithms/Sha256HashAlgorithm.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;

--- a/src/Microsoft.Sbom.Api/Hashing/HashAlgorithmProvider.cs
+++ b/src/Microsoft.Sbom.Api/Hashing/HashAlgorithmProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Hashing/HashCodeGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Hashing/HashCodeGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Hashing/IHashAlgorithmProvider.cs
+++ b/src/Microsoft.Sbom.Api/Hashing/IHashAlgorithmProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Sbom.Contracts.Enums;

--- a/src/Microsoft.Sbom.Api/Hashing/IHashCodeGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Hashing/IHashCodeGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Sbom.Contracts;

--- a/src/Microsoft.Sbom.Api/Manifest/Configuration/SBOMConfig.cs
+++ b/src/Microsoft.Sbom.Api/Manifest/Configuration/SBOMConfig.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfigFactory.cs
+++ b/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfigFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfigProvider.cs
+++ b/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfigProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Manifest/FileHashes/FileHashes.cs
+++ b/src/Microsoft.Sbom.Api/Manifest/FileHashes/FileHashes.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Manifest/FileHashes/FileHashesDictionary.cs
+++ b/src/Microsoft.Sbom.Api/Manifest/FileHashes/FileHashesDictionary.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Concurrent;

--- a/src/Microsoft.Sbom.Api/Manifest/IManifestParserProvider.cs
+++ b/src/Microsoft.Sbom.Api/Manifest/IManifestParserProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Sbom.Extensions;

--- a/src/Microsoft.Sbom.Api/Manifest/ManifestConfigHandlers/SPDX22ManifestConfigHandler.cs
+++ b/src/Microsoft.Sbom.Api/Manifest/ManifestConfigHandlers/SPDX22ManifestConfigHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Manifest/ManifestGeneratorProvider.cs
+++ b/src/Microsoft.Sbom.Api/Manifest/ManifestGeneratorProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Manifest/ManifestParserProvider.cs
+++ b/src/Microsoft.Sbom.Api/Manifest/ManifestParserProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/MetaData/LocalMetadataProvider.cs
+++ b/src/Microsoft.Sbom.Api/MetaData/LocalMetadataProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/MetaData/SBOMApiMetadataProvider.cs
+++ b/src/Microsoft.Sbom.Api/MetaData/SBOMApiMetadataProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Output/FileOutputWriter.cs
+++ b/src/Microsoft.Sbom.Api/Output/FileOutputWriter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;

--- a/src/Microsoft.Sbom.Api/Output/IOutputWriter.cs
+++ b/src/Microsoft.Sbom.Api/Output/IOutputWriter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Threading.Tasks;

--- a/src/Microsoft.Sbom.Api/Output/ManifestToolJsonSerializer.cs
+++ b/src/Microsoft.Sbom.Api/Output/ManifestToolJsonSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Output/MetadataBuilder.cs
+++ b/src/Microsoft.Sbom.Api/Output/MetadataBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Output/MetadataBuilderFactory.cs
+++ b/src/Microsoft.Sbom.Api/Output/MetadataBuilderFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Output/Telemetry/Entities/SBOMFile.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/Entities/SBOMFile.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Sbom.Extensions.Entities;

--- a/src/Microsoft.Sbom.Api/Output/Telemetry/Entities/Timing.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/Entities/Timing.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Output/Telemetry/TimingRecorder.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/TimingRecorder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Providers/EntityToJsonProviderBase.cs
+++ b/src/Microsoft.Sbom.Api/Providers/EntityToJsonProviderBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Providers/ExternalDocumentReferenceProviders/CGExternalDocumentReferenceProvider.cs
+++ b/src/Microsoft.Sbom.Api/Providers/ExternalDocumentReferenceProviders/CGExternalDocumentReferenceProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Providers/ExternalDocumentReferenceProviders/ExternalDocumentReferenceProvider.cs
+++ b/src/Microsoft.Sbom.Api/Providers/ExternalDocumentReferenceProviders/ExternalDocumentReferenceProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Providers/FilesProviders/CGScannedExternalDocumentReferenceFileProvider.cs
+++ b/src/Microsoft.Sbom.Api/Providers/FilesProviders/CGScannedExternalDocumentReferenceFileProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Providers/FilesProviders/DirectoryTraversingFileToJsonProvider.cs
+++ b/src/Microsoft.Sbom.Api/Providers/FilesProviders/DirectoryTraversingFileToJsonProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Providers/FilesProviders/ExternalDocumentReferenceFileProvider.cs
+++ b/src/Microsoft.Sbom.Api/Providers/FilesProviders/ExternalDocumentReferenceFileProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Providers/FilesProviders/FileListBasedFileToJsonProvider.cs
+++ b/src/Microsoft.Sbom.Api/Providers/FilesProviders/FileListBasedFileToJsonProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Providers/FilesProviders/FileToJsonProviderBase.cs
+++ b/src/Microsoft.Sbom.Api/Providers/FilesProviders/FileToJsonProviderBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Providers/FilesProviders/PathBasedFileToJsonProviderBase.cs
+++ b/src/Microsoft.Sbom.Api/Providers/FilesProviders/PathBasedFileToJsonProviderBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Providers/FilesProviders/SBOMFileBasedFileToJsonProvider.cs
+++ b/src/Microsoft.Sbom.Api/Providers/FilesProviders/SBOMFileBasedFileToJsonProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Providers/ISourcesProvider.cs
+++ b/src/Microsoft.Sbom.Api/Providers/ISourcesProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/Microsoft.Sbom.Api/Providers/ProviderType.cs
+++ b/src/Microsoft.Sbom.Api/Providers/ProviderType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Api.Providers;

--- a/src/Microsoft.Sbom.Api/Recorder/SBOMPackageDetailsRecorder.cs
+++ b/src/Microsoft.Sbom.Api/Recorder/SBOMPackageDetailsRecorder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/SBOMGenerator.cs
+++ b/src/Microsoft.Sbom.Api/SBOMGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/SignValidator/ISignValidationProvider.cs
+++ b/src/Microsoft.Sbom.Api/SignValidator/ISignValidationProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Sbom.Extensions;

--- a/src/Microsoft.Sbom.Api/SignValidator/SignValidationProvider.cs
+++ b/src/Microsoft.Sbom.Api/SignValidator/SignValidationProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Utils/AssemblyConfig.cs
+++ b/src/Microsoft.Sbom.Api/Utils/AssemblyConfig.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Utils/ChannelDeduplicator.cs
+++ b/src/Microsoft.Sbom.Api/Utils/ChannelDeduplicator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Concurrent;

--- a/src/Microsoft.Sbom.Api/Utils/ComponentDetectorCachedExecutor.cs
+++ b/src/Microsoft.Sbom.Api/Utils/ComponentDetectorCachedExecutor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Utils/Constants.cs
+++ b/src/Microsoft.Sbom.Api/Utils/Constants.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/Microsoft.Sbom.Api/Utils/Events.cs
+++ b/src/Microsoft.Sbom.Api/Utils/Events.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Api.Utils;

--- a/src/Microsoft.Sbom.Api/Utils/ExternalDocumentReferenceEqualityComparer.cs
+++ b/src/Microsoft.Sbom.Api/Utils/ExternalDocumentReferenceEqualityComparer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Utils/ExternalReferenceDeduplicator.cs
+++ b/src/Microsoft.Sbom.Api/Utils/ExternalReferenceDeduplicator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Sbom.Extensions.Entities;

--- a/src/Microsoft.Sbom.Api/Utils/FileTypeUtils.cs
+++ b/src/Microsoft.Sbom.Api/Utils/FileTypeUtils.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Utils/IAssemblyConfig.cs
+++ b/src/Microsoft.Sbom.Api/Utils/IAssemblyConfig.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Sbom.Extensions.Entities;

--- a/src/Microsoft.Sbom.Api/Utils/IFileTypeUtils.cs
+++ b/src/Microsoft.Sbom.Api/Utils/IFileTypeUtils.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/Microsoft.Sbom.Api/Utils/InternalSBOMFileInfoDeduplicator.cs
+++ b/src/Microsoft.Sbom.Api/Utils/InternalSBOMFileInfoDeduplicator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Sbom.Extensions.Entities;

--- a/src/Microsoft.Sbom.Api/Utils/SBOMFormatExtensions.cs
+++ b/src/Microsoft.Sbom.Api/Utils/SBOMFormatExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Utils/ScannedComponentEqualityComparer.cs
+++ b/src/Microsoft.Sbom.Api/Utils/ScannedComponentEqualityComparer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/ExternalDocumentReferenceGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/ExternalDocumentReferenceGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/FileArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/FileArrayGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/FilesValidator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/FilesValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/IJsonArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/IJsonArrayGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/PackageArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/PackageArrayGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/RelationshipsArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/RelationshipsArrayGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/Microsoft.Sbom.Api/Workflows/IWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/IWorkflow.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Threading.Tasks;

--- a/src/Microsoft.Sbom.Common/Config/Attributes/ComponentDetectorArgumentAttribute.cs
+++ b/src/Microsoft.Sbom.Common/Config/Attributes/ComponentDetectorArgumentAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Common/Config/Attributes/DefaultManifestInfoArgForValidationAttribute.cs
+++ b/src/Microsoft.Sbom.Common/Config/Attributes/DefaultManifestInfoArgForValidationAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Common/Config/Attributes/DefaultNamespaceBaseUriAttribute.cs
+++ b/src/Microsoft.Sbom.Common/Config/Attributes/DefaultNamespaceBaseUriAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Common/Config/Attributes/DirectoryExistsAttribute.cs
+++ b/src/Microsoft.Sbom.Common/Config/Attributes/DirectoryExistsAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Common/Config/Attributes/DirectoryPathIsWritableAttribute.cs
+++ b/src/Microsoft.Sbom.Common/Config/Attributes/DirectoryPathIsWritableAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Common/Config/Attributes/FileExistsAttribute.cs
+++ b/src/Microsoft.Sbom.Common/Config/Attributes/FileExistsAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Common/Config/Attributes/FilePathIsWritableAttribute.cs
+++ b/src/Microsoft.Sbom.Common/Config/Attributes/FilePathIsWritableAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Common/Config/Attributes/IntRangeAttribute.cs
+++ b/src/Microsoft.Sbom.Common/Config/Attributes/IntRangeAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Common/Config/Attributes/PathAttribute.cs
+++ b/src/Microsoft.Sbom.Common/Config/Attributes/PathAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Common/Config/Attributes/ValidUriAttribute.cs
+++ b/src/Microsoft.Sbom.Common/Config/Attributes/ValidUriAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Common/Config/Attributes/ValueRequiredAttribute.cs
+++ b/src/Microsoft.Sbom.Common/Config/Attributes/ValueRequiredAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Common/Config/ConfigurationSetting.cs
+++ b/src/Microsoft.Sbom.Common/Config/ConfigurationSetting.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Common.Config;

--- a/src/Microsoft.Sbom.Common/Config/ISettingSourceable.cs
+++ b/src/Microsoft.Sbom.Common/Config/ISettingSourceable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Common.Config;

--- a/src/Microsoft.Sbom.Common/Config/ManifestToolActions.cs
+++ b/src/Microsoft.Sbom.Common/Config/ManifestToolActions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Common/Config/SettingSource.cs
+++ b/src/Microsoft.Sbom.Common/Config/SettingSource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Common.Config;

--- a/src/Microsoft.Sbom.Common/Constants.cs
+++ b/src/Microsoft.Sbom.Common/Constants.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Serilog.Events;

--- a/src/Microsoft.Sbom.Common/EnvironmentWrapper.cs
+++ b/src/Microsoft.Sbom.Common/EnvironmentWrapper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Common/Extensions/DictionaryExtensions.cs
+++ b/src/Microsoft.Sbom.Common/Extensions/DictionaryExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Common/Extensions/FileSystemUtilsExtension.cs
+++ b/src/Microsoft.Sbom.Common/Extensions/FileSystemUtilsExtension.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Common/FileSystemUtilsProvider.cs
+++ b/src/Microsoft.Sbom.Common/FileSystemUtilsProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.InteropServices;

--- a/src/Microsoft.Sbom.Common/IEnvironmentWrapper.cs
+++ b/src/Microsoft.Sbom.Common/IEnvironmentWrapper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections;

--- a/src/Microsoft.Sbom.Common/IFileSystemUtilsExtension.cs
+++ b/src/Microsoft.Sbom.Common/IFileSystemUtilsExtension.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Common;

--- a/src/Microsoft.Sbom.Common/IMetadataBuilderFactory.cs
+++ b/src/Microsoft.Sbom.Common/IMetadataBuilderFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Sbom.Extensions;

--- a/src/Microsoft.Sbom.Common/IOSUtils.cs
+++ b/src/Microsoft.Sbom.Common/IOSUtils.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Common/ISbomConfigFactory.cs
+++ b/src/Microsoft.Sbom.Common/ISbomConfigFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Sbom.Extensions;

--- a/src/Microsoft.Sbom.Common/Microsoft.Sbom.Common.csproj
+++ b/src/Microsoft.Sbom.Common/Microsoft.Sbom.Common.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/src/Microsoft.Sbom.Common/OSUtils.cs
+++ b/src/Microsoft.Sbom.Common/OSUtils.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Common/Utils/IdentifierUtils.cs
+++ b/src/Microsoft.Sbom.Common/Utils/IdentifierUtils.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Common/Utils/PathUtils.cs
+++ b/src/Microsoft.Sbom.Common/Utils/PathUtils.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;

--- a/src/Microsoft.Sbom.Contracts/Contracts/Checksum.cs
+++ b/src/Microsoft.Sbom.Contracts/Contracts/Checksum.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Contracts/Contracts/Entities/AlgorithmNames.cs
+++ b/src/Microsoft.Sbom.Contracts/Contracts/Entities/AlgorithmNames.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/Microsoft.Sbom.Contracts/Contracts/Entities/Entity.cs
+++ b/src/Microsoft.Sbom.Contracts/Contracts/Entities/Entity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Sbom.Contracts.Enums;

--- a/src/Microsoft.Sbom.Contracts/Contracts/Entities/FileEntity.cs
+++ b/src/Microsoft.Sbom.Contracts/Contracts/Entities/FileEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Contracts/Contracts/Entities/PackageEntity.cs
+++ b/src/Microsoft.Sbom.Contracts/Contracts/Entities/PackageEntity.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Contracts/Contracts/EntityError.cs
+++ b/src/Microsoft.Sbom.Contracts/Contracts/EntityError.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Sbom.Contracts.Entities;

--- a/src/Microsoft.Sbom.Contracts/Contracts/Enums/AlgorithmName.cs
+++ b/src/Microsoft.Sbom.Contracts/Contracts/Enums/AlgorithmName.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Contracts/Contracts/Enums/EntityType.cs
+++ b/src/Microsoft.Sbom.Contracts/Contracts/Enums/EntityType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.Serialization;

--- a/src/Microsoft.Sbom.Contracts/Contracts/Enums/ErrorType.cs
+++ b/src/Microsoft.Sbom.Contracts/Contracts/Enums/ErrorType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.Serialization;

--- a/src/Microsoft.Sbom.Contracts/Contracts/Enums/FileType.cs
+++ b/src/Microsoft.Sbom.Contracts/Contracts/Enums/FileType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.Serialization;

--- a/src/Microsoft.Sbom.Contracts/Contracts/Enums/ParserState.cs
+++ b/src/Microsoft.Sbom.Contracts/Contracts/Enums/ParserState.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Contracts.Enums;

--- a/src/Microsoft.Sbom.Contracts/Contracts/LicenseInfo.cs
+++ b/src/Microsoft.Sbom.Contracts/Contracts/LicenseInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Contracts;

--- a/src/Microsoft.Sbom.Contracts/Contracts/MetadataCreationInfo.cs
+++ b/src/Microsoft.Sbom.Contracts/Contracts/MetadataCreationInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Contracts/Contracts/SBOMFile.cs
+++ b/src/Microsoft.Sbom.Contracts/Contracts/SBOMFile.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/Microsoft.Sbom.Contracts/Contracts/SBOMGenerationResult.cs
+++ b/src/Microsoft.Sbom.Contracts/Contracts/SBOMGenerationResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/Microsoft.Sbom.Contracts/Contracts/SBOMMetadata.cs
+++ b/src/Microsoft.Sbom.Contracts/Contracts/SBOMMetadata.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Contracts;

--- a/src/Microsoft.Sbom.Contracts/Contracts/SBOMPackage.cs
+++ b/src/Microsoft.Sbom.Contracts/Contracts/SBOMPackage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/Microsoft.Sbom.Contracts/Contracts/SBOMReference.cs
+++ b/src/Microsoft.Sbom.Contracts/Contracts/SBOMReference.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Contracts;

--- a/src/Microsoft.Sbom.Contracts/Contracts/SBOMRelationship.cs
+++ b/src/Microsoft.Sbom.Contracts/Contracts/SBOMRelationship.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Contracts;

--- a/src/Microsoft.Sbom.Contracts/Contracts/SBOMSpecification.cs
+++ b/src/Microsoft.Sbom.Contracts/Contracts/SBOMSpecification.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Contracts/Contracts/Spdx22Metadata.cs
+++ b/src/Microsoft.Sbom.Contracts/Contracts/Spdx22Metadata.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Contracts/ISBOMGenerator.cs
+++ b/src/Microsoft.Sbom.Contracts/ISBOMGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/Microsoft.Sbom.Contracts/Interfaces/IAlgorithmNames.cs
+++ b/src/Microsoft.Sbom.Contracts/Interfaces/IAlgorithmNames.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/Microsoft.Sbom.DotNetTool/Microsoft.Sbom.DotNetTool.csproj
+++ b/src/Microsoft.Sbom.DotNetTool/Microsoft.Sbom.DotNetTool.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Highly scalable and enterprise ready .NET tool to create SBOMs for any variety of artifacts.</Description>

--- a/src/Microsoft.Sbom.Extensions/Entities/ExternalDocumentReferenceInfo.cs
+++ b/src/Microsoft.Sbom.Extensions/Entities/ExternalDocumentReferenceInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/Microsoft.Sbom.Extensions/Entities/FileLocation.cs
+++ b/src/Microsoft.Sbom.Extensions/Entities/FileLocation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Extensions/Entities/GenerationData.cs
+++ b/src/Microsoft.Sbom.Extensions/Entities/GenerationData.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/Microsoft.Sbom.Extensions/Entities/GenerationResult.cs
+++ b/src/Microsoft.Sbom.Extensions/Entities/GenerationResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Extensions/Entities/InternalSBOMFileInfo.cs
+++ b/src/Microsoft.Sbom.Extensions/Entities/InternalSBOMFileInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/Microsoft.Sbom.Extensions/Entities/ManifestData.cs
+++ b/src/Microsoft.Sbom.Extensions/Entities/ManifestData.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/Microsoft.Sbom.Extensions/Entities/ManifestInfo.cs
+++ b/src/Microsoft.Sbom.Extensions/Entities/ManifestInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Extensions/Entities/Relationship.cs
+++ b/src/Microsoft.Sbom.Extensions/Entities/Relationship.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Extensions.Entities;

--- a/src/Microsoft.Sbom.Extensions/Entities/RelationshipType.cs
+++ b/src/Microsoft.Sbom.Extensions/Entities/RelationshipType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Text.Json.Serialization;

--- a/src/Microsoft.Sbom.Extensions/Entities/ResultMetadata.cs
+++ b/src/Microsoft.Sbom.Extensions/Entities/ResultMetadata.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Extensions.Entities;

--- a/src/Microsoft.Sbom.Extensions/IInternalMetadataProvider.cs
+++ b/src/Microsoft.Sbom.Extensions/IInternalMetadataProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Sbom.Extensions.Entities;

--- a/src/Microsoft.Sbom.Extensions/IManifestConfigHandler.cs
+++ b/src/Microsoft.Sbom.Extensions/IManifestConfigHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Extensions;

--- a/src/Microsoft.Sbom.Extensions/IManifestGenerator.cs
+++ b/src/Microsoft.Sbom.Extensions/IManifestGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/Microsoft.Sbom.Extensions/IManifestInterface.cs
+++ b/src/Microsoft.Sbom.Extensions/IManifestInterface.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;

--- a/src/Microsoft.Sbom.Extensions/IManifestToolJsonSerializer.cs
+++ b/src/Microsoft.Sbom.Extensions/IManifestToolJsonSerializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Extensions/IMetadataBuilder.cs
+++ b/src/Microsoft.Sbom.Extensions/IMetadataBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Sbom.Extensions.Entities;

--- a/src/Microsoft.Sbom.Extensions/IMetadataProvider.cs
+++ b/src/Microsoft.Sbom.Extensions/IMetadataProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/Microsoft.Sbom.Extensions/ISbomConfig.cs
+++ b/src/Microsoft.Sbom.Extensions/ISbomConfig.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Extensions/ISbomConfigProvider.cs
+++ b/src/Microsoft.Sbom.Extensions/ISbomConfigProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Extensions/ISbomPackageDetailsRecorder.cs
+++ b/src/Microsoft.Sbom.Extensions/ISbomPackageDetailsRecorder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Sbom.Contracts;

--- a/src/Microsoft.Sbom.Extensions/ISbomParser.cs
+++ b/src/Microsoft.Sbom.Extensions/ISbomParser.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/Microsoft.Sbom.Extensions/ISignValidator.cs
+++ b/src/Microsoft.Sbom.Extensions/ISignValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.InteropServices;

--- a/src/Microsoft.Sbom.Extensions/MetadataKey.cs
+++ b/src/Microsoft.Sbom.Extensions/MetadataKey.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Extensions.Entities;

--- a/src/Microsoft.Sbom.Extensions/Microsoft.Sbom.Extensions.csproj
+++ b/src/Microsoft.Sbom.Extensions/Microsoft.Sbom.Extensions.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>

--- a/src/Microsoft.Sbom.Extensions/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Sbom.Extensions/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Constants.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Constants.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Checksum.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Checksum.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Text.Json.Serialization;

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/CreationInfo.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/CreationInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Creator.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Creator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Enums/ExternalRepositoryType.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Enums/ExternalRepositoryType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics.CodeAnalysis;

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Enums/ReferenceCategory.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Enums/ReferenceCategory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Text.Json.Serialization;

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Enums/SPDXFileType.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Enums/SPDXFileType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Text.Json.Serialization;

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Enums/SPDXRelationshipType.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Enums/SPDXRelationshipType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Text.Json.Serialization;

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/ExternalReference.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/ExternalReference.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Text.Json.Serialization;

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/PackageVerificationCode.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/PackageVerificationCode.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SPDX22Document.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SPDX22Document.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SPDXPackage.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SPDXPackage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SPDXRelationship.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SPDXRelationship.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Text.Json.Serialization;

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SpdxExternalDocumentReference.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SpdxExternalDocumentReference.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Text.Json.Serialization;

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SpdxFile.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SpdxFile.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections;

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Microsoft.Sbom.Parsers.Spdx22SbomParser.csproj
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Microsoft.Sbom.Parsers.Spdx22SbomParser.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <AssemblyName>Microsoft.Sbom.Parsers.Spdx22SbomParser</AssemblyName>

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/CreationInfoParser.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/CreationInfoParser.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/ParserUtils.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/ParserUtils.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/RootPropertiesParser.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/RootPropertiesParser.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/SbomExternalDocumentReferenceParser.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/SbomExternalDocumentReferenceParser.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/SbomFileParser.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/SbomFileParser.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/SbomPackageParser.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/SbomPackageParser.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/SbomRelationshipParser.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/SbomRelationshipParser.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/SPDXParser.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/SPDXParser.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/ParserStateResult.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/ParserStateResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Sbom.Contracts.Enums;

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/SPDXToSbomFormatConverterExtensions.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/SPDXToSbomFormatConverterExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Validator.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Validator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/Microsoft.Sbom.Tool/Microsoft.Sbom.Tool.csproj
+++ b/src/Microsoft.Sbom.Tool/Microsoft.Sbom.Tool.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/test/Microsoft.Sbom.Adapters.Tests/Microsoft.Sbom.Adapters.Tests.csproj
+++ b/test/Microsoft.Sbom.Adapters.Tests/Microsoft.Sbom.Adapters.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>

--- a/test/Microsoft.Sbom.Api.Tests/ApiConfigurationBuilderTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/ApiConfigurationBuilderTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigSanitizerTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigSanitizerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsBase.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForGeneration.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForGeneration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;

--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForValidation.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForValidation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;

--- a/test/Microsoft.Sbom.Api.Tests/Config/SBOMConfigTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/SBOMConfigTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Sbom.Api.Manifest.Configuration;

--- a/test/Microsoft.Sbom.Api.Tests/Config/Validators/DirectoryPathIsWritableValidatorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/Validators/DirectoryPathIsWritableValidatorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Sbom.Api.Config.Validators;

--- a/test/Microsoft.Sbom.Api.Tests/Converters/ComponentToExternalReferenceInfoConverterTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Converters/ComponentToExternalReferenceInfoConverterTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/test/Microsoft.Sbom.Api.Tests/Converters/ExternalReferenceInfoToPathConverterTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Converters/ExternalReferenceInfoToPathConverterTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/test/Microsoft.Sbom.Api.Tests/Converters/SbomToolManifestPathConverterTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Converters/SbomToolManifestPathConverterTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.InteropServices;

--- a/test/Microsoft.Sbom.Api.Tests/Entities/FileValidationResultTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Entities/FileValidationResultTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Sbom.Api.Entities;

--- a/test/Microsoft.Sbom.Api.Tests/Entities/output/ValidationResultGeneratorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Entities/output/ValidationResultGeneratorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/test/Microsoft.Sbom.Api.Tests/Executors/DirectoryWalkerTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/DirectoryWalkerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/test/Microsoft.Sbom.Api.Tests/Executors/ExternalDocumentReferenceWriterTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/ExternalDocumentReferenceWriterTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/test/Microsoft.Sbom.Api.Tests/Executors/FileHasherTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/FileHasherTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/test/Microsoft.Sbom.Api.Tests/Executors/FileListEnumeratorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/FileListEnumeratorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/test/Microsoft.Sbom.Api.Tests/Executors/HashValidatorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/HashValidatorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/test/Microsoft.Sbom.Api.Tests/Executors/RelationshipGeneratorTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/RelationshipGeneratorTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/test/Microsoft.Sbom.Api.Tests/Executors/SPDXSBOMReaderForExternalDocumentReferenceTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/SPDXSBOMReaderForExternalDocumentReferenceTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/test/Microsoft.Sbom.Api.Tests/Filters/DownloadedRootPathFilterTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Filters/DownloadedRootPathFilterTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Sbom.Common;

--- a/test/Microsoft.Sbom.Api.Tests/Filters/ManifestFolderFilterTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Filters/ManifestFolderFilterTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/test/Microsoft.Sbom.Api.Tests/Hashing/HashCodeGeneratorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Hashing/HashCodeGeneratorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/test/Microsoft.Sbom.Api.Tests/Metadata/LocalMetadataProviderTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Metadata/LocalMetadataProviderTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/test/Microsoft.Sbom.Api.Tests/Metadata/SbomApiMetadataProviderTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Metadata/SbomApiMetadataProviderTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/test/Microsoft.Sbom.Api.Tests/Microsoft.Sbom.Api.Tests.csproj
+++ b/test/Microsoft.Sbom.Api.Tests/Microsoft.Sbom.Api.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>

--- a/test/Microsoft.Sbom.Api.Tests/Output/ManifestToolJsonSerializerTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Output/ManifestToolJsonSerializerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/test/Microsoft.Sbom.Api.Tests/PathUtils.cs
+++ b/test/Microsoft.Sbom.Api.Tests/PathUtils.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;

--- a/test/Microsoft.Sbom.Api.Tests/SBOMGeneratorTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/SBOMGeneratorTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/test/Microsoft.Sbom.Api.Tests/SignValidator/SignValidationProviderTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/SignValidator/SignValidationProviderTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/test/Microsoft.Sbom.Api.Tests/TestManifestGenerator.cs
+++ b/test/Microsoft.Sbom.Api.Tests/TestManifestGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/test/Microsoft.Sbom.Api.Tests/TestUtils.cs
+++ b/test/Microsoft.Sbom.Api.Tests/TestUtils.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;

--- a/test/Microsoft.Sbom.Api.Tests/Utils/ExternalReferenceDeduplicatorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Utils/ExternalReferenceDeduplicatorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/test/Microsoft.Sbom.Api.Tests/Utils/FileHashesDictionarySingleton.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Utils/FileHashesDictionarySingleton.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/test/Microsoft.Sbom.Api.Tests/Utils/FileSystemUtilsExtensionTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Utils/FileSystemUtilsExtensionTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Sbom.Common;

--- a/test/Microsoft.Sbom.Api.Tests/Utils/FileTypeUtilsTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Utils/FileTypeUtilsTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Sbom.Api.Utils;

--- a/test/Microsoft.Sbom.Api.Tests/Utils/IdentifierUtilsTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Utils/IdentifierUtilsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/test/Microsoft.Sbom.Api.Tests/Utils/OSUtilsTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Utils/OSUtilsTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections;

--- a/test/Microsoft.Sbom.Api.Tests/Utils/SBOMFileDedeplicatorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Utils/SBOMFileDedeplicatorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/Helpers/RelationshipsArrayGeneratorTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/Helpers/RelationshipsArrayGeneratorTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/SbomParserBasedValidationWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/SbomParserBasedValidationWorkflowTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/ValidationWorkflowTestsBase.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/ValidationWorkflowTestsBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests.csproj
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/GeneratorTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/GeneratorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Sbom.Contracts;

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomFileParserTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomFileParserTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomParserTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomParserTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomRelationshipParserTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomRelationshipParserTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/Strings/ExternalDocumentReferenceStrings.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/Strings/ExternalDocumentReferenceStrings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Parser.Strings;

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/Strings/RelationshipStrings.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/Strings/RelationshipStrings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Parser.Strings;

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/Strings/SbomFileJsonStrings.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/Strings/SbomFileJsonStrings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Parser.Strings;

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/Strings/SbomPackageStrings.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/Strings/SbomPackageStrings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Parser.Strings;

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/Strings/SbomParserStrings.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/Strings/SbomParserStrings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Sbom.Parser.Strings;

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Utils/InternalMetadataProviderIdentityExtensionsTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Utils/InternalMetadataProviderIdentityExtensionsTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;


### PR DESCRIPTION
I noticed that my PR was getting polluted when my IDE automatically removed the BOM from the front of files just because I opened them, so I thought I'd solve that by removing them all in one go.