### PR TITLE
fix: Improve case-sensitive handling

### DIFF
--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/FilesValidator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/FilesValidator.cs
@@ -94,6 +94,17 @@ public class FilesValidator
                 continue;
             }
 
+            if (file.Value == null)
+            {
+                // This generally means that we have case variations in the file names.
+                failures.Add(file.Key, new FileValidationResult
+                {
+                    ErrorType = ErrorType.AdditionalFile,
+                    Path = file.Key,
+                });
+                continue;
+            }
+
             switch (file.Value.FileLocation)
             {
                 case FileLocation.OnDisk:

--- a/src/Microsoft.Sbom.Api/Workflows/SBOMParserBasedValidationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SBOMParserBasedValidationWorkflow.cs
@@ -43,8 +43,9 @@ public class SbomParserBasedValidationWorkflow : IWorkflow<SbomParserBasedValida
     private readonly ValidationResultGenerator validationResultGenerator;
     private readonly IOutputWriter outputWriter;
     private readonly IFileSystemUtils fileSystemUtils;
+    private readonly IOSUtils osUtils;
 
-    public SbomParserBasedValidationWorkflow(IRecorder recorder, ISignValidationProvider signValidationProvider, ILogger log, IManifestParserProvider manifestParserProvider, IConfiguration configuration, ISbomConfigProvider sbomConfigs, FilesValidator filesValidator, ValidationResultGenerator validationResultGenerator, IOutputWriter outputWriter, IFileSystemUtils fileSystemUtils)
+    public SbomParserBasedValidationWorkflow(IRecorder recorder, ISignValidationProvider signValidationProvider, ILogger log, IManifestParserProvider manifestParserProvider, IConfiguration configuration, ISbomConfigProvider sbomConfigs, FilesValidator filesValidator, ValidationResultGenerator validationResultGenerator, IOutputWriter outputWriter, IFileSystemUtils fileSystemUtils, IOSUtils osUtils)
     {
         this.recorder = recorder ?? throw new ArgumentNullException(nameof(recorder));
         this.signValidationProvider = signValidationProvider ?? throw new ArgumentNullException(nameof(signValidationProvider));
@@ -56,6 +57,7 @@ public class SbomParserBasedValidationWorkflow : IWorkflow<SbomParserBasedValida
         this.validationResultGenerator = validationResultGenerator ?? throw new ArgumentNullException(nameof(validationResultGenerator));
         this.outputWriter = outputWriter ?? throw new ArgumentNullException(nameof(outputWriter));
         this.fileSystemUtils = fileSystemUtils ?? throw new ArgumentNullException(nameof(fileSystemUtils));
+        this.osUtils = osUtils ?? throw new ArgumentNullException(nameof(osUtils));
     }
 
     public async Task<bool> RunAsync()
@@ -197,9 +199,15 @@ public class SbomParserBasedValidationWorkflow : IWorkflow<SbomParserBasedValida
             return;
         }
 
+        var caseSensitiveComment = validFailures.Any() && this.osUtils.IsCaseSensitiveOS() ?
+            string.Empty :
+            "\r\n  Note: If the manifest file was originally created using a" +
+            "\r\n        case-sensitive OS, you may also need to validate it" +
+            "\r\n        using a case-sensitive OS.";
+
         Console.WriteLine(string.Empty);
         Console.WriteLine("------------------------------------------------------------");
-        Console.WriteLine("Individual file validation results");
+        Console.WriteLine($"Individual file validation results{caseSensitiveComment}");
         Console.WriteLine("------------------------------------------------------------");
         Console.WriteLine(string.Empty);
 

--- a/src/Microsoft.Sbom.Common/IOSUtils.cs
+++ b/src/Microsoft.Sbom.Common/IOSUtils.cs
@@ -15,4 +15,6 @@ public interface IOSUtils
     StringComparer GetFileSystemStringComparer();
 
     StringComparison GetFileSystemStringComparisonType();
+
+    bool IsCaseSensitiveOS();
 }

--- a/src/Microsoft.Sbom.Common/OSUtils.cs
+++ b/src/Microsoft.Sbom.Common/OSUtils.cs
@@ -25,7 +25,7 @@ public class OSUtils : IOSUtils
 
     private readonly IEnvironmentWrapper environment;
 
-    private Dictionary<string, string> environmentVariables;
+    private readonly Dictionary<string, string> environmentVariables;
 
     public OSUtils(ILogger logger, IEnvironmentWrapper environment)
     {
@@ -77,7 +77,7 @@ public class OSUtils : IOSUtils
         return IsCaseSensitiveOS() ? StringComparison.InvariantCulture : StringComparison.InvariantCultureIgnoreCase;
     }
 
-    private bool IsCaseSensitiveOS()
+    public bool IsCaseSensitiveOS()
     {
         var currentOS = GetCurrentOSPlatform();
         var isCaseSensitiveOS = currentOS == OSPlatform.Linux || currentOS == OSPlatform.OSX;

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/SbomParserBasedValidationWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/SbomParserBasedValidationWorkflowTests.cs
@@ -151,6 +151,8 @@ public class SbomParserBasedValidationWorkflowTests : ValidationWorkflowTestsBas
         var rootFileFilterMock = new DownloadedRootPathFilter(configurationMock.Object, fileSystemMock.Object, mockLogger.Object);
         rootFileFilterMock.Init();
 
+        var osUtilsMock = new Mock<IOSUtils>(MockBehavior.Strict);
+
         var hashValidator = new ConcurrentSha256HashValidator(FileHashesDictionarySingleton.Instance);
         var enumeratorChannel = new EnumeratorChannel(mockLogger.Object);
         var fileConverter = new SbomFileToFileInfoConverter(new FileTypeUtils());
@@ -178,7 +180,8 @@ public class SbomParserBasedValidationWorkflowTests : ValidationWorkflowTestsBas
             filesValidator,
             validationResultGenerator,
             outputWriterMock.Object,
-            fileSystemMock.Object);
+            fileSystemMock.Object,
+            osUtilsMock.Object);
 
         var result = await validator.RunAsync();
         Assert.IsTrue(result);
@@ -200,6 +203,7 @@ public class SbomParserBasedValidationWorkflowTests : ValidationWorkflowTestsBas
         configurationMock.VerifyAll();
         signValidatorMock.VerifyAll();
         fileSystemMock.VerifyAll();
+        osUtilsMock.VerifyAll();
     }
 
     [TestMethod]
@@ -291,6 +295,9 @@ public class SbomParserBasedValidationWorkflowTests : ValidationWorkflowTestsBas
         var rootFileFilterMock = new DownloadedRootPathFilter(configurationMock.Object, fileSystemMock.Object, mockLogger.Object);
         rootFileFilterMock.Init();
 
+        var osUtilsMock = new Mock<IOSUtils>(MockBehavior.Strict);
+        osUtilsMock.Setup(x => x.IsCaseSensitiveOS()).Returns(false);
+
         var hashValidator = new ConcurrentSha256HashValidator(FileHashesDictionarySingleton.Instance);
         var enumeratorChannel = new EnumeratorChannel(mockLogger.Object);
         var fileConverter = new SbomFileToFileInfoConverter(new FileTypeUtils());
@@ -318,7 +325,8 @@ public class SbomParserBasedValidationWorkflowTests : ValidationWorkflowTestsBas
             filesValidator,
             validationResultGenerator,
             outputWriterMock.Object,
-            fileSystemMock.Object);
+            fileSystemMock.Object,
+            osUtilsMock.Object);
 
         var result = await validator.RunAsync();
         Assert.IsFalse(result);
@@ -343,5 +351,6 @@ public class SbomParserBasedValidationWorkflowTests : ValidationWorkflowTestsBas
         configurationMock.VerifyAll();
         signValidatorMock.VerifyAll();
         fileSystemMock.VerifyAll();
+        osUtilsMock.VerifyAll();
     }
 }


### PR DESCRIPTION
As called out in #523, we have some issues if a manifest file contains files whose names vary only by case. When this happens, we create a `NullReferenceException` that causes the validator to terminate prematurely without providing information to allow the person to address the issue. This PR does the following:

It leaves the overall validation logic unchanged, but it detects the case that was causing the `NullReferenceException` and reports it as an `AdditionalFile` error. This is consistent with the effect of copying 2 files whose names vary only by case to a file case-insensitive drive. This change allows the validation to complete with errors, rather than exiting prematurely

If errors are found when scanning on a case-insensitive system, it adds a brief warning to inform the users that if they created the manifest on a case-sensitive system, they may need to validate it on a case-sensitive system. We already have a mechanism to identify case-sensitivity, but it was private inside a class. It is now exposed on the associated interface. Unit tests have been updated to account for the case sensitivity check.

I simulated this case locally by generating a manifest, then manually creating some cases where file entries differed by case and by hash. When the validator runs, the order in which the manifest entries is processed is **nondeterministic**. As a result, the same manifest file can produce different errors. Depending on the order of processing, the errors may be reported as invalid hashes or as additional files. Because of this, I made the case sensitivity warning general and displayed it at the top of the output results. If _any_ errors are found when validation is performed on a case-insensitive OS, the error header now reads as follows:

```
------------------------------------------------------------
Individual file validation results
  Note: If the manifest file was originally created using a
        case-sensitive OS, you may also need to validate it
        using a case-sensitive OS.
------------------------------------------------------------
```

There was also a private member in the `OSUtils` class that was not `readonly` and the compiler complained about it. I fixed it while I was touching the file.