### PR TITLE
Fix style errors in build

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -81,9 +81,9 @@ dotnet_analyzer_diagnostic.severity = warning
 # https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules#net-style-rules
 [*.{cs,csx,cake,vb,vbx}]
 # "this." and "Me." qualifiers
-dotnet_style_qualification_for_field = true:warning
-dotnet_style_qualification_for_property = true:warning
-dotnet_style_qualification_for_method = true:warning
+dotnet_style_qualification_for_field = true
+dotnet_style_qualification_for_property = true
+dotnet_style_qualification_for_method = true
 dotnet_style_qualification_for_event = true:warning
 # Language keywords instead of framework type names for type references
 dotnet_style_predefined_type_for_locals_parameters_members = true:warning
@@ -100,7 +100,7 @@ dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:warning
 dotnet_style_parentheses_in_other_operators = never_if_unnecessary:warning
 # Expression-level preferences
 dotnet_style_object_initializer = true:warning
-dotnet_style_collection_initializer = true:warning
+dotnet_style_collection_initializer = true
 dotnet_style_explicit_tuple_names = true:warning
 dotnet_style_prefer_inferred_tuple_names = true:warning
 dotnet_style_prefer_inferred_anonymous_type_member_names = true:warning
@@ -132,13 +132,13 @@ csharp_style_var_for_built_in_types = true:warning
 csharp_style_var_when_type_is_apparent = true:warning
 csharp_style_var_elsewhere = true:warning
 # Expression-bodied members
-csharp_style_expression_bodied_methods = true:warning
-csharp_style_expression_bodied_constructors = true:warning
-csharp_style_expression_bodied_operators = true:warning
-csharp_style_expression_bodied_properties = true:warning
+csharp_style_expression_bodied_methods = true
+csharp_style_expression_bodied_constructors = true
+csharp_style_expression_bodied_operators = true
+csharp_style_expression_bodied_properties = true
 csharp_style_expression_bodied_indexers = true:warning
-csharp_style_expression_bodied_accessors = true:warning
-csharp_style_expression_bodied_lambdas = true:warning
+csharp_style_expression_bodied_accessors = true
+csharp_style_expression_bodied_lambdas = true
 csharp_style_expression_bodied_local_functions = true:warning
 # Pattern matching preferences
 csharp_style_pattern_matching_over_is_with_cast_check = true:warning
@@ -153,7 +153,7 @@ csharp_style_pattern_local_over_anonymous_function = true:warning
 csharp_style_deconstructed_variable_declaration = true:warning
 csharp_style_prefer_index_operator = true:warning
 csharp_style_prefer_range_operator = true:warning
-csharp_style_implicit_object_creation_when_type_is_apparent = true:warning
+csharp_style_implicit_object_creation_when_type_is_apparent = true
 # "Null" checking preferences
 csharp_style_throw_expression = true:warning
 csharp_style_conditional_delegate_call = true:warning
@@ -162,7 +162,7 @@ csharp_prefer_braces = true:warning
 csharp_prefer_simple_using_statement = true:suggestion
 dotnet_diagnostic.IDE0063.severity = suggestion
 # 'using' directive preferences
-csharp_using_directive_placement = inside_namespace:warning
+csharp_using_directive_placement = inside_namespace
 # Modifier preferences
 csharp_prefer_static_local_function = true:warning
 
@@ -1069,7 +1069,12 @@ dotnet_diagnostic.IDE1006.severity = suggestion
 # IL3000: Avoid accessing Assembly file path when publishing as a single file
 dotnet_diagnostic.IL3000.severity = suggestion
 
-#IDE0305: Collection initialization can be simplified
+# IDE0301: Use collection expression for empty
+# Justification: The suggestion leads to a styling error. Collection expressions are new with dotnet 8 and are not compatible with dotnet 6.
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0301
+dotnet_diagnostic.IDE0301.severity = none
+
+# IDE0305: Collection initialization can be simplified
 # Justification: The suggestion leads to a styling error. This suggestion is new to .NET8 and performance issues have been reported with it although fixes have been made we should hold on until full release https://github.com/dotnet/roslyn/issues/69988.
 # https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0305
 dotnet_diagnostic.IDE0305.severity = none


### PR DESCRIPTION
Last month, a [regression in the dotnet SDK](https://github.com/dotnet/roslyn/issues/72094) caused our builds to start breaking due to style errors that [should have been silenced](https://github.com/microsoft/sbom-tool/issues/340). This PR uses a [known workaround](https://github.com/dotnet/roslyn/issues/52991#issuecomment-1960692440) (setting properties related to the failing style rules to `true` instead of `true:warning`. This will not interfere with the workflow described in #340 (i.e. removing the line `dotnet_diagnostic.RULE_ID.severity = suggestion` will re-enable the rule as expected).

This PR does silence one rule that was not previously silenced, because it refers to a language feature new to dotnet 8, and we build for both dotnet 8 and dotnet 6.