### PR TITLE
Loosen constraints on SBOM/SPDX validation

### DIFF
--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/ExternalReference.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/ExternalReference.cs
@@ -25,7 +25,7 @@ public class ExternalReference
     /// https://spdx.github.io/spdx-spec/appendix-VI-external-repository-identifiers/.
     /// </summary>
     [JsonPropertyName("referenceType")]
-    public ExternalRepositoryType Type { get; set; }
+    public string Type { get; set; }
 
     /// <summary>
     /// Gets or sets a unique string without any spaces that specifies a location where the package specific information

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SPDXPackage.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SPDXPackage.cs
@@ -54,7 +54,6 @@ public class SPDXPackage
     /// <summary>
     /// Gets or sets contain the license the SPDX file creator has concluded as the package or alternative values.
     /// </summary>
-    [JsonRequired]
     [JsonPropertyName("licenseConcluded")]
     public string LicenseConcluded { get; set; }
 
@@ -68,14 +67,12 @@ public class SPDXPackage
     /// <summary>
     /// Gets or sets contains a list of licenses the have been declared by the authors of the package.
     /// </summary>
-    [JsonRequired]
     [JsonPropertyName("licenseDeclared")]
     public string LicenseDeclared { get; set; }
 
     /// <summary>
     /// Gets or sets copyright holder of the package, as well as any dates present.
     /// </summary>
-    [JsonRequired]
     [JsonPropertyName("copyrightText")]
     public string CopyrightText { get; set; }
 

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SPDXRelationship.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SPDXRelationship.cs
@@ -15,7 +15,7 @@ public class SPDXRelationship
     /// Gets or sets defines the type of the relationship between the source and the target element.
     /// </summary>
     [JsonPropertyName("relationshipType")]
-    public SPDXRelationshipType RelationshipType { get; set; }
+    public string RelationshipType { get; set; }
 
     /// <summary>
     /// Gets or sets the id of the target element with whom the source element has a relationship.

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SpdxFile.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SpdxFile.cs
@@ -34,21 +34,18 @@ public class SPDXFile
     /// <summary>
     /// Gets or sets contain the license the SPDX file creator has concluded as the package or alternative values.
     /// </summary>
-    [JsonRequired]
     [JsonPropertyName("licenseConcluded")]
     public string LicenseConcluded { get; set; }
 
     /// <summary>
     /// Gets or sets contains the license information actually found in the file, if any.
     /// </summary>
-    [JsonRequired]
     [JsonPropertyName("licenseInfoInFiles")]
     public IEnumerable<string> LicenseInfoInFiles { get; set; }
 
     /// <summary>
     /// Gets or sets copyright holder of the package, as well as any dates present.
     /// </summary>
-    [JsonRequired]
     [JsonPropertyName("copyrightText")]
     public string FileCopyrightText { get; set; }
 

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Generator.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Generator.cs
@@ -206,7 +206,7 @@ public class Generator : IManifestGenerator
                 new ExternalReference
                 {
                     ReferenceCategory = ReferenceCategory.PACKAGE_MANAGER.ToNormalizedString(),
-                    Type = ExternalRepositoryType.purl,
+                    Type = ExternalRepositoryType.purl.ToString(),
                     Locator = internalMetadataProvider.GetSwidTagId()
                 }
             },
@@ -248,7 +248,7 @@ public class Generator : IManifestGenerator
         var spdxRelationship = new SPDXRelationship
         {
             SourceElementId = sourceElement,
-            RelationshipType = GetSPDXRelationshipType(relationship.RelationshipType),
+            RelationshipType = GetSPDXRelationshipType(relationship.RelationshipType).ToString(),
             TargetElementId = targetElement
         };
 

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/SPDXExtensions.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/SPDXExtensions.cs
@@ -77,7 +77,7 @@ public static class SPDXExtensions
             var extRef = new ExternalReference
             {
                 ReferenceCategory = ReferenceCategory.PACKAGE_MANAGER.ToNormalizedString(),
-                Type = ExternalRepositoryType.purl,
+                Type = ExternalRepositoryType.purl.ToString(),
                 Locator = packageInfo.PackageUrl,
             };
 

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomFileParserTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomFileParserTests.cs
@@ -104,9 +104,6 @@ public class SbomFileParserTests : SbomParserTestsBase
     [DataRow(SbomFileJsonStrings.JsonWith1FileMissingNameString)]
     [DataRow(SbomFileJsonStrings.JsonWith1FileMissingIDString)]
     [DataRow(SbomFileJsonStrings.JsonWith1FileMissingChecksumsString)]
-    [DataRow(SbomFileJsonStrings.JsonWith1FileMissingLicenseConcludedString)]
-    [DataRow(SbomFileJsonStrings.JsonWith1FileMissingLicenseInfoInFilesString)]
-    [DataRow(SbomFileJsonStrings.JsonWith1FileMissingCopyrightString)]
     [DataRow(SbomFileJsonStrings.JsonWith1FileMissingCopyrightAndPathString)]
     [TestMethod]
     public void MissingPropertiesTest_Throws(string json)

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomRelationshipParserTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomRelationshipParserTests.cs
@@ -73,7 +73,6 @@ public class SbomRelationshipParserTests : SbomParserTestsBase
     }
 
     [DataTestMethod]
-    [DataRow(RelationshipStrings.MalformedJsonRelationshipsStringBadRelationshipType)]
     [DataRow(RelationshipStrings.MalformedJsonRelationshipsString)]
     [TestMethod]
     public void MalformedJsonTest_Throws(string json)

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Utils/SPDXExtensionsTest.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Utils/SPDXExtensionsTest.cs
@@ -44,7 +44,12 @@ public class SPDXExtensionsTest
         spdxPackage.AddPackageUrls(packageInfo);
         var externalRef = spdxPackage.ExternalReferences.First();
         Assert.AreEqual(ReferenceCategory.PACKAGE_MANAGER.ToNormalizedString(), externalRef.ReferenceCategory);
-        Assert.AreEqual(ExternalRepositoryType.purl, externalRef.Type);
+
+        // ExternalRepositoryTypes are deserialized as strings for portability when handling 3P SBOMs,
+        // but in the context of this test we expect the value to align with a known enum value. So
+        // convert to enum for comparison.
+        Enum.TryParse<ExternalRepositoryType>(externalRef.Type, out var refType);
+        Assert.AreEqual(ExternalRepositoryType.purl, refType);
         Assert.AreEqual(PackageUrl, externalRef.Locator);
     }
 
@@ -84,7 +89,12 @@ public class SPDXExtensionsTest
         var externalRef = spdxPackage.ExternalReferences.First();
 
         Assert.AreEqual(ReferenceCategory.PACKAGE_MANAGER.ToNormalizedString(), externalRef.ReferenceCategory);
-        Assert.AreEqual(ExternalRepositoryType.purl, externalRef.Type);
+
+        // ExternalRepositoryTypes are deserialized as strings for portability when handling 3P SBOMs,
+        // but in the context of this test we expect the value to align with a known enum value. So
+        // convert to enum for comparison.
+        Enum.TryParse<ExternalRepositoryType>(externalRef.Type, out var refType);
+        Assert.AreEqual(ExternalRepositoryType.purl, refType);
         Assert.AreEqual(expectedUrl, externalRef.Locator);
     }
 


### PR DESCRIPTION
Reduce the validation of input values and required fields that is performed on deserializing SBOM/SPDX files. Values previously deserialized as enums will now be deserialized as strings and non-essential attributes have had the JsonRequired attribute removed. These changes allow us to deserialize a wider range of 2.x SPDX files, instead of constraining us to 2.2.1 SPDX produced only by the sbom-tool.