### PR TITLE
Add redaction workflow logic

### DIFF
--- a/src/Microsoft.Sbom.Api/FormatValidator/IValidatedSBOM.cs
+++ b/src/Microsoft.Sbom.Api/FormatValidator/IValidatedSBOM.cs
@@ -11,4 +11,6 @@ public interface IValidatedSBOM
     public Task<FormatValidationResults> GetValidationResults();
 
     public Task<FormatEnforcedSPDX2> GetRawSPDXDocument();
+
+    public void Dispose();
 }

--- a/src/Microsoft.Sbom.Api/FormatValidator/IValidatedSBOM.cs
+++ b/src/Microsoft.Sbom.Api/FormatValidator/IValidatedSBOM.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Sbom.Api.FormatValidator;
+
+using System.Threading.Tasks;
+using Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
+
+public interface IValidatedSBOM
+{
+    public Task<FormatValidationResults> GetValidationResults();
+
+    public Task<FormatEnforcedSPDX2> GetRawSPDXDocument();
+}

--- a/src/Microsoft.Sbom.Api/FormatValidator/IValidatedSBOM.cs
+++ b/src/Microsoft.Sbom.Api/FormatValidator/IValidatedSBOM.cs
@@ -3,14 +3,13 @@
 
 namespace Microsoft.Sbom.Api.FormatValidator;
 
+using System;
 using System.Threading.Tasks;
 using Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
 
-public interface IValidatedSBOM
+public interface IValidatedSBOM: IDisposable
 {
     public Task<FormatValidationResults> GetValidationResults();
 
     public Task<FormatEnforcedSPDX2> GetRawSPDXDocument();
-
-    public void Dispose();
 }

--- a/src/Microsoft.Sbom.Api/FormatValidator/ValidatedSBOM.cs
+++ b/src/Microsoft.Sbom.Api/FormatValidator/ValidatedSBOM.cs
@@ -50,6 +50,11 @@ public class ValidatedSBOM: IValidatedSBOM
         return sbom;
     }
 
+    public void Dispose()
+    {
+        this.sbomStream?.Dispose();
+    }
+
     private async Task Initialize()
     {
         if (isInitialized)

--- a/src/Microsoft.Sbom.Api/FormatValidator/ValidatedSBOM.cs
+++ b/src/Microsoft.Sbom.Api/FormatValidator/ValidatedSBOM.cs
@@ -13,7 +13,7 @@ using System.Threading.Tasks;
 using Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
 using Microsoft.Sbom.Utils;
 
-public class ValidatedSBOM
+public class ValidatedSBOM: IValidatedSBOM
 {
     private readonly Stream sbomStream;
     private readonly int requiredSpdxMajorVersion = 2;

--- a/src/Microsoft.Sbom.Api/FormatValidator/ValidatedSBOM.cs
+++ b/src/Microsoft.Sbom.Api/FormatValidator/ValidatedSBOM.cs
@@ -50,9 +50,11 @@ public class ValidatedSBOM: IValidatedSBOM
         return sbom;
     }
 
+    /// <inheritdoc/>
     public void Dispose()
     {
         this.sbomStream?.Dispose();
+        GC.SuppressFinalize(this);
     }
 
     private async Task Initialize()

--- a/src/Microsoft.Sbom.Api/FormatValidator/ValidatedSBOMFactory.cs
+++ b/src/Microsoft.Sbom.Api/FormatValidator/ValidatedSBOMFactory.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Sbom.Api.FormatValidator;
+
+using System.IO;
+
+public class ValidatedSBOMFactory
+{
+    public virtual IValidatedSBOM CreateValidatedSBOM(string sbomFilePath)
+    {
+        var sbomStream = new StreamReader(sbomFilePath);
+        var validatedSbom = new ValidatedSBOM(sbomStream.BaseStream);
+        return validatedSbom;
+    }
+}

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/ISbomRedactor.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/ISbomRedactor.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+using Microsoft.Sbom.Api.FormatValidator;
+using Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
+
+namespace Microsoft.Sbom.Api.Workflows.Helpers;
+
+/// <summary>
+/// SBOM redactor that removes file information from SBOMs
+/// </summary>
+public interface ISbomRedactor
+{
+    public Task<FormatEnforcedSPDX2> RedactSBOMAsync(IValidatedSBOM sbom);
+}

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/SbomRedactor.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/SbomRedactor.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Sbom.Api.FormatValidator;
+using Microsoft.Sbom.Common.Utils;
+using Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
+
+namespace Microsoft.Sbom.Api.Workflows.Helpers;
+
+/// <summary>
+/// SBOM redactor that removes file information from SBOMs
+/// </summary>
+public class SbomRedactor
+{
+    private const string SpdxFileRelationshipPrefix = "SPDXRef-File-";
+
+    public virtual async Task<FormatEnforcedSPDX2> RedactSBOMAsync(IValidatedSBOM sbom)
+    {
+        var spdx = await sbom.GetRawSPDXDocument();
+
+        if (spdx.Files != null)
+        {
+            spdx.Files = null;
+        }
+
+        RemovePackageFileRefs(spdx);
+        RemoveRelationshipsWithFileRefs(spdx);
+        UpdateDocumentNamespace(spdx);
+
+        return spdx;
+    }
+
+    private void RemovePackageFileRefs(FormatEnforcedSPDX2 spdx)
+    {
+        if (spdx.Packages != null)
+        {
+            foreach (var package in spdx.Packages)
+            {
+                if (package.HasFiles != null)
+                {
+                    package.HasFiles = null;
+                }
+
+                if (package.SourceInfo != null)
+                {
+                    package.SourceInfo = null;
+                }
+            }
+        }
+    }
+
+    private void RemoveRelationshipsWithFileRefs(FormatEnforcedSPDX2 spdx)
+    {
+        if (spdx.Relationships != null)
+        {
+            var relationshipsToRemove = new List<SPDXRelationship>();
+            foreach (var relationship in spdx.Relationships)
+            {
+                if (relationship.SourceElementId.Contains(SpdxFileRelationshipPrefix) || relationship.TargetElementId.Contains(SpdxFileRelationshipPrefix))
+                {
+                    relationshipsToRemove.Add(relationship);
+                }
+            }
+
+            if (relationshipsToRemove.Any())
+            {
+                spdx.Relationships = spdx.Relationships.Except(relationshipsToRemove);
+            }
+        }
+    }
+
+    private void UpdateDocumentNamespace(FormatEnforcedSPDX2 spdx)
+    {
+        if (string.IsNullOrWhiteSpace(spdx.DocumentNamespace) || !spdx.DocumentNamespace.Contains("microsoft"))
+        {
+            return;
+        }
+
+        var existingNamespaceComponents = spdx.DocumentNamespace.Split('/');
+        var uniqueComponent = IdentifierUtils.GetShortGuid(Guid.NewGuid());
+        existingNamespaceComponents[^1] = uniqueComponent;
+        spdx.DocumentNamespace = string.Join("/", existingNamespaceComponents);
+    }
+}

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/SbomRedactor.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/SbomRedactor.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Sbom.Api.Workflows.Helpers;
 /// <summary>
 /// SBOM redactor that removes file information from SBOMs
 /// </summary>
-public class SbomRedactor
+public class SbomRedactor: ISbomRedactor
 {
     private const string SpdxFileRelationshipPrefix = "SPDXRef-File-";
 

--- a/src/Microsoft.Sbom.Api/Workflows/SBOMRedactionWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SBOMRedactionWorkflow.cs
@@ -34,14 +34,14 @@ public class SbomRedactionWorkflow : IWorkflow<SbomRedactionWorkflow>
         ILogger log,
         IConfiguration configuration,
         IFileSystemUtils fileSystemUtils,
-        ValidatedSBOMFactory validatedSBOMFactory = null,
-        SbomRedactor sbomRedactor = null)
+        ValidatedSBOMFactory validatedSBOMFactory,
+        SbomRedactor sbomRedactor)
     {
         this.log = log ?? throw new ArgumentNullException(nameof(log));
         this.configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         this.fileSystemUtils = fileSystemUtils ?? throw new ArgumentNullException(nameof(fileSystemUtils));
-        this.validatedSBOMFactory = validatedSBOMFactory ?? new ValidatedSBOMFactory();
-        this.sbomRedactor = sbomRedactor ?? new SbomRedactor();
+        this.validatedSBOMFactory = validatedSBOMFactory ?? throw new ArgumentNullException(nameof(validatedSBOMFactory));
+        this.sbomRedactor = sbomRedactor ?? throw new ArgumentNullException(nameof(sbomRedactor));
     }
 
     public virtual async Task<bool> RunAsync()

--- a/src/Microsoft.Sbom.Api/Workflows/SBOMRedactionWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SBOMRedactionWorkflow.cs
@@ -2,7 +2,14 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
+using Microsoft.Sbom.Api.FormatValidator;
+using Microsoft.Sbom.Api.Workflows.Helpers;
+using Microsoft.Sbom.Common;
 using Microsoft.Sbom.Common.Config;
 using Serilog;
 
@@ -17,17 +24,133 @@ public class SbomRedactionWorkflow : IWorkflow<SbomRedactionWorkflow>
 
     private readonly IConfiguration configuration;
 
+    private readonly IFileSystemUtils fileSystemUtils;
+
+    private readonly ValidatedSBOMFactory validatedSBOMFactory;
+
+    private readonly SbomRedactor sbomRedactor;
+
     public SbomRedactionWorkflow(
         ILogger log,
-        IConfiguration configuration)
+        IConfiguration configuration,
+        IFileSystemUtils fileSystemUtils,
+        ValidatedSBOMFactory validatedSBOMFactory = null,
+        SbomRedactor sbomRedactor = null)
     {
         this.log = log ?? throw new ArgumentNullException(nameof(log));
         this.configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        this.fileSystemUtils = fileSystemUtils ?? throw new ArgumentNullException(nameof(fileSystemUtils));
+        this.validatedSBOMFactory = validatedSBOMFactory ?? new ValidatedSBOMFactory();
+        this.sbomRedactor = sbomRedactor ?? new SbomRedactor();
     }
 
     public virtual async Task<bool> RunAsync()
     {
-        log.Information($"Running redaction for SBOM path {configuration.SbomPath?.Value} and SBOM dir {configuration.SbomDir?.Value}. Output dir: {configuration.OutputPath?.Value}");
-        return await Task.FromResult(true);
+        ValidateDirStrucutre();
+        var sboms = await GetValidSbomsAsync();
+
+        log.Information($"Running redaction on the following SBOMs: {string.Join(' ', sboms.Select(sbom => sbom.Key))}");
+        foreach (var (sbomPath, validatedSbom) in sboms)
+        {
+            try
+            {
+                var outputPath = GetOutputPath(sbomPath);
+                var redactedSpdx = await this.sbomRedactor.RedactSBOMAsync(validatedSbom);
+                using (var outStream = fileSystemUtils.OpenWrite(outputPath))
+                {
+                    await JsonSerializer.SerializeAsync(outStream, redactedSpdx);
+                }
+
+                log.Information($"Redacted SBOM {sbomPath} saved to {outputPath}");
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Failed to redact {sbomPath}: {ex.Message}", ex);
+            }
+        }
+
+        return true;
+    }
+
+    private async Task<IDictionary<string, IValidatedSBOM>> GetValidSbomsAsync()
+    {
+        var sbomPaths = GetInputSbomPaths();
+        var validatedSboms = new Dictionary<string, IValidatedSBOM>();
+        foreach (var sbom in sbomPaths)
+        {
+            log.Information($"Validating SBOM {sbom}");
+            var validatedSbom = validatedSBOMFactory.CreateValidatedSBOM(sbom);
+            var validationDetails = await validatedSbom.GetValidationResults();
+            if (validationDetails.Status != FormatValidationStatus.Valid)
+            {
+                throw new InvalidDataException($"Failed to validate {sbom}:\n{string.Join('\n', validationDetails.Errors)}");
+            }
+            else
+            {
+                validatedSboms.Add(sbom, validatedSbom);
+            }
+        }
+
+        return validatedSboms;
+    }
+
+    private string GetOutputPath(string sbomPath)
+    {
+        return fileSystemUtils.JoinPaths(configuration.OutputPath.Value, fileSystemUtils.GetFileName(sbomPath));
+    }
+
+    private IEnumerable<string> GetInputSbomPaths()
+    {
+        if (configuration.SbomPath?.Value != null)
+        {
+            return new List<string>() { configuration.SbomPath.Value };
+        }
+        else if (configuration.SbomDir?.Value != null)
+        {
+            return fileSystemUtils.GetFilesInDirectory(configuration.SbomDir.Value);
+        }
+        else
+        {
+            throw new Exception("No valid input SBOMs to redact provided.");
+        }
+    }
+
+    private string ValidateDirStrucutre()
+    {
+        string inputDir;
+        if (configuration.SbomDir?.Value != null && fileSystemUtils.DirectoryExists(configuration.SbomDir.Value))
+        {
+            inputDir = configuration.SbomDir.Value;
+        }
+        else if (configuration.SbomPath?.Value != null && fileSystemUtils.FileExists(configuration.SbomPath.Value))
+        {
+            inputDir = fileSystemUtils.GetDirectoryName(configuration.SbomPath.Value);
+        }
+        else
+        {
+            throw new ArgumentException("No valid input SBOMs to redact provided.");
+        }
+
+        var outputDir = configuration.OutputPath.Value;
+        if (fileSystemUtils.GetFullPath(outputDir).Equals(fileSystemUtils.GetFullPath(inputDir)))
+        {
+            throw new ArgumentException("Output path cannot be the same as input SBOM directory.");
+        }
+
+        if (!fileSystemUtils.DirectoryExists(outputDir))
+        {
+            fileSystemUtils.CreateDirectory(outputDir);
+        }
+
+        foreach (var sbom in GetInputSbomPaths())
+        {
+            var outputPath = GetOutputPath(sbom);
+            if (fileSystemUtils.FileExists(outputPath))
+            {
+                throw new ArgumentException($"Output file {outputPath} already exists. Please update and try again.");
+            }
+        }
+
+        return outputDir;
     }
 }

--- a/src/Microsoft.Sbom.Common/FileSystemUtils.cs
+++ b/src/Microsoft.Sbom.Common/FileSystemUtils.cs
@@ -68,6 +68,9 @@ public abstract class FileSystemUtils : IFileSystemUtils
     public bool FileExists(string path) => File.Exists(path);
 
     /// <inheritdoc />
+    public string GetFileName(string filePath) => Path.GetFileName(filePath);
+
+    /// <inheritdoc />
     public Stream OpenWrite(string filePath) => new FileStream(
         filePath,
         FileMode.Create,

--- a/src/Microsoft.Sbom.Common/IFileSystemUtils.cs
+++ b/src/Microsoft.Sbom.Common/IFileSystemUtils.cs
@@ -105,6 +105,13 @@ public interface IFileSystemUtils
     bool FileExists(string path);
 
     /// <summary>
+    /// Get the file name of a file.
+    /// </summary>
+    /// <param name="filePath">The absolute path of the file.</param>
+    /// <returns>The file name.</returns>
+    string GetFileName(string filePath);
+
+    /// <summary>
     /// Get the directory name of a file.
     /// </summary>
     /// <param name="filePath">The absolute path of the file.</param>

--- a/src/Microsoft.Sbom.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Sbom.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -74,7 +74,7 @@ public static class ServiceCollectionExtensions
             .AddTransient<IWorkflow<SbomParserBasedValidationWorkflow>, SbomParserBasedValidationWorkflow>()
             .AddTransient<IWorkflow<SbomGenerationWorkflow>, SbomGenerationWorkflow>()
             .AddTransient<IWorkflow<SbomRedactionWorkflow>, SbomRedactionWorkflow>()
-            .AddTransient<SbomRedactor>()
+            .AddTransient<ISbomRedactor, SbomRedactor>()
             .AddTransient<ValidatedSBOMFactory>()
             .AddTransient<DirectoryWalker>()
             .AddTransient<IFilter<DownloadedRootPathFilter>, DownloadedRootPathFilter>()

--- a/src/Microsoft.Sbom.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Sbom.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -15,6 +15,7 @@ using Microsoft.Sbom.Api.Convertors;
 using Microsoft.Sbom.Api.Entities.Output;
 using Microsoft.Sbom.Api.Executors;
 using Microsoft.Sbom.Api.Filters;
+using Microsoft.Sbom.Api.FormatValidator;
 using Microsoft.Sbom.Api.Hashing;
 using Microsoft.Sbom.Api.Manifest;
 using Microsoft.Sbom.Api.Manifest.Configuration;
@@ -73,6 +74,8 @@ public static class ServiceCollectionExtensions
             .AddTransient<IWorkflow<SbomParserBasedValidationWorkflow>, SbomParserBasedValidationWorkflow>()
             .AddTransient<IWorkflow<SbomGenerationWorkflow>, SbomGenerationWorkflow>()
             .AddTransient<IWorkflow<SbomRedactionWorkflow>, SbomRedactionWorkflow>()
+            .AddTransient<SbomRedactor>()
+            .AddTransient<ValidatedSBOMFactory>()
             .AddTransient<DirectoryWalker>()
             .AddTransient<IFilter<DownloadedRootPathFilter>, DownloadedRootPathFilter>()
             .AddTransient<IFilter<ManifestFolderFilter>, ManifestFolderFilter>()

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/CreationInfo.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/CreationInfo.cs
@@ -11,8 +11,8 @@ namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
 /// </summary>
 public class CreationInfo
 {
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("comment")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string Comment { get; set; }
 
     /// <summary>

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/CreationInfo.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/CreationInfo.cs
@@ -11,8 +11,8 @@ namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
 /// </summary>
 public class CreationInfo
 {
-    [JsonPropertyName("comment")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("comment")]
     public string Comment { get; set; }
 
     /// <summary>
@@ -28,7 +28,7 @@ public class CreationInfo
     [JsonPropertyName("creators")]
     public IEnumerable<string> Creators { get; set; }
 
-    [JsonPropertyName("licenseListVersion")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("licenseListVersion")]
     public string LicenseListVersion { get; set; }
 }

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/CreationInfo.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/CreationInfo.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
 /// </summary>
 public class CreationInfo
 {
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("comment")]
     public string Comment { get; set; }
 
@@ -28,5 +29,6 @@ public class CreationInfo
     public IEnumerable<string> Creators { get; set; }
 
     [JsonPropertyName("licenseListVersion")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string LicenseListVersion { get; set; }
 }

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/FormatEnforcedSPDX2.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/FormatEnforcedSPDX2.cs
@@ -17,6 +17,7 @@ public class FormatEnforcedSPDX2 : SPDX2RequiredProperties
     [JsonPropertyName("documentDescribes")]
     public IEnumerable<string> DocumentDescribes { get; set; }
 
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("files")]
     public IEnumerable<SPDXFile> Files { get; set; }
 

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/FormatEnforcedSPDX2.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/FormatEnforcedSPDX2.cs
@@ -10,6 +10,7 @@ public class FormatEnforcedSPDX2 : SPDX2RequiredProperties
 {
     // These attributes are not required by the SPDX spec, but may be present in
     // SBOMs produced by sbom-tool or 3P SBOMs. We want to (de)serialize them if they are present.
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("comment")]
     public string Comment { get; set; }
 

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/Helpers/SbomRedactorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/Helpers/SbomRedactorTests.cs
@@ -9,12 +9,14 @@ using Microsoft.Sbom.Api.Workflows.Helpers;
 using Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using Serilog;
 
 namespace Microsoft.Sbom.Api.Tests.Workflows.Helpers;
 
 [TestClass]
 public class SbomRedactorTests
 {
+    private Mock<ILogger> mockLogger;
     private Mock<IValidatedSBOM> mockValidatedSbom;
 
     private SbomRedactor testSubject;
@@ -22,8 +24,15 @@ public class SbomRedactorTests
     [TestInitialize]
     public void Init()
     {
+        mockLogger = new Mock<ILogger>();
         mockValidatedSbom = new Mock<IValidatedSBOM>();
-        testSubject = new SbomRedactor();
+        testSubject = new SbomRedactor(mockLogger.Object);
+    }
+
+    [TestCleanup]
+    public void Reset()
+    {
+        mockLogger.VerifyAll();
     }
 
     [TestMethod]
@@ -119,6 +128,10 @@ public class SbomRedactorTests
         var docNamespace = "microsoft/test/namespace/fakeguid";
         var mockSbom = new FormatEnforcedSPDX2
         {
+            CreationInfo = new CreationInfo
+            {
+                Creators = new List<string> { "Tool: Microsoft.SBOMTool" }
+            },
             DocumentNamespace = docNamespace
         };
         mockValidatedSbom.Setup(x => x.GetRawSPDXDocument()).ReturnsAsync(mockSbom);
@@ -133,6 +146,10 @@ public class SbomRedactorTests
         var docNamespace = "test-namespace";
         var mockSbom = new FormatEnforcedSPDX2
         {
+            CreationInfo = new CreationInfo
+            {
+                Creators = new List<string> { "non-msft-tool" }
+            },
             DocumentNamespace = docNamespace
         };
         mockValidatedSbom.Setup(x => x.GetRawSPDXDocument()).ReturnsAsync(mockSbom);

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/Helpers/SbomRedactorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/Helpers/SbomRedactorTests.cs
@@ -1,0 +1,142 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Sbom.Api.FormatValidator;
+using Microsoft.Sbom.Api.Workflows.Helpers;
+using Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.Sbom.Api.Tests.Workflows.Helpers;
+
+[TestClass]
+public class SbomRedactorTests
+{
+    private Mock<IValidatedSBOM> mockValidatedSbom;
+
+    private SbomRedactor testSubject;
+
+    [TestInitialize]
+    public void Init()
+    {
+        mockValidatedSbom = new Mock<IValidatedSBOM>();
+        testSubject = new SbomRedactor();
+    }
+
+    [TestMethod]
+    public async Task SbomRedactor_RemovesFilesSection()
+    {
+        var mockSbom = new FormatEnforcedSPDX2
+        {
+            Files = new List<SPDXFile>
+            {
+                new SPDXFile()
+            }
+        };
+        mockValidatedSbom.Setup(x => x.GetRawSPDXDocument()).ReturnsAsync(mockSbom);
+        await testSubject.RedactSBOMAsync(mockValidatedSbom.Object);
+        Assert.IsNull(mockSbom.Files);
+    }
+
+    [TestMethod]
+    public async Task SbomRedactor_RemovesPackageFileRefs()
+    {
+        var mockSbom = new FormatEnforcedSPDX2
+        {
+            Packages = new List<SPDXPackage>
+            {
+                new SPDXPackage()
+                {
+                    SpdxId = "package-1",
+                    HasFiles = new List<string>
+                    {
+                        "file-1",
+                        "file-2",
+                    }
+                },
+                new SPDXPackage()
+                {
+                    SpdxId = "package-2",
+                    SourceInfo = "source-info"
+                },
+                new SPDXPackage()
+                {
+                    SpdxId = "package-3",
+                }
+            }
+        };
+        mockValidatedSbom.Setup(x => x.GetRawSPDXDocument()).ReturnsAsync(mockSbom);
+        await testSubject.RedactSBOMAsync(mockValidatedSbom.Object);
+        Assert.AreEqual(mockSbom.Packages.Count(), 3);
+        foreach (var package in mockSbom.Packages)
+        {
+            Assert.IsNull(package.HasFiles);
+            Assert.IsNull(package.SourceInfo);
+            Assert.IsNotNull(package.SpdxId);
+        }
+    }
+
+    [TestMethod]
+    public async Task SbomRedactor_RemovesRelationshipsWithFileRefs()
+    {
+        var unredactedRelationship = new SPDXRelationship()
+        {
+            SourceElementId = "source",
+            TargetElementId = "target",
+            RelationshipType = "relationship-3",
+        };
+        var mockSbom = new FormatEnforcedSPDX2
+        {
+            Relationships = new List<SPDXRelationship>
+            {
+                new SPDXRelationship()
+                {
+                    SourceElementId = "SPDXRef-File-1",
+                    TargetElementId = "target",
+                    RelationshipType = "relationship-1",
+                },
+                new SPDXRelationship()
+                {
+                    SourceElementId = "source",
+                    TargetElementId = "SPDXRef-File-2",
+                    RelationshipType = "relationship-2",
+                },
+                unredactedRelationship
+            }
+        };
+        mockValidatedSbom.Setup(x => x.GetRawSPDXDocument()).ReturnsAsync(mockSbom);
+        await testSubject.RedactSBOMAsync(mockValidatedSbom.Object);
+        Assert.AreEqual(mockSbom.Relationships.Count(), 1);
+        Assert.AreEqual(mockSbom.Relationships.First(), unredactedRelationship);
+    }
+
+    [TestMethod]
+    public async Task SbomRedactor_UpdatesDocNamespaceForMsftSboms()
+    {
+        var docNamespace = "microsoft/test/namespace/fakeguid";
+        var mockSbom = new FormatEnforcedSPDX2
+        {
+            DocumentNamespace = docNamespace
+        };
+        mockValidatedSbom.Setup(x => x.GetRawSPDXDocument()).ReturnsAsync(mockSbom);
+        await testSubject.RedactSBOMAsync(mockValidatedSbom.Object);
+        Assert.IsTrue(mockSbom.DocumentNamespace.Contains("microsoft/test/namespace/"));
+        Assert.IsFalse(mockSbom.DocumentNamespace.Contains("fakeguid"));
+    }
+
+    [TestMethod]
+    public async Task SbomRedactor_DoesNotEditDocNamespaceForNonMsftSboms()
+    {
+        var docNamespace = "test-namespace";
+        var mockSbom = new FormatEnforcedSPDX2
+        {
+            DocumentNamespace = docNamespace
+        };
+        mockValidatedSbom.Setup(x => x.GetRawSPDXDocument()).ReturnsAsync(mockSbom);
+        await testSubject.RedactSBOMAsync(mockValidatedSbom.Object);
+        Assert.AreEqual(mockSbom.DocumentNamespace, docNamespace);
+    }
+}

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/SbomRedactionWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/SbomRedactionWorkflowTests.cs
@@ -3,11 +3,19 @@
 
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
+using System;
+using System.IO;
+using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Sbom.Api.FormatValidator;
 using Microsoft.Sbom.Api.Workflows;
+using Microsoft.Sbom.Api.Workflows.Helpers;
+using Microsoft.Sbom.Common;
 using Microsoft.Sbom.Common.Config;
+using Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using PowerArgs;
 using Serilog;
 
 namespace Microsoft.Sbom.Workflows;
@@ -19,33 +27,135 @@ public class SbomRedactionWorkflowTests
 {
     private Mock<ILogger> mockLogger;
     private Mock<IConfiguration> configurationMock;
+    private Mock<IFileSystemUtils> fileSystemUtilsMock;
+    private Mock<ValidatedSBOMFactory> validatedSBOMFactoryMock;
+    private Mock<SbomRedactor> sbomRedactorMock;
     private SbomRedactionWorkflow testSubject;
+
+    private const string SbomPathStub = "sbom-path";
+    private const string SbomDirStub = "sbom-dir";
+    private const string OutDirStub = "out-dir";
+    private const string OutPathStub = "out-path";
+    private const string SbomFileNameStub = "sbom-name";
 
     [TestInitialize]
     public void Init()
     {
         mockLogger = new Mock<ILogger>();
         configurationMock = new Mock<IConfiguration>();
+        fileSystemUtilsMock = new Mock<IFileSystemUtils>();
+        validatedSBOMFactoryMock = new Mock<ValidatedSBOMFactory>();
+        sbomRedactorMock = new Mock<SbomRedactor>();
         testSubject = new SbomRedactionWorkflow(
             mockLogger.Object,
-            configurationMock.Object);
+            configurationMock.Object,
+            fileSystemUtilsMock.Object,
+            validatedSBOMFactoryMock.Object,
+            sbomRedactorMock.Object);
     }
 
     [TestCleanup]
     public void Reset()
     {
         mockLogger.VerifyAll();
+        fileSystemUtilsMock.VerifyAll();
         configurationMock.VerifyAll();
+        validatedSBOMFactoryMock.VerifyAll();
+        sbomRedactorMock.VerifyAll();
     }
 
     [TestMethod]
-    public async Task SbomRedactionTests_Succeeds()
+    [ExpectedException(typeof(ArgumentException))]
+    public async Task SbomRedactionWorkflow_FailsOnNoSbomsProvided()
     {
-        mockLogger.Setup(x => x.Information($"Running redaction for SBOM path path and SBOM dir dir. Output dir: out"));
-        configurationMock.SetupGet(c => c.SbomPath).Returns(new ConfigurationSetting<string> { Value = "path" });
-        configurationMock.SetupGet(c => c.SbomDir).Returns(new ConfigurationSetting<string> { Value = "dir" });
-        configurationMock.SetupGet(c => c.OutputPath).Returns(new ConfigurationSetting<string> { Value = "out" });
+        var result = await testSubject.RunAsync();
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public async Task SbomRedactionWorkflow_FailsOnMatchingInputOutputDirs()
+    {
+        configurationMock.SetupGet(c => c.SbomDir).Returns(new ConfigurationSetting<string> { Value = SbomDirStub });
+        configurationMock.SetupGet(c => c.OutputPath).Returns(new ConfigurationSetting<string> { Value = SbomDirStub });
+        fileSystemUtilsMock.Setup(m => m.DirectoryExists(SbomDirStub)).Returns(true).Verifiable();
+        fileSystemUtilsMock.Setup(m => m.GetFullPath(SbomDirStub)).Returns(SbomDirStub).Verifiable();
+        var result = await testSubject.RunAsync();
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentException))]
+    public async Task SbomRedactionWorkflow_FailsOnExistingOutputSbom()
+    {
+        configurationMock.SetupGet(c => c.SbomPath).Returns(new ConfigurationSetting<string> { Value = SbomPathStub });
+        configurationMock.SetupGet(c => c.OutputPath).Returns(new ConfigurationSetting<string> { Value = OutDirStub });
+        fileSystemUtilsMock.Setup(m => m.FileExists(SbomPathStub)).Returns(true).Verifiable();
+        fileSystemUtilsMock.Setup(m => m.GetDirectoryName(SbomPathStub)).Returns(SbomDirStub).Verifiable();
+        fileSystemUtilsMock.Setup(m => m.DirectoryExists(OutDirStub)).Returns(true).Verifiable();
+        fileSystemUtilsMock.Setup(m => m.GetFullPath(SbomDirStub)).Returns(SbomDirStub).Verifiable();
+        fileSystemUtilsMock.Setup(m => m.GetFullPath(OutDirStub)).Returns(OutDirStub).Verifiable();
+
+        // GetOutputPath
+        fileSystemUtilsMock.Setup(m => m.GetFileName(SbomPathStub)).Returns(SbomFileNameStub).Verifiable();
+        fileSystemUtilsMock.Setup(m => m.JoinPaths(OutDirStub, SbomFileNameStub)).Returns(OutPathStub).Verifiable();
+
+        // Output already file exists
+        fileSystemUtilsMock.Setup(m => m.FileExists(OutPathStub)).Returns(true).Verifiable();
+
+        var result = await testSubject.RunAsync();
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(InvalidDataException))]
+    public async Task SbomRedactionWorkflow_FailsOnInvalidSboms()
+    {
+        SetUpDirStructure();
+
+        fileSystemUtilsMock.Setup(m => m.GetFilesInDirectory(SbomDirStub, true)).Returns(new string[] { SbomPathStub }).Verifiable();
+        var validatedSbomMock = new Mock<IValidatedSBOM>();
+        validatedSBOMFactoryMock.Setup(m => m.CreateValidatedSBOM(SbomPathStub)).Returns(validatedSbomMock.Object).Verifiable();
+        var validationRes = new FormatValidationResults();
+        validationRes.AggregateValidationStatus(FormatValidationStatus.NotValid);
+        validatedSbomMock.Setup(m => m.GetValidationResults()).ReturnsAsync(validationRes).Verifiable();
+
+        var result = await testSubject.RunAsync();
+    }
+
+    [TestMethod]
+    public async Task SbomRedactionWorkflow_RunsRedactionOnValidSboms()
+    {
+        SetUpDirStructure();
+
+        fileSystemUtilsMock.Setup(m => m.GetFilesInDirectory(SbomDirStub, true)).Returns(new string[] { SbomPathStub }).Verifiable();
+        var validatedSbomMock = new Mock<IValidatedSBOM>();
+        validatedSBOMFactoryMock.Setup(m => m.CreateValidatedSBOM(SbomPathStub)).Returns(validatedSbomMock.Object).Verifiable();
+        var validationRes = new FormatValidationResults();
+        validationRes.AggregateValidationStatus(FormatValidationStatus.Valid);
+        validatedSbomMock.Setup(m => m.GetValidationResults()).ReturnsAsync(validationRes).Verifiable();
+        var redactedContent = new FormatEnforcedSPDX2() { Name = "redacted" };
+        sbomRedactorMock.Setup(m => m.RedactSBOMAsync(validatedSbomMock.Object)).ReturnsAsync(redactedContent).Verifiable();
+        var outStream = new MemoryStream();
+        fileSystemUtilsMock.Setup(m => m.OpenWrite(OutPathStub)).Returns(outStream).Verifiable();
+
         var result = await testSubject.RunAsync();
         Assert.IsTrue(result);
+        var redactedResult = Encoding.ASCII.GetString(outStream.ToArray());
+        Assert.AreEqual(redactedResult, /*lang=json,strict*/ @"{""comment"":null,""documentDescribes"":null,""files"":null,""packages"":null,""relationships"":null,""spdxVersion"":null,""dataLicense"":null,""SPDXID"":null,""name"":""redacted"",""documentNamespace"":null,""creationInfo"":null}");
+    }
+
+    private void SetUpDirStructure()
+    {
+        configurationMock.SetupGet(c => c.SbomDir).Returns(new ConfigurationSetting<string> { Value = SbomDirStub });
+        configurationMock.SetupGet(c => c.OutputPath).Returns(new ConfigurationSetting<string> { Value = OutDirStub });
+        fileSystemUtilsMock.Setup(m => m.DirectoryExists(SbomDirStub)).Returns(true).Verifiable();
+        fileSystemUtilsMock.Setup(m => m.DirectoryExists(OutDirStub)).Returns(true).Verifiable();
+        fileSystemUtilsMock.Setup(m => m.GetFullPath(SbomDirStub)).Returns(SbomDirStub).Verifiable();
+        fileSystemUtilsMock.Setup(m => m.GetFullPath(OutDirStub)).Returns(OutDirStub).Verifiable();
+
+        // GetOutputPath
+        fileSystemUtilsMock.Setup(m => m.GetFileName(SbomPathStub)).Returns(SbomFileNameStub).Verifiable();
+        fileSystemUtilsMock.Setup(m => m.JoinPaths(OutDirStub, SbomFileNameStub)).Returns(OutPathStub).Verifiable();
+
+        // Output already file exists
+        fileSystemUtilsMock.Setup(m => m.FileExists(OutPathStub)).Returns(false).Verifiable();
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/SbomRedactionWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/SbomRedactionWorkflowTests.cs
@@ -139,7 +139,7 @@ public class SbomRedactionWorkflowTests
         var result = await testSubject.RunAsync();
         Assert.IsTrue(result);
         var redactedResult = Encoding.ASCII.GetString(outStream.ToArray());
-        Assert.AreEqual(redactedResult, /*lang=json,strict*/ @"{""comment"":null,""documentDescribes"":null,""files"":null,""packages"":null,""relationships"":null,""spdxVersion"":null,""dataLicense"":null,""SPDXID"":null,""name"":""redacted"",""documentNamespace"":null,""creationInfo"":null}");
+        Assert.IsTrue(redactedResult.Contains(@"""name"":""redacted"""));
     }
 
     private void SetUpDirStructure()

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/SbomRedactionWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/SbomRedactionWorkflowTests.cs
@@ -29,7 +29,7 @@ public class SbomRedactionWorkflowTests
     private Mock<IConfiguration> configurationMock;
     private Mock<IFileSystemUtils> fileSystemUtilsMock;
     private Mock<ValidatedSBOMFactory> validatedSBOMFactoryMock;
-    private Mock<SbomRedactor> sbomRedactorMock;
+    private Mock<ISbomRedactor> sbomRedactorMock;
     private SbomRedactionWorkflow testSubject;
 
     private const string SbomPathStub = "sbom-path";
@@ -45,7 +45,7 @@ public class SbomRedactionWorkflowTests
         configurationMock = new Mock<IConfiguration>();
         fileSystemUtilsMock = new Mock<IFileSystemUtils>();
         validatedSBOMFactoryMock = new Mock<ValidatedSBOMFactory>();
-        sbomRedactorMock = new Mock<SbomRedactor>();
+        sbomRedactorMock = new Mock<ISbomRedactor>();
         testSubject = new SbomRedactionWorkflow(
             mockLogger.Object,
             configurationMock.Object,
@@ -116,6 +116,7 @@ public class SbomRedactionWorkflowTests
         var validationRes = new FormatValidationResults();
         validationRes.AggregateValidationStatus(FormatValidationStatus.NotValid);
         validatedSbomMock.Setup(m => m.GetValidationResults()).ReturnsAsync(validationRes).Verifiable();
+        validatedSbomMock.Setup(m => m.Dispose()).Verifiable();
 
         var result = await testSubject.RunAsync();
     }
@@ -135,6 +136,7 @@ public class SbomRedactionWorkflowTests
         sbomRedactorMock.Setup(m => m.RedactSBOMAsync(validatedSbomMock.Object)).ReturnsAsync(redactedContent).Verifiable();
         var outStream = new MemoryStream();
         fileSystemUtilsMock.Setup(m => m.OpenWrite(OutPathStub)).Returns(outStream).Verifiable();
+        validatedSbomMock.Setup(m => m.Dispose()).Verifiable();
 
         var result = await testSubject.RunAsync();
         Assert.IsTrue(result);


### PR DESCRIPTION
This PR is a follow up to https://github.com/microsoft/sbom-tool/pull/575, which added the CLI plumbing for the `redact` verb. This PR populates the redact workflow with the redaction logic. The current redaction logic involves the following components:
- Remove the entire files section
- Remove any relationship entries which include a file reference
- Remove any `packages.hasFiles` entries 
- Remove any `packages.sourceInfo` entries (note that this property is not populated for SBOMs generated by this tool, but we have seen syft SBOMs in which this property contains file information)
- If the document namespace indicates that the SBOM was generated via this sbom-tool, generate a new unique guid section of the document namespace