### PR TITLE
Add validate-format verb with placeholder for future validation

### DIFF
--- a/src/Microsoft.Sbom.Api/Config/Args/FormatValidationArgs.cs
+++ b/src/Microsoft.Sbom.Api/Config/Args/FormatValidationArgs.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Sbom.Api.Utils;
+using Microsoft.Sbom.Extensions.Entities;
+using PowerArgs;
+
+namespace Microsoft.Sbom.Api.Config.Args;
+
+/// <summary>
+/// The command line arguments provided for the validate action in ManifestTool.
+/// </summary>
+public class FormatValidationArgs : CommonArgs
+{
+    /// <summary>
+    /// Gets or sets the file path of the SBOM to validate.
+    /// </summary>
+    [ArgShortcut("sp")]
+    [ArgDescription("The file path of the SBOM to validate.")]
+    public string? SbomPath { get; set; }
+}

--- a/src/Microsoft.Sbom.Api/Config/ConfigSanitizer.cs
+++ b/src/Microsoft.Sbom.Api/Config/ConfigSanitizer.cs
@@ -147,17 +147,6 @@ public class ConfigSanitizer
                 throw new ValidationArgException($"Please provide a value for the BuildDropPath (-b) parameter to generate the SBOM.");
             }
         }
-        else if (configuration.ManifestToolAction == ManifestToolActions.ValidateFormat)
-        {
-            if (configuration.SbomPath.Value != null)
-            {
-                return;
-            }
-            else
-            {
-                throw new ValidationArgException($"Please provide a value for the SbomPath (-sp) parameter to validate the SBOM.");
-            }
-        }
         else
         {
             throw new ValidationArgException($"Please provide a value for the BuildDropPath (-b) parameter.");

--- a/src/Microsoft.Sbom.Api/Config/ConfigSanitizer.cs
+++ b/src/Microsoft.Sbom.Api/Config/ConfigSanitizer.cs
@@ -62,6 +62,8 @@ public class ConfigSanitizer
                 configuration.BuildDropPath = GetTempBuildDropPath(configuration);
         }
 
+        CheckValidateFormatConfig(configuration);
+
         configuration.HashAlgorithm = GetHashAlgorithmName(configuration);
 
         // set ManifestDirPath after validation of DirectoryExist and DirectoryPathIsWritable, this wouldn't exist because it needs to be created by the tool.
@@ -85,6 +87,19 @@ public class ConfigSanitizer
         logger.Dispose();
 
         return configuration;
+    }
+
+    private void CheckValidateFormatConfig(IConfiguration config)
+    {
+        if (config.ManifestToolAction != ManifestToolActions.ValidateFormat)
+        {
+            return;
+        }
+
+        if (config.SbomPath?.Value == null)
+        {
+            throw new ValidationArgException($"Please provide a value for the SbomPath (-sp) parameter to validate the SBOM.");
+        }
     }
 
     private ConfigurationSetting<IList<ManifestInfo>> GetDefaultManifestInfoForValidationAction(IConfiguration configuration)
@@ -130,6 +145,17 @@ public class ConfigSanitizer
             else
             {
                 throw new ValidationArgException($"Please provide a value for the BuildDropPath (-b) parameter to generate the SBOM.");
+            }
+        }
+        else if (configuration.ManifestToolAction == ManifestToolActions.ValidateFormat)
+        {
+            if (configuration.SbomPath.Value != null)
+            {
+                return;
+            }
+            else
+            {
+                throw new ValidationArgException($"Please provide a value for the SbomPath (-sp) parameter to validate the SBOM.");
             }
         }
         else

--- a/src/Microsoft.Sbom.Api/Config/ConfigurationBuilder.cs
+++ b/src/Microsoft.Sbom.Api/Config/ConfigurationBuilder.cs
@@ -41,6 +41,10 @@ public class ConfigurationBuilder<T> : IConfigurationBuilder<T>
                 redactArgs.ManifestToolAction = ManifestToolActions.Redact;
                 commandLineArgs = mapper.Map<InputConfiguration>(redactArgs);
                 break;
+            case FormatValidationArgs formatValidationArgs:
+                formatValidationArgs.ManifestToolAction = ManifestToolActions.ValidateFormat;
+                commandLineArgs = mapper.Map<InputConfiguration>(formatValidationArgs);
+                break;
             default:
                 throw new ValidationArgException($"Unsupported configuration type found {typeof(T)}");
         }

--- a/src/Microsoft.Sbom.Api/Config/SbomToolCmdRunner.cs
+++ b/src/Microsoft.Sbom.Api/Config/SbomToolCmdRunner.cs
@@ -44,6 +44,20 @@ public class SbomToolCmdRunner
     }
 
     /// <summary>
+    /// Validate a build artifact using the manifest. Optionally also verify the signing certificate of the manifest.
+    /// </summary>
+    /// <param name="validationArgs"></param>
+    [ArgShortcut("validate-format")]
+    [ArgShortcut("vf")]
+    [ArgActionMethod]
+    [ArgDescription("Validate the version and format of the SBOM")]
+    [OmitFromUsageDocs]
+    public FormatValidationArgs ValidateFormat(FormatValidationArgs validationArgs)
+    {
+        return validationArgs;
+    }
+
+    /// <summary>
     /// Generate a manifest.json and a bsi.json for all the files in the given build drop folder.
     /// </summary>
     [ArgActionMethod]

--- a/src/Microsoft.Sbom.Api/ConfigurationProfile.cs
+++ b/src/Microsoft.Sbom.Api/ConfigurationProfile.cs
@@ -42,6 +42,33 @@ public class ConfigurationProfile : Profile
             .ForMember(c => c.DeleteManifestDirIfPresent, o => o.Ignore())
             .ForMember(c => c.PackageSupplier, o => o.Ignore());
 
+        CreateMap<FormatValidationArgs, InputConfiguration>()
+#pragma warning disable CS0618 // 'Configuration.ManifestPath' is obsolete: 'This field is not provided by the user or configFile, set by system'
+            .ForMember(c => c.ManifestPath, o => o.Ignore())
+#pragma warning restore CS0618 // 'Configuration.ManifestPath' is obsolete: 'This field is not provided by the user or configFile, set by system'
+            .ForMember(c => c.HashAlgorithm, o => o.Ignore())
+            .ForMember(c => c.RootPathFilter, o => o.Ignore())
+            .ForMember(c => c.CatalogFilePath, o => o.Ignore())
+            .ForMember(c => c.ValidateSignature, o => o.Ignore())
+            .ForMember(c => c.PackagesList, o => o.Ignore())
+            .ForMember(c => c.FilesList, o => o.Ignore())
+            .ForMember(c => c.IgnoreMissing, o => o.Ignore())
+            .ForMember(c => c.FailIfNoPackages, o => o.Ignore())
+            .ForMember(c => c.PackageName, o => o.Ignore())
+            .ForMember(c => c.PackageVersion, o => o.Ignore())
+            .ForMember(c => c.BuildListFile, o => o.Ignore())
+            .ForMember(c => c.ExternalDocumentReferenceListFile, o => o.Ignore())
+            .ForMember(c => c.BuildComponentPath, o => o.Ignore())
+            .ForMember(c => c.PackagesList, o => o.Ignore())
+            .ForMember(c => c.FilesList, o => o.Ignore())
+            .ForMember(c => c.DockerImagesToScan, o => o.Ignore())
+            .ForMember(c => c.AdditionalComponentDetectorArgs, o => o.Ignore())
+            .ForMember(c => c.GenerationTimestamp, o => o.Ignore())
+            .ForMember(c => c.NamespaceUriUniquePart, o => o.Ignore())
+            .ForMember(c => c.NamespaceUriBase, o => o.Ignore())
+            .ForMember(c => c.DeleteManifestDirIfPresent, o => o.Ignore())
+            .ForMember(c => c.PackageSupplier, o => o.Ignore());
+
         // Create config for the generation args, ignoring other action members
         CreateMap<GenerationArgs, InputConfiguration>()
 #pragma warning disable CS0618 // 'Configuration.ManifestPath' is obsolete: 'This field is not provided by the user or configFile, set by system'

--- a/src/Microsoft.Sbom.Common/Config/ManifestToolActions.cs
+++ b/src/Microsoft.Sbom.Common/Config/ManifestToolActions.cs
@@ -12,5 +12,6 @@ public enum ManifestToolActions
     Validate = 1,
     Generate = 2,
     Redact = 4,
-    All = Validate | Generate | Redact
+    ValidateFormat = 8,
+    All = Validate | Generate | Redact | ValidateFormat
 }

--- a/src/Microsoft.Sbom.DotNetTool/FormatValidationService.cs
+++ b/src/Microsoft.Sbom.DotNetTool/FormatValidationService.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Sbom.Api;
+using Microsoft.Sbom.Api.Output.Telemetry;
+using Microsoft.Sbom.Common.Config;
+
+namespace Microsoft.Sbom.Tool;
+
+public class FormatValidationService : IHostedService
+{
+    private readonly IConfiguration config;
+    private readonly IRecorder recorder;
+    private readonly IHostApplicationLifetime hostApplicationLifetime;
+
+    public FormatValidationService(IConfiguration config,
+        IRecorder recorder,
+        IHostApplicationLifetime hostApplicationLifetime)
+    {
+        this.config = config;
+        this.recorder = recorder;
+        this.hostApplicationLifetime = hostApplicationLifetime;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            Console.WriteLine($"Format validation service called for {config.SbomPath.Value}");
+
+            await recorder.FinalizeAndLogTelemetryAsync();
+            Environment.ExitCode = true ? (int)ExitCode.Success : (int)ExitCode.ValidationError;
+        }
+        catch (Exception e)
+        {
+            var message = e.InnerException != null ? e.InnerException.Message : e.Message;
+            Console.WriteLine($"Encountered error while running format validation. Error: {message}");
+            Environment.ExitCode = (int)ExitCode.GeneralError;
+        }
+
+        hostApplicationLifetime.StopApplication();
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/src/Microsoft.Sbom.Tool/FormatValidationService.cs
+++ b/src/Microsoft.Sbom.Tool/FormatValidationService.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Sbom.Api;
+using Microsoft.Sbom.Api.Output.Telemetry;
+using Microsoft.Sbom.Common.Config;
+
+namespace Microsoft.Sbom.Tool;
+
+public class FormatValidationService : IHostedService
+{
+    private readonly IConfiguration config;
+    private readonly IRecorder recorder;
+    private readonly IHostApplicationLifetime hostApplicationLifetime;
+
+    public FormatValidationService(IConfiguration config,
+        IRecorder recorder,
+        IHostApplicationLifetime hostApplicationLifetime)
+    {
+        this.config = config;
+        this.recorder = recorder;
+        this.hostApplicationLifetime = hostApplicationLifetime;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            Console.WriteLine($"Format validation service called for {config.SbomPath.Value}");
+
+            await recorder.FinalizeAndLogTelemetryAsync();
+            Environment.ExitCode = true ? (int)ExitCode.Success : (int)ExitCode.ValidationError;
+        }
+        catch (Exception e)
+        {
+            var message = e.InnerException != null ? e.InnerException.Message : e.Message;
+            Console.WriteLine($"Encountered error while running format validation. Error: {message}");
+            Environment.ExitCode = (int)ExitCode.GeneralError;
+        }
+
+        hostApplicationLifetime.StopApplication();
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/src/Microsoft.Sbom.Tool/Program.cs
+++ b/src/Microsoft.Sbom.Tool/Program.cs
@@ -51,6 +51,7 @@ internal class Program
                         ValidationArgs v => services.AddHostedService<ValidationService>(),
                         GenerationArgs g => services.AddHostedService<GenerationService>(),
                         RedactArgs r => services.AddHostedService<RedactService>(),
+                        FormatValidationArgs f => services.AddHostedService<FormatValidationService>(),
                         _ => services
                     };
 
@@ -62,11 +63,13 @@ internal class Program
                             var validationConfigurationBuilder = x.GetService<IConfigurationBuilder<ValidationArgs>>();
                             var generationConfigurationBuilder = x.GetService<IConfigurationBuilder<GenerationArgs>>();
                             var redactConfigurationBuilder = x.GetService<IConfigurationBuilder<RedactArgs>>();
+                            var formatValidationConfigurationBuilder = x.GetService<IConfigurationBuilder<FormatValidationArgs>>();
                             var inputConfiguration = result.ActionArgs switch
                             {
                                 ValidationArgs v => validationConfigurationBuilder.GetConfiguration(v).GetAwaiter().GetResult(),
                                 GenerationArgs g => generationConfigurationBuilder.GetConfiguration(g).GetAwaiter().GetResult(),
                                 RedactArgs r => redactConfigurationBuilder.GetConfiguration(r).GetAwaiter().GetResult(),
+                                FormatValidationArgs f => formatValidationConfigurationBuilder.GetConfiguration(f).GetAwaiter().GetResult(),
                                 _ => default
                             };
 

--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigSanitizerTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigSanitizerTests.cs
@@ -123,6 +123,31 @@ public class ConfigSanitizerTests
     }
 
     [TestMethod]
+    public void NoValueForBuildDropPathForValidateFormat_Succeeds()
+    {
+        var config = GetConfigurationBaseObject();
+        config.ManifestToolAction = ManifestToolActions.ValidateFormat;
+        config.BuildDropPath = null;
+        config.SbomPath = new ConfigurationSetting<string>
+        {
+            Source = SettingSource.Default,
+            Value = "any non empty value"
+        };
+
+        configSanitizer.SanitizeConfig(config);
+    }
+
+    [TestMethod]
+    public void NoValueForSbomPathForValidateFormat_Throws()
+    {
+        var config = GetConfigurationBaseObject();
+        config.ManifestToolAction = ManifestToolActions.ValidateFormat;
+        config.SbomPath = null;
+
+        Assert.ThrowsException<ValidationArgException>(() => configSanitizer.SanitizeConfig(config));
+    }
+
+    [TestMethod]
     public void NoValueForManifestInfoForValidation_SetsDefaultValue()
     {
         var config = GetConfigurationBaseObject();


### PR DESCRIPTION
Wire up a validate-format verb that runs the format validation logic for a specified file. This is a hidden verb that I imagine being used during development, and in future by DRI to explore an SBOM or troubleshoot a validation failure. This change is just the boilerplate required to add and call the new verb; actual validation logic will be in the next PR.