### PR TITLE
fix: Output correct case-sensitive message

### DIFF
--- a/src/Microsoft.Sbom.Api/Workflows/SBOMParserBasedValidationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SBOMParserBasedValidationWorkflow.cs
@@ -206,7 +206,7 @@ public class SbomParserBasedValidationWorkflow : IWorkflow<SbomParserBasedValida
             return;
         }
 
-        var caseSensitiveComment = validFailures.Any() && this.osUtils.IsCaseSensitiveOS() ?
+        var caseSensitiveComment = !validFailures.Any() || this.osUtils.IsCaseSensitiveOS() ?
             string.Empty :
             "\r\n  Note: If the manifest file was originally created using a" +
             "\r\n        case-sensitive OS, you may also need to validate it" +

--- a/test/Microsoft.Sbom.Api.Tests/ConsoleCapture.cs
+++ b/test/Microsoft.Sbom.Api.Tests/ConsoleCapture.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Sbom.Api.Tests;
+
+using System;
+using System.IO;
+
+/// <summary>
+/// A simple class to capture console output. Always wrap it in a try/finally block to
+/// ensure that the original console output is restored.
+/// </summary>
+internal class ConsoleCapture
+{
+    private readonly TextWriter oldStdOut = Console.Out;
+    private readonly TextWriter oldStdError = Console.Error;
+    private TextWriter? stdOutWriter;
+    private TextWriter? stdErrWriter;
+
+    /// <summary>
+    /// The content of the captured output to StdOut. Is only valid after the Restore method has been called.
+    /// </summary>
+    public string CapturedStdOut { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// The content of the captured output to StdError. Is only valid after the Restore method has been called.
+    /// </summary>
+    public string CapturedStdError { get; private set; } = string.Empty;
+
+    public ConsoleCapture()
+    {
+        stdOutWriter = new StringWriter();
+        Console.SetOut(stdOutWriter);
+
+        stdErrWriter = new StringWriter();
+        Console.SetError(stdErrWriter);
+    }
+
+    /// <summary>
+    /// Restores the original console output and sets the Captured* properties
+    /// </summary>
+    public void Restore()
+    {
+        if (stdOutWriter is not null)
+        {
+            CapturedStdOut = stdOutWriter?.ToString() ?? string.Empty;
+            Console.SetOut(oldStdOut);
+            stdOutWriter?.Dispose();
+            stdOutWriter = null;
+        }
+
+        if (stdErrWriter is not null)
+        {
+            CapturedStdError = stdErrWriter?.ToString() ?? string.Empty;
+            Console.SetError(oldStdError);
+            stdErrWriter?.Dispose();
+            stdErrWriter = null;
+        }
+    }
+}


### PR DESCRIPTION
#550 contained an error. The intended behavior was to display the case-sensitive warning message if errors were found AND the validation took place on a case-insensitive OS. This was implemented incorrectly. As coded, the error message was displayed if errors were found OR validation took place on a case-insensitive OS. 

Behavior before change:

      | validFailures.Any = False | validFailures.Any = True
--- | --- | ---
IsCaseSensitiveOS = False | Show message| Show message
IsCaseSensitiveOS = True | Show message | Hide message

Behavior after change:

      | validFailures.Any = False | validFailures.Any = True
--- | --- | ---
IsCaseSensitiveOS = False | HIde message| Show message
IsCaseSensitiveOS = True | Hide message | Hide message

This also adds unit tests to cover the variations with the case-insensitive OS. Variations with a case-sensitive OS will require some substantial refactoring (beyond the scope of this change)
