### PR TITLE
fix: Don't display a warning if an output folder is specified

### DIFF
--- a/src/Microsoft.Sbom.Api/Config/Validators/DirectoryExistsValidator.cs
+++ b/src/Microsoft.Sbom.Api/Config/Validators/DirectoryExistsValidator.cs
@@ -32,6 +32,11 @@ public class DirectoryExistsValidator : ConfigValidator
                 && paramValue is string value
                 && !string.IsNullOrEmpty(value))
             {
+                if (fileSystemUtils.FileExists(value))
+                {
+                    throw new ValidationArgException($"{paramName} '{value}' must be a directory, not a file");
+                }
+
                 if (!fileSystemUtils.DirectoryExists(value))
                 {
                     throw new ValidationArgException($"{paramName} directory not found for '{value}'");

--- a/src/Microsoft.Sbom.Api/Workflows/SBOMGenerationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SBOMGenerationWorkflow.cs
@@ -91,7 +91,7 @@ public class SbomGenerationWorkflow : IWorkflow<SbomGenerationWorkflow>
                 }
                 else
                 {
-                    log.Warning("Manifest directory path was explicitly defined. Will not attempt to delete any existing _manifest directory.");
+                    log.Information("Manifest directory path was explicitly defined. Will not attempt to delete any existing _manifest directory.");
                 }
 
                 await using (sbomConfigs.StartJsonSerializationAsync())


### PR DESCRIPTION
As called out in https://github.com/microsoft/sbom-tool/issues/500, the code returns a warning if the manifest output folder is explicitly specified by the `-m` parameter. Logging a warning for normal and supported operation is bad form. It was causing grief for a team that wanted to control the output location but had a zero-warning policy on their pipeline.

Side note: The default verbosity level for logging (defined at https://github.com/microsoft/sbom-tool/blob/main/src/Microsoft.Sbom.Common/Constants.cs#L16) is `Warning`, so this message will only be displayed if a non-default verbosity is specified. Presumably a higher verbosity would be the first diagnostic step if a problem were to occur, so this feels unlikely to cause any real-world problems.