### PR TITLE
Fix bug in RubyUtils

### DIFF
--- a/src/Microsoft.Sbom.Api/PackageDetails/ComponentDetailsUtils/RubyGemsUtils.cs
+++ b/src/Microsoft.Sbom.Api/PackageDetails/ComponentDetailsUtils/RubyGemsUtils.cs
@@ -59,11 +59,11 @@ public class RubyGemsUtils : IPackageManagerUtils<RubyGemsUtils>
 
         var fullGemspecPath = Path.Join(gemspecLocation, gemspecFileName);
 
-        gemspecLocation = Path.GetFullPath(fullGemspecPath);
+        fullGemspecPath = Path.GetFullPath(fullGemspecPath);
 
         if (fileSystemUtils.FileExists(fullGemspecPath))
         {
-            return gemspecLocation;
+            return fullGemspecPath;
         }
         else
         {


### PR DESCRIPTION
The wrong variable was being modified causing the else condition to always fail and throw an exception if the metadata file was not found in the base directory.