### PR TITLE
Add missing header to AbstractGenerateSbomTaskTests

### DIFF
--- a/test/Microsoft.Sbom.Targets.Tests/AbstractGenerateSbomTaskTests.cs
+++ b/test/Microsoft.Sbom.Targets.Tests/AbstractGenerateSbomTaskTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.Build.Framework;


### PR DESCRIPTION
This change is needed for making the feature branch succeed in the CI pipeline.