### PR TITLE
Add redact documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,14 @@ Currently only SPDX2.2 is supported.
 
 ### SBOM Redact
 
-Use the tool to redact any references to files from a given SBOM or set of SBOMs with the command:
+Use the tool to redact any references to files from a given SBOM or set of SBOMs with either of the following commands:
 
 ```
 sbom-tool redact -sd <directory containing SBOMs to redact> -o <output path>
+```
+
+```
+sbom-tool redact -sp <path to the SBOM to redact> -o <output path>
 ```
 
 This command will generate a mirrored set of SBOMs in the output directory, but with the file references removed. Note that the SBOM directory and output path arguments can not reference the same directory and the output path should point to an existing, empty directory.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,16 @@ This sample command provides the minimum mandatory arguments required to validat
 
 Currently only SPDX2.2 is supported.
 
+### SBOM Redact
+
+Use the tool to redact any references to files from a given SBOM or set of SBOMs with the command:
+
+```
+sbom-tool redact -sd <directory containing SBOMs to redact> -o <output path>
+```
+
+This command will generate a mirrored set of SBOMs in the output directory, but with the file references removed. Note that the SBOM directory and output path arguments can not reference the same directory and the output path should point to an existing, empty directory.
+
 ## Integrating SBOM tool to your CI/CD pipelines.
 
 You can follow these guides to integrate the SBOM tool into your CI/CD pipelines 

--- a/docs/sbom-tool-arguments.md
+++ b/docs/sbom-tool-arguments.md
@@ -81,5 +81,19 @@ Actions
     FollowSymlinks (-F)                       If set to false, we will not follow symlinks while traversing the build drop folder. Default is set to 'true'.
     ManifestInfo (-mi)                        A list of the name and version of the manifest format that we are using.
 
+  Redact -options - Redact file information from given SBOM(s).
+
+    Option            Description
+    SbomPath (-sp)    The file path of the SBOM to redact.
+    SbomDir (-sd)     The directory containing the sbom(s) to redact.
+    OutputPath (-o)   Gets or sets the directory where the redacted SBOM file(s) will be generated.
+    Verbosity (-V)    Display this amount of detail in the logging output.
+                      Verbose
+                      Debug
+                      Information
+                      Warning
+                      Error
+                      Fatal
+
   Version  - Displays the version of the tool being used. Can be used as '--version'
 ```

--- a/src/Microsoft.Sbom.Api/Config/SbomToolCmdRunner.cs
+++ b/src/Microsoft.Sbom.Api/Config/SbomToolCmdRunner.cs
@@ -59,7 +59,6 @@ public class SbomToolCmdRunner
     /// </summary>
     [ArgActionMethod]
     [ArgDescription("Redact file information from given SBOM(s).")]
-    [OmitFromUsageDocs]
     public RedactArgs Redact(RedactArgs redactArgs)
     {
         return redactArgs;


### PR DESCRIPTION
Adding documentation of the new redact verb and removing the `OmitFromUsageDocs` so that the new verb will show up in CLI help. This PR is a follow up to https://github.com/microsoft/sbom-tool/pull/581, which adds the redact logic. 