### PR TITLE
Add redact verb to CLI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -502,6 +502,9 @@ dotnet_diagnostic.SA1005.severity = none
 # SA1515: Single-line comment should be preceded by blank line
 dotnet_diagnostic.SA1515.severity = none
 
+# SA1512: Single-line comments should not be followed by blank line
+dotnet_diagnostic.SA1512.severity = none
+
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1101.md
 # SA1101: Prefix local calls with this
 dotnet_diagnostic.SA1101.severity = suggestion

--- a/.editorconfig
+++ b/.editorconfig
@@ -496,6 +496,12 @@ dotnet_diagnostic.CA1863.severity = none
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers
 ##########################################
 
+# SA1005: Single line comments should begin with single space
+dotnet_diagnostic.SA1005.severity = none
+
+# SA1515: Single-line comment should be preceded by blank line
+dotnet_diagnostic.SA1515.severity = none
+
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1101.md
 # SA1101: Prefix local calls with this
 dotnet_diagnostic.SA1101.severity = suggestion

--- a/docs/setting-up-github-actions.md
+++ b/docs/setting-up-github-actions.md
@@ -82,8 +82,6 @@ Since the sbom tool will place the final SBOM file in the build drop folder (`bu
 
 This line of code produces a SBOM file with the same information as the GitHub Action.
 
-## The information being conveyed in this sentence needs clarification.  What is the reader  learn from "With the above our SBOM has the same retention as the build artifacts for the GitHub Action."
-
 ## Further reading
 
 If the organization or team stores the SBOM in a centrally-controlled repository, use the `-manifestDirPath` parameter to specify the intended folder location for the SBOM output file.

--- a/src/Microsoft.Sbom.Api/Config/Args/CommonArgs.cs
+++ b/src/Microsoft.Sbom.Api/Config/Args/CommonArgs.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
 using Microsoft.Sbom.Common.Config;
-using Microsoft.Sbom.Extensions.Entities;
 using PowerArgs;
 using Serilog.Events;
 
@@ -15,43 +13,14 @@ namespace Microsoft.Sbom.Api.Config.Args;
 public abstract class CommonArgs
 {
     /// <summary>
-    /// Gets or sets display this amount of detail in the logging output.
-    /// </summary>
-    [ArgDescription("Display this amount of detail in the logging output.")]
-    public LogEventLevel? Verbosity { get; set; }
-
-    /// <summary>
-    /// Gets or sets the number of parallel threads to use for the workflows.
-    /// </summary>
-    [ArgDescription("The number of parallel threads to use for the workflows.")]
-    public int? Parallelism { get; set; }
-
-    /// <summary>
-    /// Gets or sets a JSON config file that can be used to specify all the arguments for an action.
-    /// </summary>
-    [ArgDescription("The json file that contains the configuration for the DropValidator.")]
-    public string ConfigFilePath { get; set; }
-
-    /// <summary>
     /// Gets or sets the action currently being performed by the manifest tool.
     /// </summary>
     [ArgIgnore]
     public ManifestToolActions ManifestToolAction { get; set; }
 
-    [ArgShortcut("t")]
-    [ArgDescription("Specify a file where we should write detailed telemetry for the workflow.")]
-    public string TelemetryFilePath { get; set; }
-
     /// <summary>
-    /// Gets or sets if set to false, we will not follow symlinks while traversing the build drop folder. Default is set to 'true'.
+    /// Gets or sets display this amount of detail in the logging output.
     /// </summary>
-    [ArgDescription("If set to false, we will not follow symlinks while traversing the build drop folder. Default is set to 'true'.")]
-    public bool? FollowSymlinks { get; set; }
-
-    /// <summary>
-    /// Gets or sets the name and version of the manifest format that we are using.
-    /// </summary>
-    [ArgDescription("A list of the name and version of the manifest format that we are using.")]
-    [ArgShortcut("mi")]
-    public IList<ManifestInfo> ManifestInfo { get; set; }
+    [ArgDescription("Display this amount of detail in the logging output.")]
+    public LogEventLevel? Verbosity { get; set; }
 }

--- a/src/Microsoft.Sbom.Api/Config/Args/GenerationAndValidationCommonArgs.cs
+++ b/src/Microsoft.Sbom.Api/Config/Args/GenerationAndValidationCommonArgs.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Microsoft.Sbom.Common.Config;
+using Microsoft.Sbom.Extensions.Entities;
+using PowerArgs;
+using Serilog.Events;
+
+namespace Microsoft.Sbom.Api.Config.Args;
+
+/// <summary>
+/// Defines the common arguments used by the validation and generation actions of the ManifestTool.
+/// </summary>
+public abstract class GenerationAndValidationCommonArgs : CommonArgs
+{
+    /// <summary>
+    /// Gets or sets the number of parallel threads to use for the workflows.
+    /// </summary>
+    [ArgDescription("The number of parallel threads to use for the workflows.")]
+    public int? Parallelism { get; set; }
+
+    /// <summary>
+    /// Gets or sets a JSON config file that can be used to specify all the arguments for an action.
+    /// </summary>
+    [ArgDescription("The json file that contains the configuration for the DropValidator.")]
+    public string ConfigFilePath { get; set; }
+
+    [ArgShortcut("t")]
+    [ArgDescription("Specify a file where we should write detailed telemetry for the workflow.")]
+    public string TelemetryFilePath { get; set; }
+
+    /// <summary>
+    /// Gets or sets if set to false, we will not follow symlinks while traversing the build drop folder. Default is set to 'true'.
+    /// </summary>
+    [ArgDescription("If set to false, we will not follow symlinks while traversing the build drop folder. Default is set to 'true'.")]
+    public bool? FollowSymlinks { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name and version of the manifest format that we are using.
+    /// </summary>
+    [ArgDescription("A list of the name and version of the manifest format that we are using.")]
+    [ArgShortcut("mi")]
+    public IList<ManifestInfo> ManifestInfo { get; set; }
+}

--- a/src/Microsoft.Sbom.Api/Config/Args/GenerationArgs.cs
+++ b/src/Microsoft.Sbom.Api/Config/Args/GenerationArgs.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Sbom.Api.Config.Args;
 /// <summary>
 /// The command line arguments provided for the generate action in ManifestTool.
 /// </summary>
-public class GenerationArgs : CommonArgs
+public class GenerationArgs : GenerationAndValidationCommonArgs
 {
     /// <summary>
     /// Gets or sets the root folder of the drop directory for which the SBOM file will be generated.

--- a/src/Microsoft.Sbom.Api/Config/Args/RedactArgs.cs
+++ b/src/Microsoft.Sbom.Api/Config/Args/RedactArgs.cs
@@ -25,9 +25,9 @@ public class RedactArgs : CommonArgs
     public string? SbomDir { get; set; }
 
     /// <summary>
-    /// Gets or sets the root folder of the drop directory for which the redacted SBOM file will be generated.
+    /// Gets or sets the directory where the redacted SBOM file(s) will be generated.
     /// </summary>
-    [ArgShortcut("b")]
-    [ArgDescription("The root folder of the drop directory for which the redacted SBOM file will be generated.")]
-    public string BuildDropPath { get; set; }
+    [ArgShortcut("o")]
+    [ArgDescription("Gets or sets the directory where the redacted SBOM file(s) will be generated.")]
+    public string OutputPath { get; set; }
 }

--- a/src/Microsoft.Sbom.Api/Config/Args/RedactArgs.cs
+++ b/src/Microsoft.Sbom.Api/Config/Args/RedactArgs.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using PowerArgs;
+
+namespace Microsoft.Sbom.Api.Config.Args;
+
+/// <summary>
+/// The command line arguments provided for the redact action in ManifestTool.
+/// </summary>
+public class RedactArgs : CommonArgs
+{
+    /// <summary>
+    /// Gets or sets the file path of the SBOM to redact.
+    /// </summary>
+    [ArgShortcut("sp")]
+    [ArgDescription("The file path of the SBOM to redact.")]
+    public string? SbomPath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the directory containing the sbom(s) to redact.
+    /// </summary>
+    [ArgShortcut("sd")]
+    [ArgDescription("The directory containing the sbom(s) to redact.")]
+    public string? SbomDir { get; set; }
+
+    /// <summary>
+    /// Gets or sets the root folder of the drop directory for which the redacted SBOM file will be generated.
+    /// </summary>
+    [ArgShortcut("b")]
+    [ArgDescription("The root folder of the drop directory for which the redacted SBOM file will be generated.")]
+    public string BuildDropPath { get; set; }
+}

--- a/src/Microsoft.Sbom.Api/Config/Args/ValidationArgs.cs
+++ b/src/Microsoft.Sbom.Api/Config/Args/ValidationArgs.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Sbom.Api.Config.Args;
 /// <summary>
 /// The command line arguments provided for the validate action in ManifestTool.
 /// </summary>
-public class ValidationArgs : CommonArgs
+public class ValidationArgs : GenerationAndValidationCommonArgs
 {
     /// <summary>
     /// Gets or sets the root folder of the drop directory to validate.

--- a/src/Microsoft.Sbom.Api/Config/ConfigSanitizer.cs
+++ b/src/Microsoft.Sbom.Api/Config/ConfigSanitizer.cs
@@ -55,7 +55,8 @@ public class ConfigSanitizer
             .CreateLogger();
 
         // If BuildDropPath is null then run the logic to check whether it is required or not based on the current configuration.
-        if (configuration.BuildDropPath?.Value == null || (configuration.DockerImagesToScan?.Value != null && configuration.BuildComponentPath?.Value == null))
+        if ((configuration.ManifestToolAction == ManifestToolActions.Validate || configuration.ManifestToolAction == ManifestToolActions.Generate) &&
+            (configuration.BuildDropPath?.Value == null || (configuration.DockerImagesToScan?.Value != null && configuration.BuildComponentPath?.Value == null)))
         {
                 ValidateBuildDropPathConfiguration(configuration);
                 configuration.BuildDropPath = GetTempBuildDropPath(configuration);
@@ -64,7 +65,7 @@ public class ConfigSanitizer
         configuration.HashAlgorithm = GetHashAlgorithmName(configuration);
 
         // set ManifestDirPath after validation of DirectoryExist and DirectoryPathIsWritable, this wouldn't exist because it needs to be created by the tool.
-        configuration.ManifestDirPath = GetManifestDirPath(configuration.ManifestDirPath, configuration.BuildDropPath.Value, configuration.ManifestToolAction);
+        configuration.ManifestDirPath = GetManifestDirPath(configuration.ManifestDirPath, configuration.BuildDropPath?.Value, configuration.ManifestToolAction);
 
         // Set namespace value, this handles default values and user provided values.
         if (configuration.ManifestToolAction == ManifestToolActions.Generate)

--- a/src/Microsoft.Sbom.Api/Config/ConfigurationBuilder.cs
+++ b/src/Microsoft.Sbom.Api/Config/ConfigurationBuilder.cs
@@ -37,6 +37,10 @@ public class ConfigurationBuilder<T> : IConfigurationBuilder<T>
                 generationArgs.ManifestToolAction = ManifestToolActions.Generate;
                 commandLineArgs = mapper.Map<InputConfiguration>(generationArgs);
                 break;
+            case RedactArgs redactArgs:
+                redactArgs.ManifestToolAction = ManifestToolActions.Redact;
+                commandLineArgs = mapper.Map<InputConfiguration>(redactArgs);
+                break;
             default:
                 throw new ValidationArgException($"Unsupported configuration type found {typeof(T)}");
         }

--- a/src/Microsoft.Sbom.Api/Config/SbomToolCmdRunner.cs
+++ b/src/Microsoft.Sbom.Api/Config/SbomToolCmdRunner.cs
@@ -55,10 +55,10 @@ public class SbomToolCmdRunner
     }
 
     /// <summary>
-    /// Redact sensitive file information from given SBOM(s).
+    /// Redact file information from given SBOM(s).
     /// </summary>
     [ArgActionMethod]
-    [ArgDescription("Redact sensitive file information from given SBOM(s).")]
+    [ArgDescription("Redact file information from given SBOM(s).")]
     [OmitFromUsageDocs]
     public RedactArgs Redact(RedactArgs redactArgs)
     {

--- a/src/Microsoft.Sbom.Api/Config/SbomToolCmdRunner.cs
+++ b/src/Microsoft.Sbom.Api/Config/SbomToolCmdRunner.cs
@@ -55,6 +55,16 @@ public class SbomToolCmdRunner
     }
 
     /// <summary>
+    /// Redact sensitive file information from given SBOM(s).
+    /// </summary>
+    [ArgActionMethod]
+    [ArgDescription("Redact sensitive file information from given SBOM(s).")]
+    public RedactArgs Redact(RedactArgs redactArgs)
+    {
+        return redactArgs;
+    }
+
+    /// <summary>
     /// Prints the version of the tool.
     /// </summary>
     [ArgActionMethod]

--- a/src/Microsoft.Sbom.Api/Config/SbomToolCmdRunner.cs
+++ b/src/Microsoft.Sbom.Api/Config/SbomToolCmdRunner.cs
@@ -59,6 +59,7 @@ public class SbomToolCmdRunner
     /// </summary>
     [ArgActionMethod]
     [ArgDescription("Redact sensitive file information from given SBOM(s).")]
+    [OmitFromUsageDocs]
     public RedactArgs Redact(RedactArgs redactArgs)
     {
         return redactArgs;

--- a/src/Microsoft.Sbom.Api/ConfigurationProfile.cs
+++ b/src/Microsoft.Sbom.Api/ConfigurationProfile.cs
@@ -62,7 +62,6 @@ public class ConfigurationProfile : Profile
 #pragma warning disable CS0618 // 'Configuration.ManifestPath' is obsolete: 'This field is not provided by the user or configFile, set by system'
             .ForMember(c => c.ManifestPath, o => o.Ignore())
 #pragma warning restore CS0618 // 'Configuration.ManifestPath' is obsolete: 'This field is not provided by the user or configFile, set by system'
-            .ForMember(c => c.OutputPath, o => o.Ignore())
             .ForMember(c => c.HashAlgorithm, o => o.Ignore())
             .ForMember(c => c.RootPathFilter, o => o.Ignore())
             .ForMember(c => c.CatalogFilePath, o => o.Ignore())

--- a/src/Microsoft.Sbom.Api/ConfigurationProfile.cs
+++ b/src/Microsoft.Sbom.Api/ConfigurationProfile.cs
@@ -57,6 +57,35 @@ public class ConfigurationProfile : Profile
             .ForMember(c => c.IgnoreMissing, o => o.Ignore())
             .ForMember(c => c.FailIfNoPackages, o => o.Ignore());
 
+        // Create config for the redact args, ignoring other action members
+        CreateMap<RedactArgs, InputConfiguration>()
+#pragma warning disable CS0618 // 'Configuration.ManifestPath' is obsolete: 'This field is not provided by the user or configFile, set by system'
+            .ForMember(c => c.ManifestPath, o => o.Ignore())
+#pragma warning restore CS0618 // 'Configuration.ManifestPath' is obsolete: 'This field is not provided by the user or configFile, set by system'
+            .ForMember(c => c.OutputPath, o => o.Ignore())
+            .ForMember(c => c.HashAlgorithm, o => o.Ignore())
+            .ForMember(c => c.RootPathFilter, o => o.Ignore())
+            .ForMember(c => c.CatalogFilePath, o => o.Ignore())
+            .ForMember(c => c.ValidateSignature, o => o.Ignore())
+            .ForMember(c => c.PackagesList, o => o.Ignore())
+            .ForMember(c => c.FilesList, o => o.Ignore())
+            .ForMember(c => c.IgnoreMissing, o => o.Ignore())
+            .ForMember(c => c.FailIfNoPackages, o => o.Ignore())
+            .ForMember(c => c.PackageName, o => o.Ignore())
+            .ForMember(c => c.PackageVersion, o => o.Ignore())
+            .ForMember(c => c.BuildListFile, o => o.Ignore())
+            .ForMember(c => c.ExternalDocumentReferenceListFile, o => o.Ignore())
+            .ForMember(c => c.BuildComponentPath, o => o.Ignore())
+            .ForMember(c => c.PackagesList, o => o.Ignore())
+            .ForMember(c => c.FilesList, o => o.Ignore())
+            .ForMember(c => c.DockerImagesToScan, o => o.Ignore())
+            .ForMember(c => c.AdditionalComponentDetectorArgs, o => o.Ignore())
+            .ForMember(c => c.GenerationTimestamp, o => o.Ignore())
+            .ForMember(c => c.NamespaceUriUniquePart, o => o.Ignore())
+            .ForMember(c => c.NamespaceUriBase, o => o.Ignore())
+            .ForMember(c => c.DeleteManifestDirIfPresent, o => o.Ignore())
+            .ForMember(c => c.PackageSupplier, o => o.Ignore());
+
         // Create config for the config json file to configuration.
         CreateMap<ConfigFile, InputConfiguration>()
             .ForMember(c => c.PackagesList, o => o.Ignore())

--- a/src/Microsoft.Sbom.Api/Workflows/SBOMRedactionWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SBOMRedactionWorkflow.cs
@@ -9,7 +9,7 @@ using Serilog;
 namespace Microsoft.Sbom.Api.Workflows;
 
 /// <summary>
-/// The SBOM tool workflow class that is used to redact sensitive file information from a SBOM or set of SBOMs.
+/// The SBOM tool workflow class that is used to redact file information from a SBOM or set of SBOMs.
 /// </summary>
 public class SbomRedactionWorkflow : IWorkflow<SbomRedactionWorkflow>
 {

--- a/src/Microsoft.Sbom.Api/Workflows/SBOMRedactionWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SBOMRedactionWorkflow.cs
@@ -27,7 +27,7 @@ public class SbomRedactionWorkflow : IWorkflow<SbomRedactionWorkflow>
 
     public virtual async Task<bool> RunAsync()
     {
-        log.Error($"Running redaction for SBOM path {configuration.SbomPath?.Value} and SBOM dir {configuration.SbomDir?.Value}");
+        log.Information($"Running redaction for SBOM path {configuration.SbomPath?.Value} and SBOM dir {configuration.SbomDir?.Value}. Output dir: {configuration.OutputPath?.Value}");
         return await Task.FromResult(true);
     }
 }

--- a/src/Microsoft.Sbom.Api/Workflows/SBOMRedactionWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SBOMRedactionWorkflow.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Sbom.Common.Config;
+using Serilog;
+
+namespace Microsoft.Sbom.Api.Workflows;
+
+/// <summary>
+/// The SBOM tool workflow class that is used to redact sensitive file information from a SBOM or set of SBOMs.
+/// </summary>
+public class SbomRedactionWorkflow : IWorkflow<SbomRedactionWorkflow>
+{
+    private readonly ILogger log;
+
+    private readonly IConfiguration configuration;
+
+    public SbomRedactionWorkflow(
+        ILogger log,
+        IConfiguration configuration)
+    {
+        this.log = log ?? throw new ArgumentNullException(nameof(log));
+        this.configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+    }
+
+    public virtual async Task<bool> RunAsync()
+    {
+        log.Error($"Running redaction for SBOM path {configuration.SbomPath?.Value} and SBOM dir {configuration.SbomDir?.Value}");
+        return await Task.FromResult(true);
+    }
+}

--- a/src/Microsoft.Sbom.Common/Config/Configuration.cs
+++ b/src/Microsoft.Sbom.Common/Config/Configuration.cs
@@ -51,6 +51,8 @@ public class Configuration : IConfiguration
     private static readonly AsyncLocal<ConfigurationSetting<bool>> deleteManifestDirIfPresent = new();
     private static readonly AsyncLocal<ConfigurationSetting<bool>> failIfNoPackages = new();
     private static readonly AsyncLocal<ConfigurationSetting<LogEventLevel>> verbosity = new();
+    private static readonly AsyncLocal<ConfigurationSetting<string>> sbomPath = new();
+    private static readonly AsyncLocal<ConfigurationSetting<string>> sbomDir = new();
 
     /// <inheritdoc cref="IConfiguration.BuildDropPath" />
     [DirectoryExists]
@@ -313,5 +315,19 @@ public class Configuration : IConfiguration
     {
         get => enablePackageMetadataParsing.Value;
         set => enablePackageMetadataParsing.Value = value;
+    }
+
+    /// <inheritdoc cref="IConfiguration.SbomPath" />
+    public ConfigurationSetting<string> SbomPath
+    {
+        get => sbomPath.Value;
+        set => sbomPath.Value = value;
+    }
+
+    /// <inheritdoc cref="IConfiguration.SbomDir" />
+    public ConfigurationSetting<string> SbomDir
+    {
+        get => sbomDir.Value;
+        set => sbomDir.Value = value;
     }
 }

--- a/src/Microsoft.Sbom.Common/Config/IConfiguration.cs
+++ b/src/Microsoft.Sbom.Common/Config/IConfiguration.cs
@@ -198,4 +198,14 @@ public interface IConfiguration
     /// If set to true, we will attempt to locate and parse package metadata files for additional information to include in the SBOM such as .nuspec/.pom files in the local package cache.
     /// </summary>
     ConfigurationSetting<bool> EnablePackageMetadataParsing { get; set; }
+
+    /// <summary>
+    /// Gets or sets the file path of the SBOM to redact.
+    /// </summary>
+    ConfigurationSetting<string> SbomPath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the directory containing the sbom(s) to redact.
+    /// </summary>
+    ConfigurationSetting<string> SbomDir { get; set; }
 }

--- a/src/Microsoft.Sbom.Common/Config/InputConfiguration.cs
+++ b/src/Microsoft.Sbom.Common/Config/InputConfiguration.cs
@@ -143,4 +143,13 @@ public class InputConfiguration : IConfiguration
 
     [DefaultValue(false)]
     public ConfigurationSetting<bool> EnablePackageMetadataParsing { get; set; }
+
+    /// <inheritdoc cref="IConfiguration.SbomDir" />
+    [DirectoryExists]
+    [Path]
+    public ConfigurationSetting<string> SbomDir { get; set; }
+
+    /// <inheritdoc cref="IConfiguration.SbomPath" />
+    [Path]
+    public ConfigurationSetting<string> SbomPath { get; set; }
 }

--- a/src/Microsoft.Sbom.Common/Config/ManifestToolActions.cs
+++ b/src/Microsoft.Sbom.Common/Config/ManifestToolActions.cs
@@ -11,6 +11,6 @@ public enum ManifestToolActions
     None = 0,
     Validate = 1,
     Generate = 2,
-
-    All = Validate | Generate
+    Redact = 4,
+    All = Validate | Generate | Redact
 }

--- a/src/Microsoft.Sbom.DotNetTool/RedactService.cs
+++ b/src/Microsoft.Sbom.DotNetTool/RedactService.cs
@@ -6,10 +6,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Sbom.Api;
-using Microsoft.Sbom.Api.Exceptions;
 using Microsoft.Sbom.Api.Output.Telemetry;
 using Microsoft.Sbom.Api.Workflows;
-using IConfiguration = Microsoft.Sbom.Common.Config.IConfiguration;
 
 namespace Microsoft.Sbom.Tool;
 
@@ -26,9 +24,9 @@ public class RedactService : IHostedService
         IRecorder recorder,
         IHostApplicationLifetime hostApplicationLifetime)
     {
-        this.redactionWorkflow = redactionWorkflow;
-        this.recorder = recorder;
-        this.hostApplicationLifetime = hostApplicationLifetime;
+        this.redactionWorkflow = redactionWorkflow ?? throw new ArgumentNullException(nameof(redactionWorkflow));
+        this.recorder = recorder ?? throw new ArgumentNullException(nameof(recorder));
+        this.hostApplicationLifetime = hostApplicationLifetime ?? throw new ArgumentNullException(nameof(hostApplicationLifetime));
     }
 
     public async Task StartAsync(CancellationToken cancellationToken)

--- a/src/Microsoft.Sbom.DotNetTool/RedactService.cs
+++ b/src/Microsoft.Sbom.DotNetTool/RedactService.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Sbom.Api;
+using Microsoft.Sbom.Api.Exceptions;
+using Microsoft.Sbom.Api.Output.Telemetry;
+using Microsoft.Sbom.Api.Workflows;
+using IConfiguration = Microsoft.Sbom.Common.Config.IConfiguration;
+
+namespace Microsoft.Sbom.Tool;
+
+public class RedactService : IHostedService
+{
+    private readonly IWorkflow<SbomRedactionWorkflow> redactionWorkflow;
+
+    private readonly IRecorder recorder;
+
+    private readonly IHostApplicationLifetime hostApplicationLifetime;
+
+    public RedactService(
+        IWorkflow<SbomRedactionWorkflow> redactionWorkflow,
+        IRecorder recorder,
+        IHostApplicationLifetime hostApplicationLifetime)
+    {
+        this.redactionWorkflow = redactionWorkflow;
+        this.recorder = recorder;
+        this.hostApplicationLifetime = hostApplicationLifetime;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await redactionWorkflow.RunAsync();
+            await recorder.FinalizeAndLogTelemetryAsync();
+            Environment.ExitCode = result ? (int)ExitCode.Success : (int)ExitCode.GeneralError;
+        }
+        catch (Exception e)
+        {
+            var message = e.InnerException != null ? e.InnerException.Message : e.Message;
+            Console.WriteLine($"Encountered error while running ManifestTool redaction workflow. Error: {message}");
+            Environment.ExitCode = (int)ExitCode.GeneralError;
+        }
+
+        hostApplicationLifetime.StopApplication();
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/src/Microsoft.Sbom.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Sbom.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -72,6 +72,7 @@ public static class ServiceCollectionExtensions
             })
             .AddTransient<IWorkflow<SbomParserBasedValidationWorkflow>, SbomParserBasedValidationWorkflow>()
             .AddTransient<IWorkflow<SbomGenerationWorkflow>, SbomGenerationWorkflow>()
+            .AddTransient<IWorkflow<SbomRedactionWorkflow>, SbomRedactionWorkflow>()
             .AddTransient<DirectoryWalker>()
             .AddTransient<IFilter<DownloadedRootPathFilter>, DownloadedRootPathFilter>()
             .AddTransient<IFilter<ManifestFolderFilter>, ManifestFolderFilter>()

--- a/src/Microsoft.Sbom.Tool/Program.cs
+++ b/src/Microsoft.Sbom.Tool/Program.cs
@@ -50,6 +50,7 @@ internal class Program
                     {
                         ValidationArgs v => services.AddHostedService<ValidationService>(),
                         GenerationArgs g => services.AddHostedService<GenerationService>(),
+                        RedactArgs r => services.AddHostedService<RedactService>(),
                         _ => services
                     };
 
@@ -60,10 +61,12 @@ internal class Program
                         {
                             var validationConfigurationBuilder = x.GetService<IConfigurationBuilder<ValidationArgs>>();
                             var generationConfigurationBuilder = x.GetService<IConfigurationBuilder<GenerationArgs>>();
+                            var redactConfigurationBuilder = x.GetService<IConfigurationBuilder<RedactArgs>>();
                             var inputConfiguration = result.ActionArgs switch
                             {
                                 ValidationArgs v => validationConfigurationBuilder.GetConfiguration(v).GetAwaiter().GetResult(),
                                 GenerationArgs g => generationConfigurationBuilder.GetConfiguration(g).GetAwaiter().GetResult(),
+                                RedactArgs r => redactConfigurationBuilder.GetConfiguration(r).GetAwaiter().GetResult(),
                                 _ => default
                             };
 

--- a/src/Microsoft.Sbom.Tool/RedactService.cs
+++ b/src/Microsoft.Sbom.Tool/RedactService.cs
@@ -22,9 +22,9 @@ public class RedactService : IHostedService
         IRecorder recorder,
         IHostApplicationLifetime hostApplicationLifetime)
     {
-        this.redactionWorkflow = redactionWorkflow;
-        this.recorder = recorder;
-        this.hostApplicationLifetime = hostApplicationLifetime;
+        this.redactionWorkflow = redactionWorkflow ?? throw new ArgumentNullException(nameof(redactionWorkflow));
+        this.recorder = recorder ?? throw new ArgumentNullException(nameof(recorder));
+        this.hostApplicationLifetime = hostApplicationLifetime ?? throw new ArgumentNullException(nameof(hostApplicationLifetime));
     }
 
     public async Task StartAsync(CancellationToken cancellationToken)

--- a/src/Microsoft.Sbom.Tool/RedactService.cs
+++ b/src/Microsoft.Sbom.Tool/RedactService.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Sbom.Api;
+using Microsoft.Sbom.Api.Output.Telemetry;
+using Microsoft.Sbom.Api.Workflows;
+
+namespace Microsoft.Sbom.Tool;
+
+public class RedactService : IHostedService
+{
+    private readonly IWorkflow<SbomRedactionWorkflow> redactionWorkflow;
+    private readonly IRecorder recorder;
+    private readonly IHostApplicationLifetime hostApplicationLifetime;
+
+    public RedactService(
+        IWorkflow<SbomRedactionWorkflow> redactionWorkflow,
+        IRecorder recorder,
+        IHostApplicationLifetime hostApplicationLifetime)
+    {
+        this.redactionWorkflow = redactionWorkflow;
+        this.recorder = recorder;
+        this.hostApplicationLifetime = hostApplicationLifetime;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await redactionWorkflow.RunAsync();
+            await recorder.FinalizeAndLogTelemetryAsync();
+            Environment.ExitCode = result ? (int)ExitCode.Success : (int)ExitCode.GeneralError;
+        }
+        catch (Exception e)
+        {
+            var message = e.InnerException != null ? e.InnerException.Message : e.Message;
+            Console.WriteLine($"Encountered error while running ManifestTool redaction workflow. Error: {message}");
+            Environment.ExitCode = (int)ExitCode.GeneralError;
+        }
+
+        hostApplicationLifetime.StopApplication();
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigSanitizerTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigSanitizerTests.cs
@@ -113,6 +113,16 @@ public class ConfigSanitizerTests
     }
 
     [TestMethod]
+    public void NoValueForBuildDropPathForRedaction_Succeeds()
+    {
+        var config = GetConfigurationBaseObject();
+        config.ManifestToolAction = ManifestToolActions.Redact;
+        config.BuildDropPath = null;
+
+        configSanitizer.SanitizeConfig(config);
+    }
+
+    [TestMethod]
     public void NoValueForManifestInfoForValidation_SetsDefaultValue()
     {
         var config = GetConfigurationBaseObject();

--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForRedact.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForRedact.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Sbom.Api.Config.Args;
+using Microsoft.Sbom.Common.Config;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using PowerArgs;
+
+namespace Microsoft.Sbom.Api.Config.Tests;
+
+[TestClass]
+public class ConfigurationBuilderTestsForRedact : ConfigurationBuilderTestsBase
+{
+    [TestInitialize]
+    public void Setup()
+    {
+        Init();
+    }
+
+    [TestMethod]
+    public async Task ConfigurationBuilderTest_ForRedact_CombinesConfigs()
+    {
+        var configFileParser = new ConfigFileParser(fileSystemUtilsMock.Object);
+        var cb = new ConfigurationBuilder<RedactArgs>(mapper, configFileParser);
+
+        fileSystemUtilsMock.Setup(f => f.DirectoryExists(It.IsAny<string>())).Returns(true).Verifiable();
+        fileSystemUtilsMock.Setup(f => f.DirectoryHasReadPermissions(It.IsAny<string>())).Returns(true).Verifiable();
+        fileSystemUtilsMock.Setup(f => f.DirectoryHasWritePermissions(It.IsAny<string>())).Returns(true).Verifiable();
+        fileSystemUtilsMock.Setup(f => f.JoinPaths(It.IsAny<string>(), It.IsAny<string>())).Returns(Path.Join(It.IsAny<string>(), It.IsAny<string>())).Verifiable();
+
+        var args = new RedactArgs
+        {
+            SbomDir = "SbomDir",
+            OutputPath = "OutputPath"
+        };
+
+        var configuration = await cb.GetConfiguration(args);
+
+        Assert.AreEqual(configuration.SbomDir.Source, SettingSource.CommandLine);
+        Assert.AreEqual(configuration.OutputPath.Source, SettingSource.CommandLine);
+
+        fileSystemUtilsMock.VerifyAll();
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ValidationArgException))]
+    public async Task ConfigurationBuilderTest_Redact_OuputPathNotWriteAccess_Throws()
+    {
+        var configFileParser = new ConfigFileParser(fileSystemUtilsMock.Object);
+        var cb = new ConfigurationBuilder<RedactArgs>(mapper, configFileParser);
+
+        fileSystemUtilsMock.Setup(f => f.DirectoryExists(It.IsAny<string>())).Returns(true);
+        fileSystemUtilsMock.Setup(f => f.DirectoryHasReadPermissions(It.IsAny<string>())).Returns(true);
+        fileSystemUtilsMock.Setup(f => f.DirectoryHasWritePermissions(It.IsAny<string>())).Returns(false);
+
+        var args = new RedactArgs
+        {
+            SbomDir = "SbomDir",
+            OutputPath = "OutputPath"
+        };
+
+        var configuration = await cb.GetConfiguration(args);
+    }
+}

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/SbomRedactionWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/SbomRedactionWorkflowTests.cs
@@ -39,7 +39,7 @@ public class SbomRedactionWorkflowTests
     }
 
     [TestMethod]
-    public async Task SbomParserBasedValidationWorkflowTests_ReturnsSuccessAndValidationFailures_IgnoreMissingTrue_Succeeds()
+    public async Task SbomRedactionTests_Succeeds()
     {
         mockLogger.Setup(x => x.Information($"Running redaction for SBOM path path and SBOM dir dir. Output dir: out"));
         configurationMock.SetupGet(c => c.SbomPath).Returns(new ConfigurationSetting<string> { Value = "path" });

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/SbomRedactionWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/SbomRedactionWorkflowTests.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+
+using System.Threading.Tasks;
+using Microsoft.Sbom.Api.Workflows;
+using Microsoft.Sbom.Common.Config;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Serilog;
+
+namespace Microsoft.Sbom.Workflows;
+
+#nullable enable
+
+[TestClass]
+public class SbomRedactionWorkflowTests
+{
+    private Mock<ILogger> mockLogger;
+    private Mock<IConfiguration> configurationMock;
+    private SbomRedactionWorkflow testSubject;
+
+    [TestInitialize]
+    public void Init()
+    {
+        mockLogger = new Mock<ILogger>();
+        configurationMock = new Mock<IConfiguration>();
+        testSubject = new SbomRedactionWorkflow(
+            mockLogger.Object,
+            configurationMock.Object);
+    }
+
+    [TestCleanup]
+    public void Reset()
+    {
+        mockLogger.VerifyAll();
+        configurationMock.VerifyAll();
+    }
+
+    [TestMethod]
+    public async Task SbomParserBasedValidationWorkflowTests_ReturnsSuccessAndValidationFailures_IgnoreMissingTrue_Succeeds()
+    {
+        mockLogger.Setup(x => x.Information($"Running redaction for SBOM path path and SBOM dir dir. Output dir: out"));
+        configurationMock.SetupGet(c => c.SbomPath).Returns(new ConfigurationSetting<string> { Value = "path" });
+        configurationMock.SetupGet(c => c.SbomDir).Returns(new ConfigurationSetting<string> { Value = "dir" });
+        configurationMock.SetupGet(c => c.OutputPath).Returns(new ConfigurationSetting<string> { Value = "out" });
+        var result = await testSubject.RunAsync();
+        Assert.IsTrue(result);
+    }
+}


### PR DESCRIPTION
Adding the new `redact` verb to the sbom tool CLI. For now this verb is excluded from the tool help since the actual redaction logic is not yet present. With these changes running redact simply prints the arguments provided for the command, but redaction logic will be added in a future PR. 

Once we turn this feature on it will show up in the help text as follows: 
```  
  Redact -options - Redact sensitive file information from given SBOM(s).

    Option            Description
    SbomPath (-sp)    The file path of the SBOM to redact.
    SbomDir (-sd)     The directory containing the sbom(s) to redact.
    OutputPath (-o)   Gets or sets the directory where the redacted SBOM file(s) will be generated.
    Verbosity (-V)    Display this amount of detail in the logging output.
                      Verbose
                      Debug
                      Information
                      Warning
                      Error
                      Fatal

  Version  - Displays the version of the tool being used. Can be used as '--version'
```

This PR also updates the style linter to be less strict about some comment style rules.