### PR TITLE
chore: Output failure telemetry if signing validation fails

### DIFF
--- a/src/Microsoft.Sbom.Api/Entities/ErrorType.cs
+++ b/src/Microsoft.Sbom.Api/Entities/ErrorType.cs
@@ -44,5 +44,8 @@ public enum ErrorType
     ReferencedSbomFile = 10,
 
     [EnumMember(Value = "No packages found")]
-    NoPackagesFound = 11
+    NoPackagesFound = 11,
+
+    [EnumMember(Value = "Manifest file signing error")]
+    ManifestFileSigningError = 12
 }

--- a/src/Microsoft.Sbom.Api/Workflows/SBOMParserBasedValidationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SBOMParserBasedValidationWorkflow.cs
@@ -88,6 +88,7 @@ public class SbomParserBasedValidationWorkflow : IWorkflow<SbomParserBasedValida
                         if (!signValidator.Validate())
                         {
                             log.Error("Sign validation failed.");
+                            validFailures = new List<FileValidationResult> { new FileValidationResult { ErrorType = ErrorType.ManifestFileSigningError } };
                             return false;
                         }
                     }
@@ -190,7 +191,7 @@ public class SbomParserBasedValidationWorkflow : IWorkflow<SbomParserBasedValida
 
     private void LogIndividualFileResults(IEnumerable<FileValidationResult> validFailures)
     {
-        if (validFailures == null)
+        if (validFailures == null || validFailures.Any(v => v.ErrorType == ErrorType.ManifestFileSigningError))
         {
             // We failed to generate the output due to a workflow error.
             return;
@@ -232,7 +233,7 @@ public class SbomParserBasedValidationWorkflow : IWorkflow<SbomParserBasedValida
 
     private void LogResultsSummary(ValidationResult validationResultOutput, IEnumerable<FileValidationResult> validFailures)
     {
-        if (validationResultOutput == null || validFailures == null)
+        if (validationResultOutput == null || validFailures == null || validFailures.Any(v => v.ErrorType == ErrorType.ManifestFileSigningError))
         {
             // We failed to generate the output due to a workflow error.
             return;


### PR DESCRIPTION
As called out in https://github.com/microsoft/sbom-tool/issues/501, telemetry is reporting success even if the manifest signing check fails. This PR fixes this via the following additions:

1. Add a new failure type so that we can appropriately distinguish this failure case from other failure cases
2. When a signing failure occurs, capture the failure in `validFailures`. This will be used in the `finally` block to capture the telemetry results
3. Extend the "this is an error" cases in `LogResultsSummary` and `LogIndividualFileResults` so that we don't generate unhelpful log output after signing validation fails

Tested locally by forcing the signing failure in the debugger and observing the rest of the execution. The resulting telemetry log reports the error as follows:
```
{
  "Result": "Failure",
  "Errors": {
    "Count": 1,
    "Errors": [
      {
        "Path": null,
        "ErrorType": "ManifestFileSigningError"
      }
    ]
  },
  // Other properties have been omitted for brevity
}
```

I left the `Path` field blank, since it wasn't available in the scope of this function and since it can be inferred from the `Parameters` object that exists in the raw file but that I omitted for brevity.