### PR TITLE
Explicitly install .NET 6.0 and 8.0 in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: |
+            6.0.x
+            8.0.x
 
       - name: Run tests
         run: dotnet test --collect:"XPlat Code Coverage"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Setup .NET
         uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
+        with:
+          dotnet-version: '6.0.x'
 
       - name: Run tests
         run: dotnet test --collect:"XPlat Code Coverage"


### PR DESCRIPTION
It appears CI is failing because we aren't installing .NET 6.0, adding a line to install the versions we need explicitly