### PR TITLE
fix: Improve error if a file is passed as directory parameter

### DIFF
--- a/src/Microsoft.Sbom.Api/Config/Validators/DirectoryExistsValidator.cs
+++ b/src/Microsoft.Sbom.Api/Config/Validators/DirectoryExistsValidator.cs
@@ -32,6 +32,11 @@ public class DirectoryExistsValidator : ConfigValidator
                 && paramValue is string value
                 && !string.IsNullOrEmpty(value))
             {
+                if (fileSystemUtils.FileExists(value))
+                {
+                    throw new ValidationArgException($"{paramName} '{value}' must be a directory, not a file");
+                }
+
                 if (!fileSystemUtils.DirectoryExists(value))
                 {
                     throw new ValidationArgException($"{paramName} directory not found for '{value}'");


### PR DESCRIPTION
As called out in https://github.com/microsoft/sbom-tool/issues/522, our error message when a file is passed into an argument that is expected to be a directory can be improved. The bug was filed specifically against `BuildDropPath`, but the same problem exists for any parameter with the `[DirectoryExists]` attribute, so we also need to address the problem with the `BuildComponentPath` and `ManifestDirPath` arguments.

The fix is simple--we add a check to determine if the provided path is a file, then display an actionable error message. Here are the error messages of 3 runs where I intentionally passed in a file instead of a folder:

`BuildDropPath 'D:\a\_work\1\a\File.zip' must be a directory, not a file`

`BuildComponentPath 'D:\a\_work\1\a\File.zip' must be a directory, not a file`

`ManifestDirPath 'D:\a\_work\1\a\File.zip' must be a directory, not a file`