### PR TITLE
fix: Improve logging on a corrupted manifest file

### DIFF
--- a/src/Microsoft.Sbom.Api/Entities/ErrorType.cs
+++ b/src/Microsoft.Sbom.Api/Entities/ErrorType.cs
@@ -47,5 +47,8 @@ public enum ErrorType
     NoPackagesFound = 11,
 
     [EnumMember(Value = "Manifest file signing error")]
-    ManifestFileSigningError = 12
+    ManifestFileSigningError = 12,
+
+    [EnumMember(Value = "Invalid input file")]
+    InvalidInputFile = 13
 }

--- a/src/Microsoft.Sbom.Api/Executors/EnumeratorChannel.cs
+++ b/src/Microsoft.Sbom.Api/Executors/EnumeratorChannel.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using Microsoft.Sbom.Api.Entities;
+using Microsoft.Sbom.Api.Output.Telemetry;
+using Microsoft.Sbom.JsonAsynchronousNodeKit.Exceptions;
 using Serilog;
 
 namespace Microsoft.Sbom.Api.Executors;
@@ -41,6 +43,15 @@ public class EnumeratorChannel
                 {
                     await output.Writer.WriteAsync(value);
                 }
+            }
+            catch (ParserException e)
+            {
+                // Don't log this here, as it will be logged by upstream error handling.
+                await errors.Writer.WriteAsync(new FileValidationResult
+                {
+                    ErrorType = ErrorType.InvalidInputFile,
+                    Path = e.Message
+                });
             }
             catch (Exception e)
             {

--- a/src/Microsoft.Sbom.Api/Workflows/SBOMParserBasedValidationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SBOMParserBasedValidationWorkflow.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -107,6 +108,12 @@ public class SbomParserBasedValidationWorkflow : IWorkflow<SbomParserBasedValida
                         {
                             case FilesResult filesResult:
                                 (successfullyValidatedFiles, fileValidationFailures) = await filesValidator.Validate(filesResult.Files);
+                                var invalidInputFiles = fileValidationFailures.Where(f => f.ErrorType == ErrorType.InvalidInputFile).ToList();
+                                if (invalidInputFiles.Count != 0)
+                                {
+                                    throw new InvalidDataException($"Your manifest file is malformed. {invalidInputFiles.First().Path}");
+                                }
+
                                 break;
                             case PackagesResult packagesResult:
                                 var packages = packagesResult.Packages.ToList();


### PR DESCRIPTION
As called out in https://github.com/microsoft/dropvalidator/issues/857, it's hard to debug a case where the JSON inside a manifest file is corrupted. When https://github.com/microsoft/dropvalidator/issues/857 was opened, the only logging occurred at `Debug` level and it was not obvious what was happening. Since then, #540 bumped the logging to `Warning` level, which is better but not ideal:

```
##[warning]Encountered an unknown error while enumerating: Expected a '{' token at position 5444 but got String
##[error]Encountered an error while validating the drop.
##[error]Error details: Value cannot be null. (Parameter 'key')
```

The final error is actually thrown by the `Dictionary` class because we're trying to add an entry with a `null` key. This is also the error reported in telemetry.

This PR does the following:
- It defines an `ErrorType` for malformed files
- It silently catches a `ParserException` to distinguish a JSON error from some other random error, and sets the `ErrorType`. It also captures the error message for later handling. (Side note: It does this by stuffing the `Message` into the `Path` parameter, which also avoids the Exception from adding a `null` key to the `Dictionary`
- It detects the presence of the new `ErrorType` and passes the message to the top-level error handling for reporting and recording

With these changes, the output of validating a file with malformed JSON is as follows:
```
##[error]Encountered an error while validating the drop.
##[error]Error details: Your manifest file is malformed. Expected a '{' token at position 5444 but got String
```

The telemetry includes the following:
```
  "Exceptions": {
    "System.IO.InvalidDataException": "Your manifest file is malformed. Expected a \u0027{\u0027 token at position 5444 but got String"
  },
```

