### PR TITLE
Fix IsSuccess return value in SBOMValidator

### DIFF
--- a/src/Microsoft.Sbom.Api/SBOMValidator.cs
+++ b/src/Microsoft.Sbom.Api/SBOMValidator.cs
@@ -107,7 +107,7 @@ public class SbomValidator : ISBOMValidator
         await recorder.FinalizeAndLogTelemetryAsync();
 
         var errors = recorder.Errors.Select(error => error.ToEntityError()).ToList();
-        return new SBOMValidationResult(errors.Any(), errors);
+        return new SBOMValidationResult(!errors.Any(), errors);
     }
 
     private InputConfiguration ValidateConfig(InputConfiguration config)


### PR DESCRIPTION
The current return value is flipped from what it should be.