### PR TITLE
Add Validate Format functionality

### DIFF
--- a/src/Microsoft.Sbom.Api/FormatValidator/FormatValidationResults.cs
+++ b/src/Microsoft.Sbom.Api/FormatValidator/FormatValidationResults.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Sbom.Api.FormatValidator;
+
+using System.Collections.Generic;
+
+public class FormatValidationResults
+{
+    public FormatValidationStatus Status { get; private set; } = FormatValidationStatus.Unknown;
+
+    // Update the validation status, without overwriting a previous NotValid status.
+    public void AggregateValidationStatus(FormatValidationStatus newStatus)
+    {
+        // If status never set, always overwrite.
+        if (Status == FormatValidationStatus.Unknown)
+        {
+            Status = newStatus;
+            return;
+        }
+
+        // If previous status not valid, never overwrite.
+        if (Status == FormatValidationStatus.NotValid)
+        {
+            return;
+        }
+
+        // If previous status valid, always overwrite.
+        Status = newStatus;
+    }
+
+    public List<string> Errors { get; set; } = new List<string>();
+}

--- a/src/Microsoft.Sbom.Api/FormatValidator/FormatValidationStatus.cs
+++ b/src/Microsoft.Sbom.Api/FormatValidator/FormatValidationStatus.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Sbom.Api.FormatValidator;
+
+public enum FormatValidationStatus
+{
+    Unknown,
+    Valid,
+    NotValid
+}

--- a/src/Microsoft.Sbom.Api/FormatValidator/RuntimeJsonPropertyValidator.cs
+++ b/src/Microsoft.Sbom.Api/FormatValidator/RuntimeJsonPropertyValidator.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Sbom.Api.FormatValidator;
+
+using System;
+using System.Linq;
+using System.Text.Json.Serialization.Metadata;
+using Microsoft.Sbom.Common.Utils;
+
+// Use this class to ignore or require JSON properties at runtime.
+// Specify the type being deserialized (e.g. IEnumerable<SPDXFile>) as either ignored or required.
+// Then set UpdateTypeIgnoreOrRequire as a JsonSerializerOptions.TypeInfoResolver.Modifiers.
+public class RuntimeJsonPropertyValidator
+{
+    private readonly Type[] ignoredTypes;
+    private readonly Type[] requiredTypes;
+
+    public RuntimeJsonPropertyValidator(Type[] ignoredTypes, Type[] requiredTypes)
+    {
+        this.ignoredTypes = ignoredTypes;
+        this.requiredTypes = requiredTypes;
+    }
+
+    public void UpdateTypeIgnoreOrRequire(JsonTypeInfo info)
+    {
+        if (info.Kind != JsonTypeInfoKind.Object)
+        {
+            return;
+        }
+
+        // To ignore a Type, remove it from the properties list altogether.
+        info.Properties.RemoveAll(p => ignoredTypes.Contains(p.PropertyType));
+
+        foreach (var property in info.Properties)
+        {
+            if (requiredTypes.Contains(property.PropertyType))
+            {
+                property.IsRequired = true;
+            }
+        }
+    }
+}

--- a/src/Microsoft.Sbom.Api/FormatValidator/ValidatedSBOM.cs
+++ b/src/Microsoft.Sbom.Api/FormatValidator/ValidatedSBOM.cs
@@ -119,13 +119,10 @@ public class ValidatedSBOM
         return ValidationDetails;
     }
 
-    public List<string> MultilineSummary()
+    public async Task<List<string>> MultilineSummary()
     {
+        await Initialize();
         var description = new List<string>();
-        if (!isInitialized)
-        {
-            return description;
-        }
 
         if (ValidationDetails.Status != FormatValidationStatus.Valid)
         {

--- a/src/Microsoft.Sbom.Api/FormatValidator/ValidatedSBOM.cs
+++ b/src/Microsoft.Sbom.Api/FormatValidator/ValidatedSBOM.cs
@@ -1,0 +1,164 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Sbom.Api.FormatValidator;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using System.Threading.Tasks;
+using Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
+using Microsoft.Sbom.Utils;
+
+public class ValidatedSBOM
+{
+    private readonly Stream sbomStream;
+    private readonly int requiredSpdxMajorVersion = 2;
+    private readonly RuntimeJsonPropertyValidator propertyValidator = new RuntimeJsonPropertyValidator(ignoredTypes: [typeof(IEnumerable<SPDXFile>)],
+                                                                                                       requiredTypes: [typeof(IEnumerable<SPDXPackage>), typeof(IEnumerable<SPDXRelationship>)]);
+
+    private readonly JsonSerializerOptions serializerOptions;
+    private bool isInitialized = false;
+    private FormatEnforcedSPDX2 sbom;
+
+    private FormatValidationResults ValidationDetails { get; set; } = new FormatValidationResults();
+
+    public ValidatedSBOM(Stream sbomStream)
+    {
+        this.sbomStream = sbomStream;
+        serializerOptions = ConfigureSerializer();
+    }
+
+    public async Task<FormatValidationResults> GetValidationResults()
+    {
+        await Initialize();
+        return ValidationDetails;
+    }
+
+    public async Task<FormatEnforcedSPDX2> GetRawSPDXDocument()
+    {
+        await Initialize();
+
+        if (ValidationDetails.Status != FormatValidationStatus.Valid)
+        {
+            return null;
+        }
+
+        return sbom;
+    }
+
+    private async Task Initialize()
+    {
+        if (isInitialized)
+        {
+            return;
+        }
+
+        isInitialized = true;
+        sbom = await Deserialize();
+        ValidationDetails = Validate();
+    }
+
+    private async Task<FormatEnforcedSPDX2> Deserialize()
+    {
+        if (sbomStream is null)
+        {
+            ValidationDetails.AggregateValidationStatus(FormatValidationStatus.NotValid);
+            ValidationDetails.Errors.Add("SBOM stream is null. Error reading file.");
+            return null;
+        }
+
+        FormatEnforcedSPDX2 sbom = null;
+        try
+        {
+            sbom = await JsonSerializer.DeserializeAsync<FormatEnforcedSPDX2>(sbomStream, serializerOptions);
+        }
+        catch (Exception e)
+        {
+            ValidationDetails.AggregateValidationStatus(FormatValidationStatus.NotValid);
+            ValidationDetails.Errors.Add($"Error deserializing SBOM: {e.Message}");
+        }
+
+        return sbom;
+    }
+
+    private JsonSerializerOptions ConfigureSerializer()
+    {
+        var options = new JsonSerializerOptions()
+        {
+            TypeInfoResolver = new DefaultJsonTypeInfoResolver
+            {
+                Modifiers = { propertyValidator.UpdateTypeIgnoreOrRequire }
+            }
+        };
+
+        return options;
+    }
+
+    private FormatValidationResults Validate()
+    {
+        if (sbom is null)
+        {
+            // Early return so we don't misleadingly report a version error when we actually
+            // failed to deserialize.
+            ValidationDetails.AggregateValidationStatus(FormatValidationStatus.NotValid);
+            return ValidationDetails;
+        }
+
+        if (SPDXVersionParser.VersionMatchesRequiredVersion(sbom?.Version, requiredSpdxMajorVersion))
+        {
+            ValidationDetails.AggregateValidationStatus(FormatValidationStatus.Valid);
+            return ValidationDetails;
+        }
+
+        ValidationDetails.AggregateValidationStatus(FormatValidationStatus.NotValid);
+        ValidationDetails.Errors.Add($"SBOM version {sbom?.Version} is not recognized as SPDX major version 2.");
+        return ValidationDetails;
+    }
+
+    public List<string> MultilineSummary()
+    {
+        var description = new List<string>();
+        if (!isInitialized)
+        {
+            return description;
+        }
+
+        if (ValidationDetails.Status != FormatValidationStatus.Valid)
+        {
+            description.Add("SBOM format validation failed. Please see the following errors:");
+            description.Add("------------------------------");
+            foreach (var error in ValidationDetails.Errors)
+            {
+                description.Add(error);
+            }
+
+            description.Add("------------------------------");
+        }
+        else
+        {
+            description.Add("SBOM format validation passed.");
+            description.Add("------------------------------");
+            description.Add($"SPDX Version: {sbom.Version}");
+            description.Add($"Name: {sbom.Name}");
+            description.Add($"Created: {sbom.CreationInfo?.Created}");
+
+            foreach (var creator in sbom.CreationInfo?.Creators)
+            {
+                description.Add($"Creator: {creator}");
+            }
+
+            description.Add($"Contains {sbom.Files?.ToList().Count ?? 0} Files");
+            description.Add($"Contains {sbom.Packages?.ToList().Count ?? 0} Packages");
+            description.Add($"Contains {sbom.Relationships?.ToList().Count ?? 0} Relationships");
+            description.Add($"Contains {sbom.ExternalDocumentReferences?.ToList().Count ?? 0} External Document References");
+            description.Add($"Contains {sbom.Snippets?.ToList().Count ?? 0} Snippets");
+            description.Add("------------------------------");
+        }
+
+        return description;
+    }
+}

--- a/src/Microsoft.Sbom.Common/Utils/ListUtils.cs
+++ b/src/Microsoft.Sbom.Common/Utils/ListUtils.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Sbom.Common.Utils;
+
+using System;
+using System.Collections.Generic;
+
+public static class ListUtils
+{
+    // RemoveAll only added in .NET 8.0.
+    public static void RemoveAll<T>(this IList<T> list, Predicate<T> predicate)
+    {
+        for (var i = 0; i < list.Count; i++)
+        {
+            if (predicate(list[i]))
+            {
+                list.RemoveAt(i--);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Sbom.DotNetTool/FormatValidationService.cs
+++ b/src/Microsoft.Sbom.DotNetTool/FormatValidationService.cs
@@ -44,10 +44,7 @@ public class FormatValidationService : IHostedService
             using (var sbomStream = new StreamReader(config.SbomPath.Value))
             {
                 var validatedSbom = new ValidatedSBOM(sbomStream.BaseStream);
-                var details = await validatedSbom.GetValidationResults();
-                var sbom = await validatedSbom.GetRawSPDXDocument();
-
-                PrintLines(validatedSbom.MultilineSummary());
+                PrintLines(await validatedSbom.MultilineSummary());
             }
 
             await recorder.FinalizeAndLogTelemetryAsync();

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Annotation.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Annotation.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
+
+using System;
+using System.Text.Json.Serialization;
+
+public class Annotation
+{
+    [JsonPropertyName("annotationDate")]
+    public DateTime AnnotationDate { get; set; }
+
+    [JsonPropertyName("annotationType")]
+    public string AnnotationType { get; set; }
+
+    [JsonPropertyName("annotator")]
+    public string Annotator { get; set; }
+
+    [JsonPropertyName("comment")]
+    public string Comment { get; set; }
+}

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/CreationInfo.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/CreationInfo.cs
@@ -11,6 +11,9 @@ namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
 /// </summary>
 public class CreationInfo
 {
+    [JsonPropertyName("comment")]
+    public string Comment { get; set; }
+
     /// <summary>
     /// Gets or sets a string that specifies the time the SBOM was created on.
     /// </summary>
@@ -23,4 +26,7 @@ public class CreationInfo
     /// </summary>
     [JsonPropertyName("creators")]
     public IEnumerable<string> Creators { get; set; }
+
+    [JsonPropertyName("licenseListVersion")]
+    public string LicenseListVersion { get; set; }
 }

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/ExternalReference.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/ExternalReference.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Text.Json.Serialization;
-using Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities.Enums;
 
 namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
 
@@ -34,4 +33,8 @@ public class ExternalReference
     [JsonRequired]
     [JsonPropertyName("referenceLocator")]
     public string Locator { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("comment")]
+    public string Comment { get; set; }
 }

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/ExtractedLicensingInfo.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/ExtractedLicensingInfo.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+public class ExtractedLicensingInfo
+{
+    [JsonPropertyName("licenseId")]
+    public string LicenseId { get; set; }
+
+    [JsonPropertyName("extractedText")]
+    public string ExtractedText { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("comment")]
+    public string Comment { get; set; }
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("seeAlsos")]
+    public IEnumerable<string> SeeAlsos { get; set; }
+}

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/FormatEnforcedSPDX2.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/FormatEnforcedSPDX2.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+public class FormatEnforcedSPDX2 : SPDX2RequiredProperties
+{
+    // These attributes are not required by the SPDX spec, but may be present in
+    // SBOMs produced by sbom-tool or 3P SBOMs. We want to (de)serialize them if they are present.
+    [JsonPropertyName("comment")]
+    public string Comment { get; set; }
+
+    [JsonPropertyName("documentDescribes")]
+    public IEnumerable<string> DocumentDescribes { get; set; }
+
+    [JsonPropertyName("files")]
+    public IEnumerable<SPDXFile> Files { get; set; }
+
+    [JsonPropertyName("packages")]
+    public IEnumerable<SPDXPackage> Packages { get; set; }
+
+    [JsonPropertyName("relationships")]
+    public IEnumerable<SPDXRelationship> Relationships { get; set; }
+
+    // These attributes are not required, and not serialized by sbom-tool SBOMs, but may be present
+    // if we are operating on a 3P SBOM. If they are there, we want to deserialize them, so that we
+    // do not lose any information if we re-serialize later.
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("externalDocumentRefs")]
+    public IEnumerable<SpdxExternalDocumentReference> ExternalDocumentReferences { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("snippets")]
+    public IEnumerable<Snippet> Snippets { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("hasExtractedLicensingInfos")]
+    public IEnumerable<ExtractedLicensingInfo> ExtractedLicensingInfos { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("annotations")]
+    public IEnumerable<Annotation> Annotations { get; set; }
+}

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Pointer.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Pointer.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
+
+using System.Text.Json.Serialization;
+
+public class Pointer
+{
+    [JsonPropertyName("offset")]
+    public int Offset { get; set; }
+
+    [JsonPropertyName("reference")]
+    public string Reference { get; set; }
+}

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Range.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Range.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
+
+using System.Text.Json.Serialization;
+
+public class Range
+{
+    [JsonPropertyName("endPointer")]
+    public Pointer EndPointer { get; set; }
+
+    [JsonPropertyName("startPointer")]
+    public Pointer StartPointer { get; set; }
+}

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SPDX2RequiredProperties.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SPDX2RequiredProperties.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
+
+using System.Text.Json.Serialization;
+
+// This class uses JSON serialization attributes to enforce the SPDX 2.x format
+// Metadata fields tagged as required are required by the SPDX 2.x specification.
+public class SPDX2RequiredProperties
+{
+    // These attributes are required by the SPDX 2.x spec.
+    [JsonRequired]
+    [JsonPropertyName("spdxVersion")]
+    public string Version { get; set; }
+
+    [JsonRequired]
+    [JsonPropertyName("dataLicense")]
+    public string DataLicense { get; set; }
+
+    [JsonRequired]
+    [JsonPropertyName("SPDXID")]
+    public string SPDXID { get; set; }
+
+    [JsonRequired]
+    [JsonPropertyName("name")]
+    public string Name { get; set; }
+
+    [JsonRequired]
+    [JsonPropertyName("documentNamespace")]
+    public string DocumentNamespace { get; set; }
+
+    [JsonRequired]
+    [JsonPropertyName("creationInfo")]
+    public CreationInfo CreationInfo { get; set; }
+}

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SPDXPackage.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SPDXPackage.cs
@@ -113,4 +113,52 @@ public class SPDXPackage
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("hasFiles")]
     public List<string> HasFiles { get; set; }
+
+    [JsonIgnore(Condition =JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("annotations")]
+    public List<Annotation> Annotations { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("attributionTexts")]
+    public List<string> AttibutionTexts;
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("builtDate")]
+    public string BuiltDate { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("description")]
+    public string Description { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("homepage")]
+    public string Homepage { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("licenseComments")]
+    public string LicenseComments { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("originator")]
+    public string Originator { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("primaryPackagePurpose")]
+    public string PrimaryPackagePurpose { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("releaseDate")]
+    public string ReleaseDate { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("sourceInfo")]
+    public string SourceInfo { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("summary")]
+    public string Summary { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("validUntilDate")]
+    public string ValidUntilDate { get; set; }
 }

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Snippet.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Snippet.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+public class Snippet
+{
+    [JsonPropertyName("SPDXID")]
+    public string SPDXID { get; set; }
+
+    [JsonPropertyName("comment")]
+    public string Comment { get; set; }
+
+    [JsonPropertyName("copyrightText")]
+    public string CopyrightText { get; set; }
+
+    [JsonPropertyName("licenseComments")]
+    public string LicenseComments { get; set; }
+
+    [JsonPropertyName("licenseConcluded")]
+    public string LicenseConcluded { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("licenseInfoInSnippets")]
+    public IEnumerable<string> LicenseInfoInSnippets { get; set; }
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; }
+
+    [JsonPropertyName("ranges")]
+    public IEnumerable<Range> Ranges { get; set; }
+
+    [JsonPropertyName("snippetFromFile")]
+    public string SnippetFromFile { get; set; }
+}

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/SPDXVersionParser.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/SPDXVersionParser.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Sbom.Utils;
+
+using System;
+
+public static class SPDXVersionParser
+{
+    // SPDX versions are of the form "SPDX-m.n". We only care about the major version.
+    public static bool VersionMatchesRequiredVersion(string spdxVersionString, int requiredMajorVersion)
+    {
+        if (string.IsNullOrEmpty(spdxVersionString))
+        {
+            return false;
+        }
+
+        var spdxTag = "SPDX-";
+        var start = spdxVersionString.IndexOf(spdxTag, StringComparison.InvariantCulture);
+        if (start == -1)
+        {
+            return false;
+        }
+
+        start += spdxTag.Length;
+
+        var end = spdxVersionString.IndexOf(".", start, StringComparison.InvariantCulture);
+        if (!int.TryParse(spdxVersionString[start..end], out var majorVersion))
+        {
+            return false;
+        }
+
+        return majorVersion == requiredMajorVersion;
+    }
+}

--- a/src/Microsoft.Sbom.Tool/FormatValidationService.cs
+++ b/src/Microsoft.Sbom.Tool/FormatValidationService.cs
@@ -44,10 +44,7 @@ public class FormatValidationService : IHostedService
             using (var sbomStream = new StreamReader(config.SbomPath.Value))
             {
                 var validatedSbom = new ValidatedSBOM(sbomStream.BaseStream);
-                var details = await validatedSbom.GetValidationResults();
-                var sbom = await validatedSbom.GetRawSPDXDocument();
-
-                PrintLines(validatedSbom.MultilineSummary());
+                PrintLines(await validatedSbom.MultilineSummary());
             }
 
             await recorder.FinalizeAndLogTelemetryAsync();

--- a/test/Microsoft.Sbom.Api.Tests/FormatValidator/FormatValidatorTestStrings.cs
+++ b/test/Microsoft.Sbom.Api.Tests/FormatValidator/FormatValidatorTestStrings.cs
@@ -16,11 +16,11 @@ internal readonly struct FormatValidatorTestStrings
                 ""dataLicense"": ""CC0-1.0"",
                 ""SPDXID"": ""SPDXRef-DOCUMENT"",
                 ""name"": ""sbom-tool 1.0.0"",
-                ""documentNamespace"": ""https://microsoft.com/sbom-tool/alisontest/sbom-tool/1.0.0/cuK7iCCPVEuSmgBfeFPc-g"",
+                ""documentNamespace"": ""https://microsoft.com/sbom-tool/test/sbom-tool/1.0.0/cuK7iCCPVEuSmgBfeFPc-g"",
                 ""creationInfo"": {
                 ""created"": ""2024-05-08T15:58:25Z"",
                 ""creators"": [
-                    ""Organization: AlisonTest"",
+                    ""Organization: Test"",
                     ""Tool: Microsoft.SBOMTool-2.2.5""
                     ]},
                 ""documentDescribes"": [
@@ -35,11 +35,11 @@ internal readonly struct FormatValidatorTestStrings
                 ""dataLicense"": ""CC0-1.0"",
                 ""SPDXID"": ""SPDXRef-DOCUMENT"",
                 ""name"": ""sbom-tool 1.0.0"",
-                ""documentNamespace"": ""https://microsoft.com/sbom-tool/alisontest/sbom-tool/1.0.0/cuK7iCCPVEuSmgBfeFPc-g"",
+                ""documentNamespace"": ""https://microsoft.com/sbom-tool/test/sbom-tool/1.0.0/cuK7iCCPVEuSmgBfeFPc-g"",
                 ""creationInfo"": {
                 ""created"": ""2024-05-08T15:58:25Z"",
                 ""creators"": [
-                    ""Organization: AlisonTest"",
+                    ""Organization: Test"",
                     ""Tool: Microsoft.SBOMTool-2.2.5""
                     ]},
                 ""documentDescribes"": [
@@ -58,7 +58,7 @@ internal readonly struct FormatValidatorTestStrings
                 ""creationInfo"": {
                 ""created"": ""2024-05-08T15:58:25Z"",
                 ""creators"": [
-                    ""Organization: AlisonTest"",
+                    ""Organization: Test"",
                     ""Tool: Microsoft.SBOMTool-2.2.5""
                     ]},
                 ""documentDescribes"": [
@@ -73,11 +73,11 @@ internal readonly struct FormatValidatorTestStrings
                 ""spdxVersion"": ""SPDX-2.2"",
                 ""SPDXID"": ""SPDXRef-DOCUMENT"",
                 ""name"": ""sbom-tool 1.0.0"",
-                ""documentNamespace"": ""https://microsoft.com/sbom-tool/alisontest/sbom-tool/1.0.0/cuK7iCCPVEuSmgBfeFPc-g"",
+                ""documentNamespace"": ""https://microsoft.com/sbom-tool/test/sbom-tool/1.0.0/cuK7iCCPVEuSmgBfeFPc-g"",
                 ""creationInfo"": {
                 ""created"": ""2024-05-08T15:58:25Z"",
                 ""creators"": [
-                    ""Organization: AlisonTest"",
+                    ""Organization: Test"",
                     ""Tool: Microsoft.SBOMTool-2.2.5""
                     ]},
                 ""documentDescribes"": [
@@ -92,11 +92,11 @@ internal readonly struct FormatValidatorTestStrings
                 ""spdxVersion"": ""SPDX-2.2"",
                 ""SPDXID"": ""SPDXRef-DOCUMENT"",
                 ""dataLicense"": ""CC0-1.0"",
-                ""documentNamespace"": ""https://microsoft.com/sbom-tool/alisontest/sbom-tool/1.0.0/cuK7iCCPVEuSmgBfeFPc-g"",
+                ""documentNamespace"": ""https://microsoft.com/sbom-tool/test/sbom-tool/1.0.0/cuK7iCCPVEuSmgBfeFPc-g"",
                 ""creationInfo"": {
                 ""created"": ""2024-05-08T15:58:25Z"",
                 ""creators"": [
-                    ""Organization: AlisonTest"",
+                    ""Organization: Test"",
                     ""Tool: Microsoft.SBOMTool-2.2.5""
                     ]},
                 ""documentDescribes"": [
@@ -111,11 +111,11 @@ internal readonly struct FormatValidatorTestStrings
                 ""spdxVersion"": ""SPDX-2.2"",
                 ""SPDXID"": ""SPDXRef-DOCUMENT"",
                 ""dataLicense"": ""CC0-1.0"",
-                ""documentNamespace"": ""https://microsoft.com/sbom-tool/alisontest/sbom-tool/1.0.0/cuK7iCCPVEuSmgBfeFPc-g"",
+                ""documentNamespace"": ""https://microsoft.com/sbom-tool/test/sbom-tool/1.0.0/cuK7iCCPVEuSmgBfeFPc-g"",
                 ""creationInfo"": {
                 ""created"": ""2024-05-08T15:58:25Z"",
                 ""creators"": [
-                    ""Organization: AlisonTest"",
+                    ""Organization: Test"",
                     ""Tool: Microsoft.SBOMTool-2.2.5""
                     ]},
                 ""documentDescribes"": [
@@ -130,11 +130,11 @@ internal readonly struct FormatValidatorTestStrings
                 ""spdxVersion"": ""SPDX-2.2"",
                 ""SPDXID"": ""SPDXRef-DOCUMENT"",
                 ""dataLicense"": ""CC0-1.0"",
-                ""documentNamespace"": ""https://microsoft.com/sbom-tool/alisontest/sbom-tool/1.0.0/cuK7iCCPVEuSmgBfeFPc-g"",
+                ""documentNamespace"": ""https://microsoft.com/sbom-tool/test/sbom-tool/1.0.0/cuK7iCCPVEuSmgBfeFPc-g"",
                 ""creationInfo"": {
                 ""created"": ""2024-05-08T15:58:25Z"",
                 ""creators"": [
-                    ""Organization: AlisonTest"",
+                    ""Organization: Test"",
                     ""Tool: Microsoft.SBOMTool-2.2.5""
                     ]},
                 ""documentDescribes"": [
@@ -150,7 +150,7 @@ internal readonly struct FormatValidatorTestStrings
                 ""spdxVersion"": ""SPDX-2.2"",
                 ""SPDXID"": ""SPDXRef-DOCUMENT"",
                 ""dataLicense"": ""CC0-1.0"",
-                ""documentNamespace"": ""https://microsoft.com/sbom-tool/alisontest/sbom-tool/1.0.0/cuK7iCCPVEuSmgBfeFPc-g"",
+                ""documentNamespace"": ""https://microsoft.com/sbom-tool/test/sbom-tool/1.0.0/cuK7iCCPVEuSmgBfeFPc-g"",
                 ""documentDescribes"": [
                     ""SPDXRef-RootPackage""
                     ]}";
@@ -164,11 +164,11 @@ internal readonly struct FormatValidatorTestStrings
                 ""spdxVersion"": ""SPDX-3.2"",
                 ""SPDXID"": ""SPDXRef-DOCUMENT"",
                 ""dataLicense"": ""CC0-1.0"",
-                ""documentNamespace"": ""https://microsoft.com/sbom-tool/alisontest/sbom-tool/1.0.0/cuK7iCCPVEuSmgBfeFPc-g"",
+                ""documentNamespace"": ""https://microsoft.com/sbom-tool/test/sbom-tool/1.0.0/cuK7iCCPVEuSmgBfeFPc-g"",
                 ""creationInfo"": {
                 ""created"": ""2024-05-08T15:58:25Z"",
                 ""creators"": [
-                    ""Organization: AlisonTest"",
+                    ""Organization: Test"",
                     ""Tool: Microsoft.SBOMTool-2.2.5""
                     ]},
                 ""documentDescribes"": [
@@ -184,11 +184,11 @@ internal readonly struct FormatValidatorTestStrings
                 ""spdxVersion"": ""SPDX-3.2"",
                 ""SPDXID"": ""SPDXRef-DOCUMENT"",
                 ""dataLicense"": ""CC0-1.0"",
-                ""documentNamespace"": ""https://microsoft.com/sbom-tool/alisontest/sbom-tool/1.0.0/cuK7iCCPVEuSmgBfeFPc-g"",
+                ""documentNamespace"": ""https://microsoft.com/sbom-tool/test/sbom-tool/1.0.0/cuK7iCCPVEuSmgBfeFPc-g"",
                 ""creationInfo"": {
                 ""created"": ""2024-05-08T15:58:25Z"",
                 ""creators"": [
-                    ""Organization: AlisonTest"",
+                    ""Organization: Test"",
                     ""Tool: Microsoft.SBOMTool-2.2.5""
                     ]},
                 ""documentDescribes"": [

--- a/test/Microsoft.Sbom.Api.Tests/FormatValidator/FormatValidatorTestStrings.cs
+++ b/test/Microsoft.Sbom.Api.Tests/FormatValidator/FormatValidatorTestStrings.cs
@@ -1,0 +1,197 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Sbom.Api.Tests.FormatValidator;
+
+internal readonly struct FormatValidatorTestStrings
+{
+    // Means a legal 2.x SPDX with required SPDX properties, packages, and relationships.
+    // Files may be present but will be ignored.
+    public const string JsonSuitableForRedaction = /*lang=json,strict*/ @"{
+                ""files"":[],
+                ""packages"":[],
+                ""relationships"":[],
+                ""externalDocumentRefs"":[],
+                ""spdxVersion"": ""SPDX-2.2"",
+                ""dataLicense"": ""CC0-1.0"",
+                ""SPDXID"": ""SPDXRef-DOCUMENT"",
+                ""name"": ""sbom-tool 1.0.0"",
+                ""documentNamespace"": ""https://microsoft.com/sbom-tool/alisontest/sbom-tool/1.0.0/cuK7iCCPVEuSmgBfeFPc-g"",
+                ""creationInfo"": {
+                ""created"": ""2024-05-08T15:58:25Z"",
+                ""creators"": [
+                    ""Organization: AlisonTest"",
+                    ""Tool: Microsoft.SBOMTool-2.2.5""
+                    ]},
+                ""documentDescribes"": [
+                    ""SPDXRef-RootPackage""
+                    ]}";
+
+    public const string JsonMissingSpdxVersion = /*lang=json,strict*/ @"{
+                ""files"":[],
+                ""packages"":[],
+                ""relationships"":[],
+                ""externalDocumentRefs"":[],
+                ""dataLicense"": ""CC0-1.0"",
+                ""SPDXID"": ""SPDXRef-DOCUMENT"",
+                ""name"": ""sbom-tool 1.0.0"",
+                ""documentNamespace"": ""https://microsoft.com/sbom-tool/alisontest/sbom-tool/1.0.0/cuK7iCCPVEuSmgBfeFPc-g"",
+                ""creationInfo"": {
+                ""created"": ""2024-05-08T15:58:25Z"",
+                ""creators"": [
+                    ""Organization: AlisonTest"",
+                    ""Tool: Microsoft.SBOMTool-2.2.5""
+                    ]},
+                ""documentDescribes"": [
+                    ""SPDXRef-RootPackage""
+                    ]}";
+
+    public const string JsonMissingDocumentNamespace = /*lang=json,strict*/ @"{
+                ""files"":[],
+                ""packages"":[],
+                ""relationships"":[],
+                ""externalDocumentRefs"":[],
+                ""dataLicense"": ""CC0-1.0"",
+                ""spdxVersion"": ""SPDX-2.2"",
+                ""name"": ""sbom-tool 1.0.0"",
+                ""SPDXID"": ""SPDXRef-DOCUMENT"",
+                ""creationInfo"": {
+                ""created"": ""2024-05-08T15:58:25Z"",
+                ""creators"": [
+                    ""Organization: AlisonTest"",
+                    ""Tool: Microsoft.SBOMTool-2.2.5""
+                    ]},
+                ""documentDescribes"": [
+                    ""SPDXRef-RootPackage""
+                    ]}";
+
+    public const string JsonMissingSpdxDataLicense = /*lang=json,strict*/ @"{
+                ""files"":[],
+                ""packages"":[],
+                ""relationships"":[],
+                ""externalDocumentRefs"":[],
+                ""spdxVersion"": ""SPDX-2.2"",
+                ""SPDXID"": ""SPDXRef-DOCUMENT"",
+                ""name"": ""sbom-tool 1.0.0"",
+                ""documentNamespace"": ""https://microsoft.com/sbom-tool/alisontest/sbom-tool/1.0.0/cuK7iCCPVEuSmgBfeFPc-g"",
+                ""creationInfo"": {
+                ""created"": ""2024-05-08T15:58:25Z"",
+                ""creators"": [
+                    ""Organization: AlisonTest"",
+                    ""Tool: Microsoft.SBOMTool-2.2.5""
+                    ]},
+                ""documentDescribes"": [
+                    ""SPDXRef-RootPackage""
+                    ]}";
+
+    public const string JsonMissingSpdxName = /*lang=json,strict*/ @"{
+                ""files"":[],
+                ""packages"":[],
+                ""relationships"":[],
+                ""externalDocumentRefs"":[],
+                ""spdxVersion"": ""SPDX-2.2"",
+                ""SPDXID"": ""SPDXRef-DOCUMENT"",
+                ""dataLicense"": ""CC0-1.0"",
+                ""documentNamespace"": ""https://microsoft.com/sbom-tool/alisontest/sbom-tool/1.0.0/cuK7iCCPVEuSmgBfeFPc-g"",
+                ""creationInfo"": {
+                ""created"": ""2024-05-08T15:58:25Z"",
+                ""creators"": [
+                    ""Organization: AlisonTest"",
+                    ""Tool: Microsoft.SBOMTool-2.2.5""
+                    ]},
+                ""documentDescribes"": [
+                    ""SPDXRef-RootPackage""
+                    ]}";
+
+    public const string JsonMissingSpdxPackages = /*lang=json,strict*/ @"{
+                ""files"":[],
+                ""relationships"":[],
+                ""name"": ""sbom-tool 1.0.0"",
+                ""externalDocumentRefs"":[],
+                ""spdxVersion"": ""SPDX-2.2"",
+                ""SPDXID"": ""SPDXRef-DOCUMENT"",
+                ""dataLicense"": ""CC0-1.0"",
+                ""documentNamespace"": ""https://microsoft.com/sbom-tool/alisontest/sbom-tool/1.0.0/cuK7iCCPVEuSmgBfeFPc-g"",
+                ""creationInfo"": {
+                ""created"": ""2024-05-08T15:58:25Z"",
+                ""creators"": [
+                    ""Organization: AlisonTest"",
+                    ""Tool: Microsoft.SBOMTool-2.2.5""
+                    ]},
+                ""documentDescribes"": [
+                    ""SPDXRef-RootPackage""
+                    ]}";
+
+    public const string JsonMissingSpdxRelationships = /*lang=json,strict*/ @"{
+                ""files"":[],
+                ""packages"":[],
+                ""name"": ""sbom-tool 1.0.0"",
+                ""externalDocumentRefs"":[],
+                ""spdxVersion"": ""SPDX-2.2"",
+                ""SPDXID"": ""SPDXRef-DOCUMENT"",
+                ""dataLicense"": ""CC0-1.0"",
+                ""documentNamespace"": ""https://microsoft.com/sbom-tool/alisontest/sbom-tool/1.0.0/cuK7iCCPVEuSmgBfeFPc-g"",
+                ""creationInfo"": {
+                ""created"": ""2024-05-08T15:58:25Z"",
+                ""creators"": [
+                    ""Organization: AlisonTest"",
+                    ""Tool: Microsoft.SBOMTool-2.2.5""
+                    ]},
+                ""documentDescribes"": [
+                    ""SPDXRef-RootPackage""
+                    ]}";
+
+    public const string JsonMissingSpdxCreationInfo = /*lang=json,strict*/ @"{
+                ""files"":[],
+                ""packages"":[],
+                ""relationships"":[],
+                ""externalDocumentRefs"":[],
+                ""name"": ""sbom-tool 1.0.0"",
+                ""spdxVersion"": ""SPDX-2.2"",
+                ""SPDXID"": ""SPDXRef-DOCUMENT"",
+                ""dataLicense"": ""CC0-1.0"",
+                ""documentNamespace"": ""https://microsoft.com/sbom-tool/alisontest/sbom-tool/1.0.0/cuK7iCCPVEuSmgBfeFPc-g"",
+                ""documentDescribes"": [
+                    ""SPDXRef-RootPackage""
+                    ]}";
+
+    public const string JsonUnsupportedSpdxVersion = /*lang=json,strict*/ @"{
+                ""files"":[],
+                ""packages"":[],
+                ""relationships"":[],
+                ""name"": ""sbom-tool 1.0.0"",
+                ""externalDocumentRefs"":[],
+                ""spdxVersion"": ""SPDX-3.2"",
+                ""SPDXID"": ""SPDXRef-DOCUMENT"",
+                ""dataLicense"": ""CC0-1.0"",
+                ""documentNamespace"": ""https://microsoft.com/sbom-tool/alisontest/sbom-tool/1.0.0/cuK7iCCPVEuSmgBfeFPc-g"",
+                ""creationInfo"": {
+                ""created"": ""2024-05-08T15:58:25Z"",
+                ""creators"": [
+                    ""Organization: AlisonTest"",
+                    ""Tool: Microsoft.SBOMTool-2.2.5""
+                    ]},
+                ""documentDescribes"": [
+                    ""SPDXRef-RootPackage""
+                    ]}";
+
+    public const string MalformedJson = @"{
+                ""files"":[],
+                ""packages"":[],
+                ""relationships"":[],
+                ""name"": ""sbom-tool 1.0.0"",
+                ""externalDocumentRefs"":[,
+                ""spdxVersion"": ""SPDX-3.2"",
+                ""SPDXID"": ""SPDXRef-DOCUMENT"",
+                ""dataLicense"": ""CC0-1.0"",
+                ""documentNamespace"": ""https://microsoft.com/sbom-tool/alisontest/sbom-tool/1.0.0/cuK7iCCPVEuSmgBfeFPc-g"",
+                ""creationInfo"": {
+                ""created"": ""2024-05-08T15:58:25Z"",
+                ""creators"": [
+                    ""Organization: AlisonTest"",
+                    ""Tool: Microsoft.SBOMTool-2.2.5""
+                    ]},
+                ""documentDescribes"": [
+                    ""SPDXRef-RootPackage""
+                    ]}";
+}

--- a/test/Microsoft.Sbom.Api.Tests/FormatValidator/FormatValidatorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/FormatValidator/FormatValidatorTests.cs
@@ -30,7 +30,7 @@ public class FormatValidatorTests
             Assert.AreEqual("SPDX-2.2", rawspdx.Version);
             Assert.AreEqual("CC0-1.0", rawspdx.DataLicense);
             Assert.AreEqual("sbom-tool 1.0.0", rawspdx.Name);
-            Assert.AreEqual("https://microsoft.com/sbom-tool/alisontest/sbom-tool/1.0.0/cuK7iCCPVEuSmgBfeFPc-g", rawspdx.DocumentNamespace);
+            Assert.AreEqual("https://microsoft.com/sbom-tool/test/sbom-tool/1.0.0/cuK7iCCPVEuSmgBfeFPc-g", rawspdx.DocumentNamespace);
             Assert.AreEqual(rawspdx.CreationInfo.Created, "2024-05-08T15:58:25Z");
             Assert.IsNotNull(rawspdx.CreationInfo.Creators);
             Assert.IsNotNull(rawspdx.DocumentDescribes);

--- a/test/Microsoft.Sbom.Api.Tests/FormatValidator/FormatValidatorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/FormatValidator/FormatValidatorTests.cs
@@ -1,0 +1,185 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Sbom.Api.FormatValidator;
+using Microsoft.Sbom.Utils;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Sbom.Api.Tests.FormatValidator;
+
+[TestClass]
+public class FormatValidatorTests
+{
+    [TestMethod]
+    public async Task FormatValidator_CanReadValidSbom()
+    {
+        using (var sbomStream = CreateStream(FormatValidatorTestStrings.JsonSuitableForRedaction))
+        {
+            var sbom = new ValidatedSBOM(sbomStream);
+            var rawspdx = await sbom.GetRawSPDXDocument();
+            var details = await sbom.GetValidationResults();
+
+            Assert.AreEqual(FormatValidationStatus.Valid, details.Status);
+            Assert.IsTrue(details.Errors.Count == 0);
+            Assert.IsNotNull(rawspdx);
+            Assert.AreEqual("SPDX-2.2", rawspdx.Version);
+            Assert.AreEqual("CC0-1.0", rawspdx.DataLicense);
+            Assert.AreEqual("sbom-tool 1.0.0", rawspdx.Name);
+            Assert.AreEqual("https://microsoft.com/sbom-tool/alisontest/sbom-tool/1.0.0/cuK7iCCPVEuSmgBfeFPc-g", rawspdx.DocumentNamespace);
+            Assert.AreEqual(rawspdx.CreationInfo.Created, "2024-05-08T15:58:25Z");
+            Assert.IsNotNull(rawspdx.CreationInfo.Creators);
+            Assert.IsNotNull(rawspdx.DocumentDescribes);
+        }
+    }
+
+    [DataTestMethod]
+    [DataRow(FormatValidatorTestStrings.JsonMissingSpdxVersion, "spdxVersion")]
+    [DataRow(FormatValidatorTestStrings.JsonMissingSpdxDataLicense, "dataLicense")]
+    [DataRow(FormatValidatorTestStrings.JsonMissingDocumentNamespace, "documentNamespace")]
+    [DataRow(FormatValidatorTestStrings.JsonMissingSpdxName, "name")]
+    [DataRow(FormatValidatorTestStrings.JsonMissingSpdxPackages, "packages")]
+    [DataRow(FormatValidatorTestStrings.JsonMissingSpdxRelationships, "relationships")]
+    [DataRow(FormatValidatorTestStrings.JsonMissingSpdxCreationInfo, "creationInfo")]
+    public async Task FormatValidator_FailsIfRequiredAttributeMissing(string json, string attribute)
+    {
+        using (var sbomStream = CreateStream(json))
+        {
+            var sbom = new ValidatedSBOM(sbomStream);
+            var rawspdx = await sbom.GetRawSPDXDocument();
+            var details = await sbom.GetValidationResults();
+
+            Assert.AreEqual(FormatValidationStatus.NotValid, details.Status);
+            Assert.IsTrue(details.Errors.Count > 0);
+
+            // We want the error message to clearly signal the missing element.
+            Assert.IsTrue(ErrorContains(details.Errors, attribute));
+            Assert.IsTrue(ErrorContains(details.Errors, "missing required properties"));
+        }
+    }
+
+    [TestMethod]
+    public async Task FormatValidator_FailsForUnsupportedVersion()
+    {
+        // In the real world this is an unlikely scenario; SPDX v3 is so different from v2 that an attempt
+        // to deserialize using a v2 model will fail. So this is more likely to catch some scenario where
+        // the document was 2.x but the version was improperly serialized.
+        using (var sbomStream = CreateStream(FormatValidatorTestStrings.JsonUnsupportedSpdxVersion))
+        {
+            var sbom = new ValidatedSBOM(sbomStream);
+            var rawspdx = await sbom.GetRawSPDXDocument();
+            var details = await sbom.GetValidationResults();
+
+            Assert.AreEqual(FormatValidationStatus.NotValid, details.Status);
+            Assert.IsTrue(details.Errors.Count > 0);
+
+            // We want the error message to clearly signal the erroring element.
+            Assert.IsTrue(ErrorContains(details.Errors, "SPDX-3.2 is not recognized"));
+        }
+    }
+
+    [TestMethod]
+    public async Task FormatValidator_FailsForMalformedJson()
+    {
+        using (var sbomStream = CreateStream(FormatValidatorTestStrings.MalformedJson))
+        {
+            var sbom = new ValidatedSBOM(sbomStream);
+            var rawspdx = await sbom.GetRawSPDXDocument();
+            var details = await sbom.GetValidationResults();
+
+            Assert.AreEqual(FormatValidationStatus.NotValid, details.Status);
+            Assert.IsTrue(details.Errors.Count > 0);
+
+            // We want the error message to indicate that this is a Json parse error, and providing
+            // context on where the error occurred is helpful too.
+            Assert.IsTrue(ErrorContains(details.Errors, "is an invalid start of a value"));
+            Assert.IsTrue(ErrorContains(details.Errors, "Path: $.externalDocumentRefs[0]"));
+        }
+    }
+
+    [TestMethod]
+    public async Task FormatValidator_CanDeserializeAllSpdx23Attributes()
+    {
+        using (var sbomStream = CreateStream(SpdxExemplars.JsonSpdx23Exemplar))
+        {
+            var sbom = new ValidatedSBOM(sbomStream);
+            var rawspdx = await sbom.GetRawSPDXDocument();
+            var details = await sbom.GetValidationResults();
+
+            Assert.AreEqual(FormatValidationStatus.Valid, details.Status);
+            Assert.AreEqual("SPDXRef-DOCUMENT", rawspdx.SPDXID);
+            Assert.AreEqual("SPDX-2.3", rawspdx.Version);
+            Assert.AreEqual("CC0-1.0", rawspdx.DataLicense);
+            Assert.AreEqual(5, rawspdx.ExtractedLicensingInfos.ToList().Count);
+            Assert.AreEqual(1, rawspdx.ExternalDocumentReferences.ToList().Count);
+            Assert.AreEqual(3, rawspdx.Annotations.ToList().Count);
+            Assert.AreEqual(1, rawspdx.Snippets.ToList().Count);
+        }
+    }
+
+    [TestMethod]
+    public void ValidationDetails_AggregateValidationStatus()
+    {
+        var details = new FormatValidationResults();
+        details.AggregateValidationStatus(FormatValidationStatus.Valid);
+        Assert.AreEqual(FormatValidationStatus.Valid, details.Status);
+
+        details.AggregateValidationStatus(FormatValidationStatus.Valid);
+        Assert.AreEqual(FormatValidationStatus.Valid, details.Status);
+
+        details.AggregateValidationStatus(FormatValidationStatus.NotValid);
+        Assert.AreEqual(FormatValidationStatus.NotValid, details.Status);
+
+        // Once we detect any validation failure, the status should always stay NotValid.
+        details.AggregateValidationStatus(FormatValidationStatus.Valid);
+        Assert.AreEqual(FormatValidationStatus.NotValid, details.Status);
+    }
+
+    [TestMethod]
+    public void SPDXVersionParsing_CanParseVersion()
+    {
+        var version = "SPDX-2.3";
+        var versionMatched = SPDXVersionParser.VersionMatchesRequiredVersion(version, 2);
+        Assert.IsTrue(versionMatched);
+
+        version = "SPDX-2.2";
+        versionMatched = SPDXVersionParser.VersionMatchesRequiredVersion(version, 2);
+        Assert.IsTrue(versionMatched);
+
+        version = "version 2.2";
+        versionMatched = SPDXVersionParser.VersionMatchesRequiredVersion(version, 2);
+        Assert.IsFalse(versionMatched);
+
+        version = "SPDX-3.0";
+        versionMatched = SPDXVersionParser.VersionMatchesRequiredVersion(version, 2);
+        Assert.IsFalse(versionMatched);
+
+        version = "frimplepants";
+        versionMatched = SPDXVersionParser.VersionMatchesRequiredVersion(version, 2);
+        Assert.IsFalse(versionMatched);
+    }
+
+    private Stream CreateStream(string json)
+    {
+        var utf8BOM = Encoding.UTF8.GetString(Encoding.UTF8.Preamble);
+        var bytes = Encoding.UTF8.GetBytes(utf8BOM + json);
+        return new MemoryStream(bytes);
+    }
+
+    private bool ErrorContains(List<string> errors, string message)
+    {
+        foreach (var error in errors)
+        {
+            if (error.Contains(message))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/test/Microsoft.Sbom.Api.Tests/FormatValidator/SpdxExemplars.cs
+++ b/test/Microsoft.Sbom.Api.Tests/FormatValidator/SpdxExemplars.cs
@@ -1,0 +1,306 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Sbom.Api.Tests.FormatValidator;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+internal readonly struct SpdxExemplars
+{
+    public const string JsonSpdx23Exemplar = /*lang=json,strict*/ @"{
+  ""SPDXID"" : ""SPDXRef-DOCUMENT"",
+  ""spdxVersion"" : ""SPDX-2.3"",
+  ""creationInfo"" : {
+    ""comment"" : ""This package has been shipped in source and binary form.\nThe binaries were created with gcc 4.5.1 and expect to link to\ncompatible system run time libraries."",
+    ""created"" : ""2010-01-29T18:30:22Z"",
+    ""creators"" : [ ""Tool: LicenseFind-1.0"", ""Organization: ExampleCodeInspect ()"", ""Person: Jane Doe ()"" ],
+    ""licenseListVersion"" : ""3.17""
+  },
+  ""name"" : ""SPDX-Tools-v2.0"",
+  ""dataLicense"" : ""CC0-1.0"",
+  ""comment"" : ""This document was created using SPDX 2.0 using licenses from the web site."",
+  ""externalDocumentRefs"" : [ {
+    ""externalDocumentId"" : ""DocumentRef-spdx-tool-1.2"",
+    ""checksum"" : {
+      ""algorithm"" : ""SHA1"",
+      ""checksumValue"" : ""d6a770ba38583ed4bb4525bd96e50461655d2759""
+    },
+    ""spdxDocument"" : ""http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301""
+  } ],
+  ""hasExtractedLicensingInfos"" : [ {
+    ""licenseId"" : ""LicenseRef-1"",
+    ""extractedText"" : ""/*\n * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n*/""
+  }, {
+    ""licenseId"" : ""LicenseRef-2"",
+    ""extractedText"" : ""This package includes the GRDDL parser developed by Hewlett Packard under the following license:\n© Copyright 2007 Hewlett-Packard Development Company, LP\n\nRedistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: \n\nRedistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. \nRedistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. \nThe name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. \nTHIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.""
+  }, {
+    ""licenseId"" : ""LicenseRef-4"",
+    ""extractedText"" : ""/*\n * (c) Copyright 2009 University of Bristol\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n*/""
+  }, {
+    ""licenseId"" : ""LicenseRef-Beerware-4.2"",
+    ""comment"" : ""The beerware license has a couple of other standard variants."",
+    ""extractedText"" : ""\""THE BEER-WARE LICENSE\"" (Revision 42):\nphk@FreeBSD.ORG wrote this file. As long as you retain this notice you\ncan do whatever you want with this stuff. If we meet some day, and you think this stuff is worth it, you can buy me a beer in return Poul-Henning Kamp"",
+    ""name"" : ""Beer-Ware License (Version 42)"",
+    ""seeAlsos"" : [ ""http://people.freebsd.org/~phk/"" ]
+  }, {
+    ""licenseId"" : ""LicenseRef-3"",
+    ""comment"" : ""This is tye CyperNeko License"",
+    ""extractedText"" : ""The CyberNeko Software License, Version 1.0\n\n \n(C) Copyright 2002-2005, Andy Clark.  All rights reserved.\n \nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions\nare met:\n\n1. Redistributions of source code must retain the above copyright\n   notice, this list of conditions and the following disclaimer. \n\n2. Redistributions in binary form must reproduce the above copyright\n   notice, this list of conditions and the following disclaimer in\n   the documentation and/or other materials provided with the\n   distribution.\n\n3. The end-user documentation included with the redistribution,\n   if any, must include the following acknowledgment:  \n     \""This product includes software developed by Andy Clark.\""\n   Alternately, this acknowledgment may appear in the software itself,\n   if and wherever such third-party acknowledgments normally appear.\n\n4. The names \""CyberNeko\"" and \""NekoHTML\"" must not be used to endorse\n   or promote products derived from this software without prior \n   written permission. For written permission, please contact \n   andyc@cyberneko.net.\n\n5. Products derived from this software may not be called \""CyberNeko\"",\n   nor may \""CyberNeko\"" appear in their name, without prior written\n   permission of the author.\n\nTHIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED\nWARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\nOF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS\nBE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, \nOR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT \nOF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR \nBUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, \nWHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE \nOR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, \nEVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."",
+    ""name"" : ""CyberNeko License"",
+    ""seeAlsos"" : [ ""http://people.apache.org/~andyc/neko/LICENSE"", ""http://justasample.url.com"" ]
+  } ],
+  ""annotations"" : [ {
+    ""annotationDate"" : ""2010-01-29T18:30:22Z"",
+    ""annotationType"" : ""OTHER"",
+    ""annotator"" : ""Person: Jane Doe ()"",
+    ""comment"" : ""Document level annotation""
+  }, {
+    ""annotationDate"" : ""2010-02-10T00:00:00Z"",
+    ""annotationType"" : ""REVIEW"",
+    ""annotator"" : ""Person: Joe Reviewer"",
+    ""comment"" : ""This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses""
+  }, {
+    ""annotationDate"" : ""2011-03-13T00:00:00Z"",
+    ""annotationType"" : ""REVIEW"",
+    ""annotator"" : ""Person: Suzanne Reviewer"",
+    ""comment"" : ""Another example reviewer.""
+  } ],
+  ""documentDescribes"" : [ ""SPDXRef-File"", ""SPDXRef-Package"" ],
+  ""documentNamespace"" : ""http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301"",
+  ""packages"" : [ {
+    ""SPDXID"" : ""SPDXRef-Package"",
+    ""annotations"" : [ {
+      ""annotationDate"" : ""2011-01-29T18:30:22Z"",
+      ""annotationType"" : ""OTHER"",
+      ""annotator"" : ""Person: Package Commenter"",
+      ""comment"" : ""Package level annotation""
+    } ],
+    ""attributionTexts"" : [ ""The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually."" ],
+    ""builtDate"" : ""2011-01-29T18:30:22Z"",
+    ""checksums"" : [ {
+      ""algorithm"" : ""MD5"",
+      ""checksumValue"" : ""624c1abb3664f4b35547e7c73864ad24""
+    }, {
+      ""algorithm"" : ""SHA1"",
+      ""checksumValue"" : ""85ed0817af83a24ad8da68c2b5094de69833983c""
+    }, {
+      ""algorithm"" : ""SHA256"",
+      ""checksumValue"" : ""11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd""
+    }, {
+      ""algorithm"" : ""BLAKE2b-384"",
+      ""checksumValue"" : ""aaabd89c926ab525c242e6621f2f5fa73aa4afe3d9e24aed727faaadd6af38b620bdb623dd2b4788b1c8086984af8706""
+    } ],
+    ""copyrightText"" : ""Copyright 2008-2010 John Smith"",
+    ""description"" : ""The GNU C Library defines functions that are specified by the ISO C standard, as well as additional features specific to POSIX and other derivatives of the Unix operating system, and extensions specific to GNU systems."",
+    ""downloadLocation"" : ""http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz"",
+    ""externalRefs"" : [ {
+      ""referenceCategory"" : ""SECURITY"",
+      ""referenceLocator"" : ""cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:*"",
+      ""referenceType"" : ""cpe23Type""
+    }, {
+      ""comment"" : ""This is the external ref for Acme"",
+      ""referenceCategory"" : ""OTHER"",
+      ""referenceLocator"" : ""acmecorp/acmenator/4.1.3-alpha"",
+      ""referenceType"" : ""http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#LocationRef-acmeforge""
+    } ],
+    ""filesAnalyzed"" : true,
+    ""homepage"" : ""http://ftp.gnu.org/gnu/glibc"",
+    ""licenseComments"" : ""The license for this project changed with the release of version x.y.  The version of the project included here post-dates the license change."",
+    ""licenseConcluded"" : ""(LGPL-2.0-only OR LicenseRef-3)"",
+    ""licenseDeclared"" : ""(LGPL-2.0-only AND LicenseRef-3)"",
+    ""licenseInfoFromFiles"" : [ ""GPL-2.0-only"", ""LicenseRef-2"", ""LicenseRef-1"" ],
+    ""name"" : ""glibc"",
+    ""originator"" : ""Organization: ExampleCodeInspect (contact@example.com)"",
+    ""packageFileName"" : ""glibc-2.11.1.tar.gz"",
+    ""packageVerificationCode"" : {
+      ""packageVerificationCodeExcludedFiles"" : [ ""./package.spdx"" ],
+      ""packageVerificationCodeValue"" : ""d6a770ba38583ed4bb4525bd96e50461655d2758""
+    },
+    ""primaryPackagePurpose"" : ""SOURCE"",
+    ""hasFiles"" : [ ""SPDXRef-Specification"", ""SPDXRef-Specification"", ""SPDXRef-CommonsLangSrc"", ""SPDXRef-Specification"", ""SPDXRef-CommonsLangSrc"", ""SPDXRef-JenaLib"", ""SPDXRef-Specification"", ""SPDXRef-CommonsLangSrc"", ""SPDXRef-JenaLib"", ""SPDXRef-DoapSource"", ""SPDXRef-Specification"", ""SPDXRef-CommonsLangSrc"", ""SPDXRef-JenaLib"", ""SPDXRef-DoapSource"" ],
+    ""releaseDate"" : ""2012-01-29T18:30:22Z"",
+    ""sourceInfo"" : ""uses glibc-2_11-branch from git://sourceware.org/git/glibc.git."",
+    ""summary"" : ""GNU C library."",
+    ""supplier"" : ""Person: Jane Doe (jane.doe@example.com)"",
+    ""validUntilDate"" : ""2014-01-29T18:30:22Z"",
+    ""versionInfo"" : ""2.11.1""
+  }, {
+    ""SPDXID"" : ""SPDXRef-fromDoap-1"",
+    ""copyrightText"" : ""NOASSERTION"",
+    ""downloadLocation"" : ""NOASSERTION"",
+    ""filesAnalyzed"" : false,
+    ""homepage"" : ""http://commons.apache.org/proper/commons-lang/"",
+    ""licenseConcluded"" : ""NOASSERTION"",
+    ""licenseDeclared"" : ""NOASSERTION"",
+    ""supplier"" : ""Person: Jane Doe (jane.doe@example.com)"",
+    ""name"" : ""Apache Commons Lang""
+  }, {
+    ""SPDXID"" : ""SPDXRef-fromDoap-0"",
+    ""downloadLocation"" : ""https://search.maven.org/remotecontent?filepath=org/apache/jena/apache-jena/3.12.0/apache-jena-3.12.0.tar.gz"",
+    ""externalRefs"" : [ {
+      ""referenceCategory"" : ""PACKAGE-MANAGER"",
+      ""referenceLocator"" : ""pkg:maven/org.apache.jena/apache-jena@3.12.0"",
+      ""referenceType"" : ""purl""
+    } ],
+    ""supplier"": ""NOASSERTION"",
+    ""filesAnalyzed"" : false,
+    ""homepage"" : ""http://www.openjena.org/"",
+    ""name"" : ""Jena"",
+    ""versionInfo"" : ""3.12.0""
+  }, {
+    ""SPDXID"" : ""SPDXRef-Saxon"",
+    ""checksums"" : [ {
+      ""algorithm"" : ""SHA1"",
+      ""checksumValue"" : ""85ed0817af83a24ad8da68c2b5094de69833983c""
+    } ],
+    ""copyrightText"" : ""Copyright Saxonica Ltd"",
+    ""description"" : ""The Saxon package is a collection of tools for processing XML documents."",
+    ""downloadLocation"" : ""https://sourceforge.net/projects/saxon/files/Saxon-B/8.8.0.7/saxonb8-8-0-7j.zip/download"",
+    ""filesAnalyzed"" : false,
+    ""homepage"" : ""http://saxon.sourceforge.net/"",
+    ""licenseComments"" : ""Other versions available for a commercial license"",
+    ""licenseConcluded"" : ""MPL-1.0"",
+    ""licenseDeclared"" : ""MPL-1.0"",
+    ""name"" : ""Saxon"",
+    ""packageFileName"" : ""saxonB-8.8.zip"",
+    ""supplier"" : ""Person: Jane Doe (jane.doe@example.com)"",
+    ""versionInfo"" : ""8.8""
+  } ],
+  ""files"" : [ {
+    ""SPDXID"" : ""SPDXRef-DoapSource"",
+    ""checksums"" : [ {
+      ""algorithm"" : ""SHA1"",
+      ""checksumValue"" : ""2fd4e1c67a2d28fced849ee1bb76e7391b93eb12""
+    } ],
+    ""copyrightText"" : ""Copyright 2010, 2011 Source Auditor Inc."",
+    ""fileContributors"" : [ ""Protecode Inc."", ""SPDX Technical Team Members"", ""Open Logic Inc."", ""Source Auditor Inc."", ""Black Duck Software In.c"" ],
+    ""fileName"" : ""./src/org/spdx/parser/DOAPProject.java"",
+    ""fileTypes"" : [ ""SOURCE"" ],
+    ""licenseConcluded"" : ""Apache-2.0"",
+    ""licenseInfoInFiles"" : [ ""Apache-2.0"" ]
+  }, {
+    ""SPDXID"" : ""SPDXRef-CommonsLangSrc"",
+    ""checksums"" : [ {
+      ""algorithm"" : ""SHA1"",
+      ""checksumValue"" : ""c2b4e1c67a2d28fced849ee1bb76e7391b93f125""
+    } ],
+    ""comment"" : ""This file is used by Jena"",
+    ""copyrightText"" : ""Copyright 2001-2011 The Apache Software Foundation"",
+    ""fileContributors"" : [ ""Apache Software Foundation"" ],
+    ""fileName"" : ""./lib-source/commons-lang3-3.1-sources.jar"",
+    ""fileTypes"" : [ ""ARCHIVE"" ],
+    ""licenseConcluded"" : ""Apache-2.0"",
+    ""licenseInfoInFiles"" : [ ""Apache-2.0"" ],
+    ""noticeText"" : ""Apache Commons Lang\nCopyright 2001-2011 The Apache Software Foundation\n\nThis product includes software developed by\nThe Apache Software Foundation (http://www.apache.org/).\n\nThis product includes software from the Spring Framework,\nunder the Apache License 2.0 (see: StringUtils.containsWhitespace())""
+  }, {
+    ""SPDXID"" : ""SPDXRef-JenaLib"",
+    ""checksums"" : [ {
+      ""algorithm"" : ""SHA1"",
+      ""checksumValue"" : ""3ab4e1c67a2d28fced849ee1bb76e7391b93f125""
+    } ],
+    ""comment"" : ""This file belongs to Jena"",
+    ""copyrightText"" : ""(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP"",
+    ""fileContributors"" : [ ""Apache Software Foundation"", ""Hewlett Packard Inc."" ],
+    ""fileName"" : ""./lib-source/jena-2.6.3-sources.jar"",
+    ""fileTypes"" : [ ""ARCHIVE"" ],
+    ""licenseComments"" : ""This license is used by Jena"",
+    ""licenseConcluded"" : ""LicenseRef-1"",
+    ""licenseInfoInFiles"" : [ ""LicenseRef-1"" ]
+  }, {
+    ""SPDXID"" : ""SPDXRef-Specification"",
+    ""checksums"" : [ {
+      ""algorithm"" : ""SHA1"",
+      ""checksumValue"" : ""fff4e1c67a2d28fced849ee1bb76e7391b93f125""
+    } ],
+    ""comment"" : ""Specification Documentation"",
+    ""fileName"" : ""./docs/myspec.pdf"",
+    ""fileTypes"" : [ ""DOCUMENTATION"" ]
+  }, {
+    ""SPDXID"" : ""SPDXRef-File"",
+    ""annotations"" : [ {
+      ""annotationDate"" : ""2011-01-29T18:30:22Z"",
+      ""annotationType"" : ""OTHER"",
+      ""annotator"" : ""Person: File Commenter"",
+      ""comment"" : ""File level annotation""
+    } ],
+    ""checksums"" : [ {
+      ""algorithm"" : ""SHA1"",
+      ""checksumValue"" : ""d6a770ba38583ed4bb4525bd96e50461655d2758""
+    }, {
+      ""algorithm"" : ""MD5"",
+      ""checksumValue"" : ""624c1abb3664f4b35547e7c73864ad24""
+    } ],
+    ""comment"" : ""The concluded license was taken from the package level that the file was included in.\nThis information was found in the COPYING.txt file in the xyz directory."",
+    ""copyrightText"" : ""Copyright 2008-2010 John Smith"",
+    ""fileContributors"" : [ ""The Regents of the University of California"", ""Modified by Paul Mundt lethal@linux-sh.org"", ""IBM Corporation"" ],
+    ""fileName"" : ""./package/foo.c"",
+    ""fileTypes"" : [ ""SOURCE"" ],
+    ""licenseComments"" : ""The concluded license was taken from the package level that the file was included in."",
+    ""licenseConcluded"" : ""(LGPL-2.0-only OR LicenseRef-2)"",
+    ""licenseInfoInFiles"" : [ ""GPL-2.0-only"", ""LicenseRef-2"" ],
+    ""noticeText"" : ""Copyright (c) 2001 Aaron Lehmann aaroni@vitelus.com\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \""Software\""), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: \nThe above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \""AS IS\"", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.""
+  } ],
+  ""snippets"" : [ {
+    ""SPDXID"" : ""SPDXRef-Snippet"",
+    ""comment"" : ""This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0."",
+    ""copyrightText"" : ""Copyright 2008-2010 John Smith"",
+    ""licenseComments"" : ""The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz."",
+    ""licenseConcluded"" : ""GPL-2.0-only"",
+    ""licenseInfoInSnippets"" : [ ""GPL-2.0-only"" ],
+    ""name"" : ""from linux kernel"",
+    ""ranges"" : [ {
+      ""endPointer"" : {
+        ""offset"" : 420,
+        ""reference"" : ""SPDXRef-DoapSource""
+      },
+      ""startPointer"" : {
+        ""offset"" : 310,
+        ""reference"" : ""SPDXRef-DoapSource""
+      }
+    }, {
+      ""endPointer"" : {
+        ""lineNumber"" : 23,
+        ""reference"" : ""SPDXRef-DoapSource""
+      },
+      ""startPointer"" : {
+        ""lineNumber"" : 5,
+        ""reference"" : ""SPDXRef-DoapSource""
+      }
+    } ],
+    ""snippetFromFile"" : ""SPDXRef-DoapSource""
+  } ],
+  ""relationships"" : [ {
+    ""spdxElementId"" : ""SPDXRef-DOCUMENT"",
+    ""relationshipType"" : ""CONTAINS"",
+    ""relatedSpdxElement"" : ""SPDXRef-Package""
+  }, {
+    ""spdxElementId"" : ""SPDXRef-DOCUMENT"",
+    ""relationshipType"" : ""COPY_OF"",
+    ""relatedSpdxElement"" : ""DocumentRef-spdx-tool-1.2:SPDXRef-ToolsElement""
+  }, {
+    ""spdxElementId"" : ""SPDXRef-Package"",
+    ""relationshipType"" : ""DYNAMIC_LINK"",
+    ""relatedSpdxElement"" : ""SPDXRef-Saxon""
+  }, {
+    ""spdxElementId"" : ""SPDXRef-CommonsLangSrc"",
+    ""relationshipType"" : ""GENERATED_FROM"",
+    ""relatedSpdxElement"" : ""NOASSERTION""
+  }, {
+    ""spdxElementId"" : ""SPDXRef-JenaLib"",
+    ""relationshipType"" : ""CONTAINS"",
+    ""relatedSpdxElement"" : ""SPDXRef-Package""
+  }, {
+    ""spdxElementId"" : ""SPDXRef-Specification"",
+    ""relationshipType"" : ""SPECIFICATION_FOR"",
+    ""relatedSpdxElement"" : ""SPDXRef-fromDoap-0""
+  }, {
+    ""spdxElementId"" : ""SPDXRef-File"",
+    ""relationshipType"" : ""GENERATED_FROM"",
+    ""relatedSpdxElement"" : ""SPDXRef-fromDoap-0""
+  } ]
+}";
+}


### PR DESCRIPTION
Implement a format validation service in support of redacting the Files section from an SPDX 2.x format SBOM.

This is a naive implementation that does ***not*** leverage the JSON object streaming mechanism that is used for drop validation. The reason for this is that it is fairly complex to amend that logic to customize the validation behavior. Since we are operating on a very tight timeline, the preliminary redaction implementation will rely on deserializing the entire JSON file at once, on the assumption that will cover a large proportion of our in-the-wild use cases. A follow-on investigation will be conducted to determine the practical limits of this technique and necessity for extending to support larger SBOMs.

The criteria for a "valid" SBOM include:
- well-formed JSON document
- includes required SPDX elements
- SPDX v2.x
- Packages and Relationships sections present

Validating SBOMs for SPDX elements covering the NTIA definition of an SBOM is out of scope for this change. Such validation may not be practical when processing 3P SBOMs since an SBOM creator could choose to use different attributes to satisfy the NTIA requirements.

In context of redaction, we will skip deserializing the files section (since removing it is the purpose of redaction anyway - this is also expected to reduce the size of an SBOM by ~50%). We will also require Packages and Relationships, since we need to operate on those in order to successfully redact. These ignore/require expectations are set at runtime but currently hardcoded; making them configurable is out of scope for this feature but definitely feasible.

The JSON validation and SPDX required elements are explicitly and implicitly enforced by the JSON model definition and deserialization. This also implicitly enforces the SPDX version since v3 is so different in format that the deserialization would fail before we ever got to a version check. Nonetheless, we make our expectations explicit by also parsing and verifying the spdxVersion value.

Expanding support for all SPDX 2.x (previously only SPDX 2.2.1) was in scope for this feature, and was accomplished by eliminating the use of enums for deserialization (an earlier PR) and adding to the JSON model all properties found in the SPDX 2.3 exemplar document (https://github.com/spdx/spdx-spec/blob/development/v2.3.1/examples/SPDXJSONExample-v2.3.spdx.json). SPDX 2.3 is backwards compatible with earlier 2.x versions. Note that this expanded SPDX version support ***only*** applies to the Validate Format and Redact functionality, ***not*** to Generate or Drop Validation. Adding all documented properties to the model also ensures that we do not lose data when deserializing/re-serializing after redaction.