### PR TITLE
Refresh SbomConfigProvider when config values change

### DIFF
--- a/src/Microsoft.Sbom.Api/Config/Extensions/ConfigurationExtensions.cs
+++ b/src/Microsoft.Sbom.Api/Config/Extensions/ConfigurationExtensions.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Sbom.Api.Config.Extensions;
 /// </summary>
 public static class ConfigurationExtensions
 {
+    public static int Version = 0;
+
     /// <summary>
     /// Get the name and value of each IConfiguration property that is annotated with <see cref=ComponentDetectorArgumentAttribute />.
     /// </summary>
@@ -53,8 +55,11 @@ public static class ConfigurationExtensions
     }
 
     // Map the validated InputConfiguration to a Configuration, which will persist the mapping statically and globally
-    public static Configuration ToConfiguration(this InputConfiguration inputConfig) =>
-        new MapperConfiguration(cfg => cfg.CreateMap<InputConfiguration, Configuration>())
+    public static Configuration ToConfiguration(this InputConfiguration inputConfig)
+    {
+        Version++;
+        return new MapperConfiguration(cfg => cfg.CreateMap<InputConfiguration, Configuration>())
             .CreateMapper()
             .Map<Configuration>(inputConfig);
+    }
 }

--- a/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfigProvider.cs
+++ b/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfigProvider.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Sbom.Api.Config.Extensions;
 using Microsoft.Sbom.Api.Metadata;
 using Microsoft.Sbom.Api.Output.Telemetry;
 using Microsoft.Sbom.Common.Extensions;
@@ -26,6 +27,13 @@ public class SbomConfigProvider : ISbomConfigProvider
     {
         get
         {
+            // Config has been updated, so we need to update the manifest information
+            if (configVersion != ConfigurationExtensions.Version)
+            {
+                configVersion = ConfigurationExtensions.Version;
+                configsDictionary = null;
+            }
+
             if (configsDictionary is not null)
             {
                 // Exit fast if config map is already initialized.
@@ -72,6 +80,7 @@ public class SbomConfigProvider : ISbomConfigProvider
     private readonly IEnumerable<IMetadataProvider> metadataProviders;
     private readonly ILogger logger;
     private readonly IRecorder recorder;
+    private int configVersion;
 
     public SbomConfigProvider(
         IEnumerable<IManifestConfigHandler> manifestConfigHandlers,
@@ -83,6 +92,7 @@ public class SbomConfigProvider : ISbomConfigProvider
         this.metadataProviders = metadataProviders ?? throw new ArgumentNullException(nameof(metadataProviders));
         this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
         this.recorder = recorder ?? throw new ArgumentNullException(nameof(recorder));
+        this.configVersion = ConfigurationExtensions.Version;
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
Currently SbomConfigProvider doesn't pick up updated config values when the global Configuration changes. 