### PR TITLE
chore: Fix JSON002 error

### DIFF
--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsBase.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsBase.cs
@@ -62,6 +62,6 @@ public class ConfigurationBuilderTestsBase
         mapper = mapperConfiguration.CreateMapper();
     }
 
-    protected const string JSONConfigWithManifestPath = "{ \"ManifestDirPath\": \"manifestDirPath\"}";
-    protected const string JSONConfigGoodWithManifestInfo = "{ \"ManifestInfo\": [{ \"Name\":\"manifest\", \"Version\":\"1\"}]}";
+    protected const string JSONConfigWithManifestPath = $"{{ \"ManifestDirPath\": \"manifestDirPath\"}}";
+    protected const string JSONConfigGoodWithManifestInfo = $"{{ \"ManifestInfo\": [{{ \"Name\":\"manifest\", \"Version\":\"1\"}}]}}";
 }


### PR DESCRIPTION
Building the project locally, I get 2 errors when I happen to have this file opened in the IDE:

Severity | Code | Description | Project | File | Line 
--- | --- | --- | --- | --- | --- 
Error (active) | JSON002 | Probable JSON string detected | Microsoft.Sbom.Api.Tests (net6.0), Microsoft.Sbom.Api.Tests (net8.0) | .\test\Microsoft.Sbom.Api.Tests\Config\ConfigurationBuilderTestsBase.cs | 65
Error (active) | JSON002 | Probable JSON string detected | Microsoft.Sbom.Api.Tests (net6.0), Microsoft.Sbom.Api.Tests (net8.0) | .\test\Microsoft.Sbom.Api.Tests\Config\ConfigurationBuilderTestsBase.cs | 66

The IDE suggests making these interpolated strings, which silences the error. Seems like the IDE is being a bit extra picky, but the low-risk change seems like a better option than adding some sort of override.