### PR TITLE
fix: Return failing error code on invalid parameter

### DIFF
--- a/src/Microsoft.Sbom.Tool/Program.cs
+++ b/src/Microsoft.Sbom.Tool/Program.cs
@@ -37,6 +37,7 @@ internal class Program
         var result = await Args.InvokeActionAsync<SbomToolCmdRunner>(args);
         if (result.HandledException != null || (result.ActionArgs is not CommonArgs))
         {
+            Environment.ExitCode = (int)ExitCode.GeneralError;
             return;
         }
 
@@ -73,6 +74,7 @@ internal class Program
                         .AddSbomTool();
                 })
                 .RunConsoleAsync(x => x.SuppressStatusMessages = true);
+            Environment.ExitCode = (int)ExitCode.Success;
         }
         catch (AccessDeniedValidationArgException e)
         {


### PR DESCRIPTION
As called out in https://github.com/microsoft/sbom-tool/issues/520, the sbom generation tool is a little inconsistent in how it handles return codes, returning a value of 0 if invalid parameters are passed in. This PR adds 2 lines to explicitly set the return values after displaying help or after successful completion. The successful completion is probably not necessary since we're setting to the default value, but being explicit here is low cost and makes the code (IMO) a little clearer. There was no obvious need to have a specific error code for invalid parameters, so we reuse `ExitCode.GeneralError` for this case. It's trivial to add a different error code if we later decide that we need to expose more information.

Testing was simple--I ran the following script to launch the app and capture the return code. This needs to be a .bat file
```
@echo off
Microsoft.Sbom.DotNetTool.exe
echo %ERRORLEVEL%
```

Before the change, `ERRORLEVEL` is 0. After the change, `ERRORLEVEL` is 1

I also tested it with correct parameters and ensured that `ERRORLEVEL` was correctly set to 0
