### PR TITLE
Add link to component detection arguments

### DIFF
--- a/docs/sbom-tool-arguments.md
+++ b/docs/sbom-tool-arguments.md
@@ -57,7 +57,7 @@ Actions
                                               fails, the SBOM generation fails.
     PackageSupplier (-ps)                     Supplier of the package that this SBOM represents.
     DockerImagesToScan (-di)                  Comma separated list of docker image names or hashes to be scanned for packages, ex: ubuntu:16.04, 56bab49eef2ef07505f6a1b0d5bd3a601dfc3c76ad4460f24c91d6fa298369ab.
-    AdditionalComponentDetectorArgs (-cd)     Additional set of arguments for Component Detector.  An appropriate usage of this would be a space-delimited list of `--key value` pairs, representing command-line
+    AdditionalComponentDetectorArgs (-cd)     Additional set of arguments for Component Detector.  An appropriate usage of this would be a space-delimited list of `--key value` pairs, representing command-line arguments. See the component-detection repository for a list of valid arguments (https://github.com/microsoft/component-detection/blob/main/docs/detector-arguments.md).
                                               switches.
     ExternalDocumentReferenceListFile (-er)   The path to a file containing a list of external SBOMs that will be included as external document reference in the output SBOM. SPDX 2.2 is the only supported
                                               format for now.


### PR DESCRIPTION
Our tool supports command-line parameters to the component detection tool, but nowhere in this repo do we document or have a link to what additional parameters are allowed (except --DirectoryExcludeList, which is only mentioned in sbom-tool-cli.md and not easy to find). This PR adds a link to the component detection tool's readme in sbom-tool-arguments.md (the page which is linked from the main readme) where the AdditionalComponentDetectorArgs parameter is described.