### PR TITLE
fix: Add logging to Windows permissions checks

### DIFF
--- a/src/Microsoft.Sbom.Common/FileSystemUtilsProvider.cs
+++ b/src/Microsoft.Sbom.Common/FileSystemUtilsProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.InteropServices;
+using Serilog;
 
 namespace Microsoft.Sbom.Common;
 
@@ -15,10 +16,11 @@ public static class FileSystemUtilsProvider
     /// This is important due to the different file systems of operating systems.
     /// </summary>
     /// <param name="context"></param>
+    /// <param name="logger">Logger to capture Exceptions</param>
     /// <returns></returns>
-    public static IFileSystemUtils CreateInstance()
+    public static IFileSystemUtils CreateInstance(ILogger logger)
     {
         var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-        return isWindows ? new WindowsFileSystemUtils() : new UnixFileSystemUtils();
+        return isWindows ? new WindowsFileSystemUtils(logger) : new UnixFileSystemUtils();
     }
 }

--- a/src/Microsoft.Sbom.Common/WindowsFileSystemUtils.cs
+++ b/src/Microsoft.Sbom.Common/WindowsFileSystemUtils.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Security.AccessControl;
 using System.Security.Principal;
+using Serilog;
 
 /// <summary>
 /// Wrapper around file system functions. Used for unit testing.
@@ -17,6 +18,18 @@ using System.Security.Principal;
 [SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "This is a Windows only implementation")]
 public class WindowsFileSystemUtils : FileSystemUtils
 {
+    private readonly ILogger logger;
+
+    /// <summary>
+    /// Constructor for <see cref="WindowsFileSystemUtils"/>.
+    /// </summary>
+    /// <param name="logger">Logger to capture any exceptions</param>
+    /// <exception cref="ArgumentNullException"></exception>
+    public WindowsFileSystemUtils(ILogger logger)
+    {
+        this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
     /// <inheritdoc />
     public override bool DirectoryHasReadPermissions(string directoryPath) => this.DirectoryHasRights(directoryPath, FileSystemRights.Read);
 
@@ -49,9 +62,9 @@ public class WindowsFileSystemUtils : FileSystemUtils
                 return accessRules;
             }
         }
-        catch (Exception)
+        catch (Exception e)
         {
-            // TODO Add logger with debug
+            logger.Warning("Unable to obtain directory rights. Exception = {Exception}", e);
             return false;
         }
     }


### PR DESCRIPTION
As called out in https://github.com/microsoft/sbom-tool/issues/444, we need to provide a little more help in debugging some directory permission failures. This PR adds an `ILogger` to the `WindowsFileSystemUtils` class, so that we can log the Exceptions that are caught in that class. 

There was a //TODO in the original code, suggesting that we would log this at `Debug` level. This makes total sense, but I encountered a problem when testing this--the `Config` that exposes the user-configured verbosity level only becomes available _after_ we need to create the `WindowsFileSystemUtils`, and none of the variations I tried were successful in altering that order. Due to this, I opted to log the error at `Warning` level, so that it would show up with the default settings but not show up as the key problem.

Testing
I inserted a test Exception inside the `DirectoryHasRights` method and tested locally to confirm that the Exception appears as a warning in the output. I then removed the test Exception and tested the following scenarios locally to ensure that our "expected" scenarios work without displaying an additional Exception:
- Trying to write to a protected directory (C:\Windows)
- Trying to write to a non-existent directory (C:\NotThere)
- Trying to write to a non-existent network drive (Q:\)
- Trying to write to a non-existent UNC path (\\FOO\BAR)

The net result is that the new warning displays only in cases where an Exception is thrown inside `WindowsFileSystemUtils.DirectoryHasRights`. Flow continues as it did before.