### PR TITLE
Remove an unneeded comment (formatted as a heading) in documentation

### DIFF
--- a/docs/setting-up-github-actions.md
+++ b/docs/setting-up-github-actions.md
@@ -82,8 +82,6 @@ Since the sbom tool will place the final SBOM file in the build drop folder (`bu
 
 This line of code produces a SBOM file with the same information as the GitHub Action.
 
-## The information being conveyed in this sentence needs clarification.  What is the reader  learn from "With the above our SBOM has the same retention as the build artifacts for the GitHub Action."
-
 ## Further reading
 
 If the organization or team stores the SBOM in a centrally-controlled repository, use the `-manifestDirPath` parameter to specify the intended folder location for the SBOM output file.


### PR DESCRIPTION
Seems to have been added in #392 .