### PR TITLE
Better default for JsonSerialization

### DIFF
--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/SPDXParser.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Parser/SPDXParser.cs
@@ -59,7 +59,10 @@ public class SPDXParser : ISbomParser
         JsonSerializerOptions? jsonSerializerOptions = null,
         int? bufferSize = null)
     {
-        this.jsonSerializerOptions = jsonSerializerOptions ?? new JsonSerializerOptions();
+        this.jsonSerializerOptions = jsonSerializerOptions ?? new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+        };
         var handlers = new Dictionary<string, PropertyHandler>
         {
             { ReferenceProperty, new PropertyHandler<SpdxExternalDocumentReference>(ParameterType.Array) },

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomFileParserTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomFileParserTests.cs
@@ -30,6 +30,23 @@ public class SbomFileParserTests : SbomParserTestsBase
     }
 
     [TestMethod]
+    public void MetadataPopulates()
+    {
+        var bytes = Encoding.UTF8.GetBytes(SbomFileJsonStrings.GoodJsonWith2FilesString);
+        using var stream = new MemoryStream(bytes);
+
+        var parser = new SPDXParser(stream);
+
+        var results = this.Parse(parser);
+        var metadata = parser.GetMetadata();
+
+        Assert.IsNotNull(metadata);
+        Assert.IsNotNull(metadata.CreationInfo);
+        var expectedTime = DateTime.Parse("2023-05-11T00:24:54Z").ToUniversalTime();
+        Assert.AreEqual(expectedTime, metadata.CreationInfo.Created);
+    }
+
+    [TestMethod]
     public void ParseSbomFilesTest()
     {
         var bytes = Encoding.UTF8.GetBytes(SbomFileJsonStrings.GoodJsonWith2FilesString);

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/Strings/SbomFileJsonStrings.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/Strings/SbomFileJsonStrings.cs
@@ -49,7 +49,13 @@ internal struct SbomFileJsonStrings
                 ],
                 ""copyrightText"": ""NOASSERTION""
             }
-        ], ""packages"": [], ""relationships"": []}";
+        ], ""packages"": [], ""relationships"": [],   ""creationInfo"": {
+    ""created"": ""2023-05-11T00:24:54Z"",
+    ""creators"": [
+      ""Organization: Microsoft"",
+      ""Tool: Microsoft.SBOMTool-1.1.0""
+    ]
+  }}";
 
     public const string MalformedJsonEmptyObjectNoArrayEnd = @"{
             ""files"": [{


### PR DESCRIPTION
The previous default caused CreationInfo to not be properly parsed. This can be fixed by passing your JsonSerializationOptions explicitly (which is how I missed it in testing).