### PR TITLE
fix: Remap errors to warnings if logged inside ComponentDetection

### DIFF
--- a/src/Microsoft.Sbom.Extensions.DependencyInjection/RemapComponentDetectionErrorsToWarningsLogger.cs
+++ b/src/Microsoft.Sbom.Extensions.DependencyInjection/RemapComponentDetectionErrorsToWarningsLogger.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Sbom;
+
+using System;
+using Serilog;
+using Serilog.Events;
+
+/// <summary>
+/// A class to remap Errors logged from ComponentDetection assemblies to Warnings.
+/// </summary>
+public class RemapComponentDetectionErrorsToWarningsLogger : ILogger
+{
+    private readonly ILogger logger;
+    private readonly Func<string?> stackTraceProvider;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RemapComponentDetectionErrorsToWarningsLogger"/> class.
+    /// Production constructor.
+    /// </summary>
+    public RemapComponentDetectionErrorsToWarningsLogger(ILogger logger)
+        : this(logger, () => Environment.StackTrace)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RemapComponentDetectionErrorsToWarningsLogger"/> class.
+    /// Testable constructor.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"></exception>
+    public RemapComponentDetectionErrorsToWarningsLogger(ILogger logger, Func<string?> stackTraceProvider)
+    {
+        this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        this.stackTraceProvider = stackTraceProvider ?? throw new ArgumentNullException(nameof(stackTraceProvider));
+    }
+
+    /// <inheritdoc />
+    /// <remarks>If ComponentDetection is on the stack, remap and log Errors to Warnings.</remarks>
+    public void Write(LogEvent logEvent)
+    {
+        // For performance reasons, bypass StackTrace work for non-errors.
+        if (logEvent.Level == LogEventLevel.Error)
+        {
+            var stackTrace = stackTraceProvider();
+            if (stackTrace is not null && stackTrace.Contains("Microsoft.ComponentDetection."))
+            {
+                var warningLogEvent = new LogEvent(
+                    logEvent.Timestamp,
+                    LogEventLevel.Warning,
+                    logEvent.Exception,
+                    logEvent.MessageTemplate,
+                    logEvent.Properties.Select(kvp => new LogEventProperty(kvp.Key, kvp.Value)));
+
+                logger.Write(warningLogEvent);
+                return;
+            }
+        }
+
+        logger.Write(logEvent);
+    }
+}


### PR DESCRIPTION
As called out in https://github.com/microsoft/sbom-tool/issues/505, `ComponentDetection` will sometimes log things that might be errors in some scenarios, but not in ours. These error messages show up in the log file and potentially confuse the user to pursue the wrong problem. We could either suppress these errors completely or remap them to warnings. This PR takes the latter approach.

Summary of changes:
- Create a new implementation of the `ILogger` interface.
    - This implementation is a decorator around a previously existing `ILogger` implementation
    - This implementation is called `RemapComponentDetectionErrorsToWarningsLogger`
    - This implementation uses `Environment.StackTrace` to detect the presence of "Microsoft.ComponentDetection." in the stack trace, and remaps any log events at `LogEventLevel.Error` to `LogEventLevel.Warning`
- Update the `CreateLogger` method to wrap the existing logger in a `RemapComponentDetectionErrorsToWarningsLogger` object

Tested locally by changing the `LogEventLevel.Error` to `LogEventLevel.Debug` and generating an SBOM. Here is a portion of that output showing the remapping in effect (these lines map as Debug events and are not normally output). It doesn't show in the PR, but the field properties are correctly retained in the logs:

```
##[warning]Gradle dev-only lockfiles ""
##[warning]Gradle dev-only configurations ""
##[warning]Finished applying restrictions to detectors.
##[warning]Removing "NewPipDetector" from active experiments
```