### PR TITLE
fix: Improve visibility of logging from inside exception handlers

### DIFF
--- a/src/Microsoft.Sbom.Api/Converters/ComponentToExternalReferenceInfoConverter.cs
+++ b/src/Microsoft.Sbom.Api/Converters/ComponentToExternalReferenceInfoConverter.cs
@@ -43,7 +43,7 @@ public class ComponentToExternalReferenceInfoConverter
                 }
                 catch (Exception e)
                 {
-                    log.Debug($"Encountered an error while converting SBOM component {scannedComponent.Component.Id} to external reference: {e.Message}");
+                    log.Warning($"Encountered an error while converting SBOM component {scannedComponent.Component.Id} to external reference: {e.Message}");
                     await errors.Writer.WriteAsync(new FileValidationResult
                     {
                         ErrorType = Entities.ErrorType.PackageError,

--- a/src/Microsoft.Sbom.Api/Converters/ExternalReferenceInfoToPathConverter.cs
+++ b/src/Microsoft.Sbom.Api/Converters/ExternalReferenceInfoToPathConverter.cs
@@ -53,7 +53,7 @@ public class ExternalReferenceInfoToPathConverter
                 }
                 catch (Exception e)
                 {
-                    log.Debug($"Encountered an error while converting external reference {externalDocumentRef.ExternalDocumentName} to path: {e.Message}");
+                    log.Warning($"Encountered an error while converting external reference {externalDocumentRef.ExternalDocumentName} to path: {e.Message}");
                     await errors.Writer.WriteAsync(new FileValidationResult
                     {
                         ErrorType = ErrorType.Other,

--- a/src/Microsoft.Sbom.Api/Executors/ComponentToPackageInfoConverter.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ComponentToPackageInfoConverter.cs
@@ -66,7 +66,7 @@ public class ComponentToPackageInfoConverter
                 }
                 catch (Exception e)
                 {
-                    log.Debug($"Encountered an error while processing package {scannedComponent.Component.Id}: {e.Message}");
+                    log.Warning($"Encountered an error while processing package {scannedComponent.Component.Id}: {e.Message}");
                     await errors.Writer.WriteAsync(new FileValidationResult
                     {
                         ErrorType = ErrorType.PackageError,

--- a/src/Microsoft.Sbom.Api/Executors/DirectoryWalker.cs
+++ b/src/Microsoft.Sbom.Api/Executors/DirectoryWalker.cs
@@ -69,7 +69,7 @@ public class DirectoryWalker
             }
             catch (Exception e)
             {
-                log.Debug($"Encountered an unknown error for {path}: {e.Message}");
+                log.Warning($"Encountered an unknown error for {path}: {e.Message}");
                 await errors.Writer.WriteAsync(new FileValidationResult
                 {
                     ErrorType = ErrorType.Other,

--- a/src/Microsoft.Sbom.Api/Executors/EnumeratorChannel.cs
+++ b/src/Microsoft.Sbom.Api/Executors/EnumeratorChannel.cs
@@ -44,7 +44,7 @@ public class EnumeratorChannel
             }
             catch (Exception e)
             {
-                log.Debug($"Encountered an unknown error while enumerating: {e.Message}");
+                log.Warning($"Encountered an unknown error while enumerating: {e.Message}");
                 await errors.Writer.WriteAsync(new FileValidationResult
                 {
                     ErrorType = ErrorType.Other

--- a/src/Microsoft.Sbom.Api/Executors/FileFilterer.cs
+++ b/src/Microsoft.Sbom.Api/Executors/FileFilterer.cs
@@ -96,7 +96,7 @@ public class FileFilterer
         }
         catch (Exception e)
         {
-            log.Debug($"Encountered an error while filtering file {file.Path}: {e.Message}");
+            log.Warning($"Encountered an error while filtering file {file.Path}: {e.Message}");
             await errors.Writer.WriteAsync(new FileValidationResult
             {
                 ErrorType = ErrorType.Other,

--- a/src/Microsoft.Sbom.Api/Executors/FileInfoWriter.cs
+++ b/src/Microsoft.Sbom.Api/Executors/FileInfoWriter.cs
@@ -81,7 +81,7 @@ public class FileInfoWriter
         }
         catch (Exception e)
         {
-            log.Debug($"Encountered an error while generating json for file {sbomFile.Path}: {e.Message}");
+            log.Warning($"Encountered an error while generating json for file {sbomFile.Path}: {e.Message}");
             await errors.Writer.WriteAsync(new FileValidationResult
             {
                 ErrorType = ErrorType.JsonSerializationError,

--- a/src/Microsoft.Sbom.Api/Executors/ManifestFileFilterer.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ManifestFileFilterer.cs
@@ -69,7 +69,7 @@ public class ManifestFileFilterer
                 }
                 catch (Exception e)
                 {
-                    log.Debug($"Encountered an error while filtering file {manifestFile} from the manifest: {e.Message}");
+                    log.Warning($"Encountered an error while filtering file {manifestFile} from the manifest: {e.Message}");
                     await errors.Writer.WriteAsync(new FileValidationResult
                     {
                         ErrorType = ErrorType.Other,

--- a/src/Microsoft.Sbom.Api/Executors/ManifestFolderFilterer.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ManifestFolderFilterer.cs
@@ -66,7 +66,7 @@ public class ManifestFolderFilterer
         }
         catch (Exception e)
         {
-            log.Debug($"Encountered an error while filtering file {file}: {e.Message}");
+            log.Warning($"Encountered an error while filtering file {file}: {e.Message}");
             await errors.Writer.WriteAsync(new FileValidationResult
             {
                 ErrorType = ErrorType.Other,

--- a/src/Microsoft.Sbom.Api/Executors/PackageInfoJsonWriter.cs
+++ b/src/Microsoft.Sbom.Api/Executors/PackageInfoJsonWriter.cs
@@ -72,7 +72,7 @@ public class PackageInfoJsonWriter
         }
         catch (Exception e)
         {
-            log.Debug($"Encountered an error while generating json for packageInfo {packageInfo}: {e.Message}");
+            log.Warning($"Encountered an error while generating json for packageInfo {packageInfo}: {e.Message}");
             await errors.Writer.WriteAsync(new FileValidationResult
             {
                 ErrorType = ErrorType.JsonSerializationError,

--- a/src/Microsoft.Sbom.Api/Executors/SPDXSBOMReaderForExternalDocumentReference.cs
+++ b/src/Microsoft.Sbom.Api/Executors/SPDXSBOMReaderForExternalDocumentReference.cs
@@ -106,7 +106,7 @@ public class SPDXSBOMReaderForExternalDocumentReference : ISBOMReaderForExternal
                     }
                     catch (HashGenerationException e)
                     {
-                        log.Debug($"Encountered an error while generating hash for file {file}: {e.Message}");
+                        log.Warning($"Encountered an error while generating hash for file {file}: {e.Message}");
                         await errors.Writer.WriteAsync(new FileValidationResult
                         {
                             ErrorType = ErrorType.Other,
@@ -115,7 +115,7 @@ public class SPDXSBOMReaderForExternalDocumentReference : ISBOMReaderForExternal
                     }
                     catch (Exception e)
                     {
-                        log.Debug($"Encountered an error while generating externalDocumentReferenceInfo from file {file}: {e.Message}");
+                        log.Warning($"Encountered an error while generating externalDocumentReferenceInfo from file {file}: {e.Message}");
                         await errors.Writer.WriteAsync(new FileValidationResult
                         {
                             ErrorType = ErrorType.Other,

--- a/src/Microsoft.Sbom.Api/Output/MetadataBuilder.cs
+++ b/src/Microsoft.Sbom.Api/Output/MetadataBuilder.cs
@@ -60,7 +60,7 @@ public class MetadataBuilder : IMetadataBuilder
         catch (NotSupportedException)
         {
             headerName = null;
-            logger.Debug("Files array not suppored on this SBOM format.");
+            logger.Warning("Files array not suppored on this SBOM format.");
             return false;
         }
     }
@@ -75,7 +75,7 @@ public class MetadataBuilder : IMetadataBuilder
         catch (NotSupportedException)
         {
             headerName = null;
-            logger.Debug("Packages array not suppored on this SBOM format.");
+            logger.Warning("Packages array not suppored on this SBOM format.");
             return false;
         }
     }
@@ -90,7 +90,7 @@ public class MetadataBuilder : IMetadataBuilder
         catch (NotSupportedException)
         {
             headerName = null;
-            logger.Debug("External Document Reference array not suppored on this SBOM format.");
+            logger.Warning("External Document Reference array not suppored on this SBOM format.");
             return false;
         }
     }
@@ -112,7 +112,7 @@ public class MetadataBuilder : IMetadataBuilder
         catch (NotSupportedException)
         {
             generationResult = null;
-            logger.Debug("Root package serialization not supported on this SBOM format.");
+            logger.Warning("Root package serialization not supported on this SBOM format.");
             return false;
         }
     }
@@ -127,7 +127,7 @@ public class MetadataBuilder : IMetadataBuilder
         catch (NotSupportedException)
         {
             headerName = null;
-            logger.Debug("Relationships array are not supported on this SBOM format.");
+            logger.Warning("Relationships array are not supported on this SBOM format.");
             return false;
         }
     }


### PR DESCRIPTION
https://github.com/microsoft/dropvalidator/issues/874 calls out some scenarios where error messages were being logged only at Debug verbosity. This PR changes all `ILogger.Debug` calls in exception handlers to `ILogger.Warning` to increase the visibility.
