### PR TITLE
Bump sdk, pin dependency versions.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,7 @@
         <PackageVersion Include="Microsoft.ComponentDetection.Detectors" Version="$(ComponentDetectionPackageVersion)" />
         <PackageVersion Include="Microsoft.ComponentDetection.Orchestrator" Version="$(ComponentDetectionPackageVersion)" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0-rc.2.23479.6" />
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
         <PackageVersion Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
         <PackageVersion Include="Microsoft.Extensions.Http" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
         </PackageVersion>
     </ItemDefinitionGroup>
     <PropertyGroup>
-        <ComponentDetectionPackageVersion>4.0.6</ComponentDetectionPackageVersion>
+        <ComponentDetectionPackageVersion>4.0.8</ComponentDetectionPackageVersion>
     </PropertyGroup>
     <ItemGroup>
         <PackageVersion Include="AutoMapper" Version="10.1.1" />
@@ -21,6 +21,7 @@
         <PackageVersion Include="Microsoft.ComponentDetection.Detectors" Version="$(ComponentDetectionPackageVersion)" />
         <PackageVersion Include="Microsoft.ComponentDetection.Orchestrator" Version="$(ComponentDetectionPackageVersion)" />
         <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0-rc.2.23479.6" />
         <PackageVersion Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
         <PackageVersion Include="Microsoft.Extensions.Http" Version="7.0.0" />
         <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100-rc.2.23502.2",
+    "version": "8.0.100",
     "rollForward": "latestMajor"
   }
 }

--- a/src/Microsoft.Sbom.Api/Microsoft.Sbom.Api.csproj
+++ b/src/Microsoft.Sbom.Api/Microsoft.Sbom.Api.csproj
@@ -16,6 +16,7 @@
         <PackageReference Include="Microsoft.ComponentDetection.Detectors" />
         <PackageReference Include="Microsoft.ComponentDetection.Orchestrator" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
         <PackageReference Include="Newtonsoft.Json" />
         <PackageReference Include="NuGet.Configuration" />
         <PackageReference Include="packageurl-dotnet" />

--- a/src/Microsoft.Sbom.Api/PackageDetails/PackageDetailsFactory.cs
+++ b/src/Microsoft.Sbom.Api/PackageDetails/PackageDetailsFactory.cs
@@ -8,6 +8,7 @@ using System.IO;
 using Microsoft.ComponentDetection.Contracts.BcdeModels;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.Sbom.Api.Output.Telemetry;
+using Microsoft.Sbom.Api.Utils;
 using Serilog;
 
 namespace Microsoft.Sbom.Api.PackageDetails;
@@ -34,9 +35,12 @@ public class PackageDetailsFactory : IPackageDetailsFactory
 
     public IDictionary<(string Name, string Version), PackageDetails> GetPackageDetailsDictionary(IEnumerable<ScannedComponent> scannedComponents)
     {
-        var packageDetailsLocations = GetPackageDetailsLocations(scannedComponents);
+        using (recorder.TraceEvent(Events.SBOMParseMetadata))
+        {
+            var packageDetailsLocations = GetPackageDetailsLocations(scannedComponents);
 
-        return ExtractPackageDetailsFromFiles(packageDetailsLocations);
+            return ExtractPackageDetailsFromFiles(packageDetailsLocations);
+        }
     }
 
     private List<string> GetPackageDetailsLocations(IEnumerable<ScannedComponent> scannedComponents)

--- a/src/Microsoft.Sbom.Api/Utils/Events.cs
+++ b/src/Microsoft.Sbom.Api/Utils/Events.cs
@@ -7,6 +7,7 @@ internal static class Events
 {
     #region Generation
     internal const string SBOMGenerationWorkflow = "Total generation time";
+    internal const string SBOMParseMetadata = "Total metadata parsing time";
     internal const string FilesGeneration = "Files generation time";
     internal const string PackagesGeneration = "Packages generation time";
     internal const string RelationshipsGeneration = "Relationships generation time";


### PR DESCRIPTION
Bumps sdk to latest release version of dotnet. Pins dependency that was updated through component-detection update to avoid package downgrade errors (Version in question is coming through a Spectre package in the CD repo which we do not use). The update of CD libraries is to pick up this fix: https://github.com/microsoft/component-detection/issues/862. Also adds timer around package metadata parsing.