### PR TITLE
Add simple integration tests

### DIFF
--- a/Microsoft.Sbom.sln
+++ b/Microsoft.Sbom.sln
@@ -49,6 +49,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Sbom.Extensions.D
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Sbom.Extensions.DependencyInjection.Tests", "test\Microsoft.Sbom.Extensions.DependencyInjection.Tests\Microsoft.Sbom.Extensions.DependencyInjection.Tests.csproj", "{EE4E2E03-7B4C-46E5-B9D2-89E84A18D787}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Sbom.Tool.Tests", "test\Microsoft.Sbom.Tool.Tests\Microsoft.Sbom.Tool.Tests.csproj", "{FC5A9799-7C44-4BFA-BA22-55DCAF1A1B9F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -107,6 +109,10 @@ Global
 		{EE4E2E03-7B4C-46E5-B9D2-89E84A18D787}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EE4E2E03-7B4C-46E5-B9D2-89E84A18D787}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EE4E2E03-7B4C-46E5-B9D2-89E84A18D787}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FC5A9799-7C44-4BFA-BA22-55DCAF1A1B9F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FC5A9799-7C44-4BFA-BA22-55DCAF1A1B9F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FC5A9799-7C44-4BFA-BA22-55DCAF1A1B9F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FC5A9799-7C44-4BFA-BA22-55DCAF1A1B9F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/test/Microsoft.Sbom.Tool.Tests/IntegrationTests.cs
+++ b/test/Microsoft.Sbom.Tool.Tests/IntegrationTests.cs
@@ -20,23 +20,23 @@ public class IntegrationTests
 
     public TestContext TestContext { get; set; }
 
-    private static string testResultsDirectory;
+    private static string testRunDirectory;
 
     [ClassInitialize]
     public static void Setup(TestContext context)
     {
-        testResultsDirectory = context.ResultsDirectory;
+        testRunDirectory = context.TestRunDirectory;
     }
 
     [ClassCleanup]
     public static void TearDown()
     {
         // Clean up test directories
-        if (testResultsDirectory is not null)
+        if (testRunDirectory is not null)
         {
-            if (Directory.Exists(testResultsDirectory))
+            if (Directory.Exists(testRunDirectory))
             {
-                Directory.Delete(testResultsDirectory, true);
+                Directory.Delete(testRunDirectory, true);
             }
         }
     }
@@ -90,7 +90,7 @@ public class IntegrationTests
         var testFolderPath = CreateTestFolder();
         GenerateManifestAndValidateSuccess(testFolderPath);
 
-        var outputFile = Path.Combine(TestContext.ResultsDirectory, TestContext.TestName, "validation.json");
+        var outputFile = Path.Combine(TestContext.TestRunDirectory, TestContext.TestName, "validation.json");
         var manifestRootFolderName = Path.Combine(testFolderPath, ManifestRootFolderName);
         var arguments = $"validate -m \"{manifestRootFolderName}\" -b . -o \"{outputFile}\" -mi spdx:2.2";
 
@@ -114,7 +114,7 @@ public class IntegrationTests
         var testFolderPath = CreateTestFolder();
         GenerateManifestAndValidateSuccess(testFolderPath);
 
-        var outputFolder = Path.Combine(TestContext.ResultsDirectory, TestContext.TestName, "redacted");
+        var outputFolder = Path.Combine(TestContext.TestRunDirectory, TestContext.TestName, "redacted");
         var originalManifestFolderPath = AppendFullManifestFolderPath(testFolderPath);
         var originalManifestFilePath = Path.Combine(AppendFullManifestFolderPath(testFolderPath), ManifestFileName);
         var arguments = $"redact -sp \"{originalManifestFilePath}\" -o \"{outputFolder}\" -verbosity verbose";
@@ -148,7 +148,7 @@ public class IntegrationTests
 
     private string CreateTestFolder()
     {
-        var testFolderPath = Path.GetFullPath(Path.Combine(TestContext.ResultsDirectory, TestContext.TestName));
+        var testFolderPath = Path.GetFullPath(Path.Combine(TestContext.TestRunDirectory, TestContext.TestName));
         Directory.CreateDirectory(testFolderPath);
         return testFolderPath;
     }

--- a/test/Microsoft.Sbom.Tool.Tests/IntegrationTests.cs
+++ b/test/Microsoft.Sbom.Tool.Tests/IntegrationTests.cs
@@ -18,7 +18,6 @@ public class IntegrationTests
 
     private static TestContext testContext;
     private static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-    private static readonly object LockObject = new object();
 
     [ClassInitialize]
     public static void SetUp(TestContext testContext)
@@ -35,6 +34,12 @@ public class IntegrationTests
     [TestMethod]
     public void E2E_NoParameters_DisplaysHelpMessage_ReturnsNonZeroExitCode()
     {
+        if (!IsWindows)
+        {
+            Assert.Inconclusive("This test is not (yet) supported on non-Windows platforms.");
+            return;
+        }
+
         var (stdout, stderr, exitCode) = LaunchAndCaptureOutput(null);
 
         Assert.AreEqual(stderr, string.Empty);
@@ -47,6 +52,12 @@ public class IntegrationTests
     [TestMethod]
     public void E2E_GenerateManifest_GeneratesManifest_ReturnsZeroExitCode()
     {
+        if (!IsWindows)
+        {
+            Assert.Inconclusive("This test is not (yet) supported on non-Windows platforms.");
+            return;
+        }
+
         var testFolderPath = CreateTestFolder();
         GenerateManifestAndValidateSuccess(testFolderPath);
     }
@@ -54,6 +65,12 @@ public class IntegrationTests
     [TestMethod]
     public void E2E_GenerateAndValidateManifest_ValidationSucceeds_ReturnsZeroExitCode()
     {
+        if (!IsWindows)
+        {
+            Assert.Inconclusive("This test is not (yet) supported on non-Windows platforms.");
+            return;
+        }
+
         var testFolderPath = CreateTestFolder();
         GenerateManifestAndValidateSuccess(testFolderPath);
 
@@ -72,6 +89,12 @@ public class IntegrationTests
     [TestMethod]
     public void E2E_GenerateAndRedactManifest_RedactedFileIsSmaller_ReturnsZeroExitCode()
     {
+        if (!IsWindows)
+        {
+            Assert.Inconclusive("This test is not (yet) supported on non-Windows platforms.");
+            return;
+        }
+
         var testFolderPath = CreateTestFolder();
         GenerateManifestAndValidateSuccess(testFolderPath);
 
@@ -90,42 +113,6 @@ public class IntegrationTests
         var redactedManifestSize = File.ReadAllText(redactedManifestFilePath).Length;
         Assert.IsTrue(redactedManifestSize > 0, "Redacted file must not be empty");
         Assert.IsTrue(redactedManifestSize < originalManifestSize, "Redacted file must be smaller than the original");
-    }
-
-    private static void EnsureAppIsExecutable()
-    {
-        if (IsWindows)
-        {
-            return;
-        }
-
-        lock (LockObject)
-        {
-            Process process = null;
-            try
-            {
-                process = new Process
-                {
-                    StartInfo = new ProcessStartInfo
-                    {
-                        RedirectStandardOutput = true,
-                        RedirectStandardError = true,
-                        UseShellExecute = false,
-                        CreateNoWindow = true,
-                        WindowStyle = ProcessWindowStyle.Hidden,
-                        FileName = "/bin/bash",
-                        Arguments = $"chmod u+x {GetAppName()}"
-                    }
-                };
-
-                process.Start();
-                process.WaitForExit();
-            }
-            finally
-            {
-                process?.Dispose();
-            }
-        }
     }
 
     private void GenerateManifestAndValidateSuccess(string testFolderPath)
@@ -171,8 +158,6 @@ public class IntegrationTests
         var stderr = string.Empty;
         int? exitCode = null;
         Process process = null;
-
-        EnsureAppIsExecutable();
 
         try
         {

--- a/test/Microsoft.Sbom.Tool.Tests/IntegrationTests.cs
+++ b/test/Microsoft.Sbom.Tool.Tests/IntegrationTests.cs
@@ -2,14 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NuGet.Frameworks;
 
 namespace Microsoft.Sbom.Tools.Tests;
 

--- a/test/Microsoft.Sbom.Tool.Tests/IntegrationTests.cs
+++ b/test/Microsoft.Sbom.Tool.Tests/IntegrationTests.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NuGet.Frameworks;
 
@@ -19,6 +20,7 @@ public class IntegrationTests
     private const string ManifestFileName = "manifest.spdx.json";
 
     private static TestContext testContext;
+    private static readonly string AppName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Microsoft.Sbom.Tool.exe" : "Microsoft.Sbom.Tool";
 
     [ClassInitialize]
     public static void SetUp(TestContext testContext)
@@ -128,7 +130,7 @@ public class IntegrationTests
         try
         {
             process = new Process();
-            process.StartInfo.FileName = "Microsoft.Sbom.Tool.exe";
+            process.StartInfo.FileName = AppName;
             process.StartInfo.RedirectStandardOutput = true;
             process.StartInfo.RedirectStandardError = true;
             process.StartInfo.UseShellExecute = false;

--- a/test/Microsoft.Sbom.Tool.Tests/IntegrationTests.cs
+++ b/test/Microsoft.Sbom.Tool.Tests/IntegrationTests.cs
@@ -1,0 +1,183 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NuGet.Frameworks;
+
+namespace Microsoft.Sbom.Tools.Tests;
+
+[TestClass]
+public class IntegrationTests
+{
+    private const string ManifestRootFolderName = "_manifest";
+    private const string ManifestFileName = "manifest.spdx.json";
+
+    private static TestContext testContext;
+
+    [ClassInitialize]
+    public static void SetUp(TestContext testContext)
+    {
+        IntegrationTests.testContext = testContext;
+    }
+
+    [TestMethod]
+    public void E2E_NoParameters_DisplaysHelpMessage_ReturnsNonZeroExitCode()
+    {
+        var (stdout, stderr, exitCode) = LaunchAndCaptureOutput(null);
+
+        Assert.AreEqual(stderr, string.Empty);
+        Assert.IsTrue(stdout.Contains("Validate -options"));
+        Assert.IsTrue(stdout.Contains("Generate -options"));
+        Assert.IsTrue(stdout.Contains("Redact -options"));
+        Assert.AreNotEqual(0, exitCode.Value);
+    }
+
+    [TestMethod]
+    public void E2E_GenerateManifest_GeneratesManifest_ReturnsZeroExitCode()
+    {
+        var testFolderPath = CreateTestFolder();
+        GenerateManifestAndValidateSuccess(testFolderPath);
+    }
+
+    [TestMethod]
+    public void E2E_GenerateAndValidateManifest_ValidationSucceeds_ReturnsZeroExitCode()
+    {
+        var testFolderPath = CreateTestFolder();
+        GenerateManifestAndValidateSuccess(testFolderPath);
+
+        var outputFile = Path.Combine(testContext.ResultsDirectory, testContext.TestName, "validation.json");
+        var manifestRootFolderName = Path.Combine(testFolderPath, ManifestRootFolderName);
+        var arguments = $"validate -m \"{manifestRootFolderName}\" -b . -o \"{outputFile}\" -mi spdx:2.2";
+
+        var (stdout, stderr, exitCode) = LaunchAndCaptureOutput(arguments);
+
+        Assert.AreEqual(stderr, string.Empty);
+        Assert.AreEqual(0, exitCode.Value);
+        Assert.IsTrue(File.Exists(outputFile), $"{outputFile} should have been created during validation");
+        Assert.IsTrue(File.ReadAllText(outputFile).Contains("\"Result\":\"Success\"", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [TestMethod]
+    public void E2E_GenerateAndRedactManifest_RedactedFileIsSmaller_ReturnsZeroExitCode()
+    {
+        var testFolderPath = CreateTestFolder();
+        GenerateManifestAndValidateSuccess(testFolderPath);
+
+        var outputFolder = Path.Combine(testContext.ResultsDirectory, testContext.TestName, "redacted");
+        var originalManifestFolderPath = AppendFullManifestFolderPath(testFolderPath);
+        var originalManifestFilePath = Path.Combine(AppendFullManifestFolderPath(testFolderPath), ManifestFileName);
+        var arguments = $"redact -sp \"{originalManifestFilePath}\" -o \"{outputFolder}\" -verbosity verbose";
+
+        var (stdout, stderr, exitCode) = LaunchAndCaptureOutput(arguments);
+
+        Assert.AreEqual(stderr, string.Empty);
+        Assert.AreEqual(0, exitCode.Value);
+        Assert.IsTrue(stdout.Contains("Result=Success", StringComparison.OrdinalIgnoreCase));
+        var redactedManifestFilePath = Path.Combine(outputFolder, ManifestFileName);
+        var originalManifestSize = File.ReadAllText(originalManifestFilePath).Length;
+        var redactedManifestSize = File.ReadAllText(redactedManifestFilePath).Length;
+        Assert.IsTrue(redactedManifestSize > 0, "Redacted file must not be empty");
+        Assert.IsTrue(redactedManifestSize < originalManifestSize, "Redacted file must be smaller than the original");
+    }
+
+    public void GenerateManifestAndValidateSuccess(string testFolderPath)
+    {
+        var arguments = $"generate -ps IntegrationTests -pn IntegrationTests -pv 1.2.3 -m \"{testFolderPath}\"  -b . -bc \"{GetSolutionFolderPath()}\"";
+
+        var (stdout, stderr, exitCode) = LaunchAndCaptureOutput(arguments);
+
+        Assert.AreEqual(stderr, string.Empty);
+        var manifestFolderPath = AppendFullManifestFolderPath(testFolderPath);
+        var jsonFilePath = Path.Combine(manifestFolderPath, ManifestFileName);
+        var shaFilePath = Path.Combine(manifestFolderPath, "manifest.spdx.json.sha256");
+        Assert.IsTrue(File.Exists(jsonFilePath));
+        Assert.IsTrue(File.Exists(shaFilePath));
+        Assert.AreEqual(0, exitCode.Value);
+    }
+
+    private string CreateTestFolder()
+    {
+        var testFolderPath = Path.GetFullPath(Path.Combine(testContext.ResultsDirectory, testContext.TestName));
+        Directory.CreateDirectory(testFolderPath);
+        return testFolderPath;
+    }
+
+    private static string AppendFullManifestFolderPath(string manifestDir)
+    {
+        return Path.Combine(manifestDir, ManifestRootFolderName, "spdx_2.2");
+    }
+
+    private static string GetSolutionFolderPath()
+    {
+        return Path.GetFullPath(Path.Combine(Assembly.GetExecutingAssembly().Location, "..", "..", ".."));
+    }
+
+    private static (string stdout, string stderr, int? exitCode) LaunchAndCaptureOutput(string? arguments)
+    {
+        var stdout = string.Empty;
+        var stderr = string.Empty;
+        int? exitCode = null;
+        Process process = null;
+
+        try
+        {
+            process = new Process();
+            process.StartInfo.FileName = "Microsoft.Sbom.Tool.exe";
+            process.StartInfo.RedirectStandardOutput = true;
+            process.StartInfo.RedirectStandardError = true;
+            process.StartInfo.UseShellExecute = false;
+            process.StartInfo.CreateNoWindow = true;
+
+            if (!string.IsNullOrEmpty(arguments))
+            {
+                process.StartInfo.Arguments = arguments;
+            }
+
+            process.OutputDataReceived += (sender, e) =>
+            {
+                if (!string.IsNullOrEmpty(e.Data))
+                {
+                    stdout += e.Data + Environment.NewLine;
+                }
+            };
+
+            process.ErrorDataReceived += (sender, e) =>
+            {
+                if (!string.IsNullOrEmpty(e.Data))
+                {
+                    stderr += e.Data + Environment.NewLine;
+                }
+            };
+
+            process.Start();
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+            process.WaitForExit();
+        }
+        catch (Exception ex)
+        {
+            // Handle any exceptions here
+            Console.WriteLine("Error: " + ex.Message);
+        }
+        finally
+        {
+            if (process is not null)
+            {
+                if (process.HasExited)
+                {
+                    process.Kill();
+                }
+
+                exitCode = process.ExitCode;
+            }
+        }
+
+        return (stdout, stderr, exitCode);
+    }
+}

--- a/test/Microsoft.Sbom.Tool.Tests/IntegrationTests.cs
+++ b/test/Microsoft.Sbom.Tool.Tests/IntegrationTests.cs
@@ -34,6 +34,12 @@ public class IntegrationTests
     [TestMethod]
     public void E2E_NoParameters_DisplaysHelpMessage_ReturnsNonZeroExitCode()
     {
+        if (!IsWindows)
+        {
+            Assert.Inconclusive("This test is not (yet) supported on non-Windows platforms.");
+            return;
+        }
+
         var (stdout, stderr, exitCode) = LaunchAndCaptureOutput(null);
 
         Assert.AreEqual(stderr, string.Empty);

--- a/test/Microsoft.Sbom.Tool.Tests/IntegrationTests.cs
+++ b/test/Microsoft.Sbom.Tool.Tests/IntegrationTests.cs
@@ -16,24 +16,27 @@ public class IntegrationTests
     private const string ManifestRootFolderName = "_manifest";
     private const string ManifestFileName = "manifest.spdx.json";
 
-    private static TestContext testContext;
     private static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
+    public TestContext TestContext { get; set; }
+
+    private static string testResultsDirectory;
+
     [ClassInitialize]
-    public static void SetUp(TestContext testContext)
+    public static void Setup(TestContext context)
     {
-        IntegrationTests.testContext = testContext;
+        testResultsDirectory = context.ResultsDirectory;
     }
 
     [ClassCleanup]
     public static void TearDown()
     {
         // Clean up test directories
-        if (testContext is not null)
+        if (testResultsDirectory is not null)
         {
-            if (Directory.Exists(testContext.ResultsDirectory))
+            if (Directory.Exists(testResultsDirectory))
             {
-                Directory.Delete(testContext.ResultsDirectory, true);
+                Directory.Delete(testResultsDirectory, true);
             }
         }
     }
@@ -87,7 +90,7 @@ public class IntegrationTests
         var testFolderPath = CreateTestFolder();
         GenerateManifestAndValidateSuccess(testFolderPath);
 
-        var outputFile = Path.Combine(testContext.ResultsDirectory, testContext.TestName, "validation.json");
+        var outputFile = Path.Combine(TestContext.ResultsDirectory, TestContext.TestName, "validation.json");
         var manifestRootFolderName = Path.Combine(testFolderPath, ManifestRootFolderName);
         var arguments = $"validate -m \"{manifestRootFolderName}\" -b . -o \"{outputFile}\" -mi spdx:2.2";
 
@@ -111,7 +114,7 @@ public class IntegrationTests
         var testFolderPath = CreateTestFolder();
         GenerateManifestAndValidateSuccess(testFolderPath);
 
-        var outputFolder = Path.Combine(testContext.ResultsDirectory, testContext.TestName, "redacted");
+        var outputFolder = Path.Combine(TestContext.ResultsDirectory, TestContext.TestName, "redacted");
         var originalManifestFolderPath = AppendFullManifestFolderPath(testFolderPath);
         var originalManifestFilePath = Path.Combine(AppendFullManifestFolderPath(testFolderPath), ManifestFileName);
         var arguments = $"redact -sp \"{originalManifestFilePath}\" -o \"{outputFolder}\" -verbosity verbose";
@@ -145,7 +148,7 @@ public class IntegrationTests
 
     private string CreateTestFolder()
     {
-        var testFolderPath = Path.GetFullPath(Path.Combine(testContext.ResultsDirectory, testContext.TestName));
+        var testFolderPath = Path.GetFullPath(Path.Combine(TestContext.ResultsDirectory, TestContext.TestName));
         Directory.CreateDirectory(testFolderPath);
         return testFolderPath;
     }

--- a/test/Microsoft.Sbom.Tool.Tests/IntegrationTests.cs
+++ b/test/Microsoft.Sbom.Tool.Tests/IntegrationTests.cs
@@ -17,12 +17,18 @@ public class IntegrationTests
     private const string ManifestFileName = "manifest.spdx.json";
 
     private static TestContext testContext;
-    private static readonly string AppName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Microsoft.Sbom.Tool.exe" : "Microsoft.Sbom.Tool";
+    private static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
     [ClassInitialize]
     public static void SetUp(TestContext testContext)
     {
         IntegrationTests.testContext = testContext;
+    }
+
+    [TestMethod]
+    public void TargetAppExists()
+    {
+        Assert.IsTrue(File.Exists(GetAppName()));
     }
 
     [TestMethod]
@@ -40,6 +46,12 @@ public class IntegrationTests
     [TestMethod]
     public void E2E_GenerateManifest_GeneratesManifest_ReturnsZeroExitCode()
     {
+        if (!IsWindows)
+        {
+            Assert.Inconclusive("This test is not (yet) supported on non-Windows platforms.");
+            return;
+        }
+
         var testFolderPath = CreateTestFolder();
         GenerateManifestAndValidateSuccess(testFolderPath);
     }
@@ -47,6 +59,12 @@ public class IntegrationTests
     [TestMethod]
     public void E2E_GenerateAndValidateManifest_ValidationSucceeds_ReturnsZeroExitCode()
     {
+        if (!IsWindows)
+        {
+            Assert.Inconclusive("This test is not (yet) supported on non-Windows platforms.");
+            return;
+        }
+
         var testFolderPath = CreateTestFolder();
         GenerateManifestAndValidateSuccess(testFolderPath);
 
@@ -65,6 +83,12 @@ public class IntegrationTests
     [TestMethod]
     public void E2E_GenerateAndRedactManifest_RedactedFileIsSmaller_ReturnsZeroExitCode()
     {
+        if (!IsWindows)
+        {
+            Assert.Inconclusive("This test is not (yet) supported on non-Windows platforms.");
+            return;
+        }
+
         var testFolderPath = CreateTestFolder();
         GenerateManifestAndValidateSuccess(testFolderPath);
 
@@ -117,6 +141,11 @@ public class IntegrationTests
         return Path.GetFullPath(Path.Combine(Assembly.GetExecutingAssembly().Location, "..", "..", ".."));
     }
 
+    private static string GetAppName()
+    {
+        return IsWindows ? "Microsoft.Sbom.Tool.exe" : "Microsoft.Sbom.Tool";
+    }
+
     private static (string stdout, string stderr, int? exitCode) LaunchAndCaptureOutput(string? arguments)
     {
         var stdout = string.Empty;
@@ -127,7 +156,7 @@ public class IntegrationTests
         try
         {
             process = new Process();
-            process.StartInfo.FileName = AppName;
+            process.StartInfo.FileName = GetAppName();
             process.StartInfo.RedirectStandardOutput = true;
             process.StartInfo.RedirectStandardError = true;
             process.StartInfo.UseShellExecute = false;

--- a/test/Microsoft.Sbom.Tool.Tests/IntegrationTests.cs
+++ b/test/Microsoft.Sbom.Tool.Tests/IntegrationTests.cs
@@ -25,6 +25,19 @@ public class IntegrationTests
         IntegrationTests.testContext = testContext;
     }
 
+    [ClassCleanup]
+    public static void TearDown()
+    {
+        // Clean up test directories
+        if (testContext is not null)
+        {
+            if (Directory.Exists(testContext.ResultsDirectory))
+            {
+                Directory.Delete(testContext.ResultsDirectory, true);
+            }
+        }
+    }
+
     [TestMethod]
     public void TargetAppExists()
     {
@@ -195,10 +208,9 @@ public class IntegrationTests
             process.BeginErrorReadLine();
             process.WaitForExit();
         }
-        catch (Exception ex)
+        catch (Exception e)
         {
-            // Handle any exceptions here
-            Console.WriteLine("Error: " + ex.Message);
+            Assert.Fail($"Caught the following Exception: {e}");
         }
         finally
         {

--- a/test/Microsoft.Sbom.Tool.Tests/Microsoft.Sbom.Tool.Tests.csproj
+++ b/test/Microsoft.Sbom.Tool.Tests/Microsoft.Sbom.Tool.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <SignAssembly>True</SignAssembly>
+    <RootNamespace>Microsoft.Sbom.Tools.Tests</RootNamespace>
+    <AssemblyOriginatorKeyFile>$(StrongNameSigningKeyFilePath)</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DefineConstants>TRACE</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.Sbom.Tool\Microsoft.Sbom.Tool.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
As called out in #483, our PR pipelines include no E2E tests. This PR adds E2E tests to cover 5 simple cases (more can be added at a later time):
1. Runs on all platforms. App exists where it is expected
    - This exists mainly as a step toward cross-platform testing. It can be removed, if desired.
2. Runs only on Windows. App is run with no parameters. The following checks are made:
    - App provides a non-zero return code
    - Nothing is sent to `stderr`
    - Help text is displayed to `stdout`
3. Runs only on Windows. App is run to generate an SBOM. The following checks are made:
    - App provides a zero return code from generation
    - A non-empty SBOM file is created in the specified location
    - A non-empty SHA file is created in the specified location
4. Runs only on Windows. App is run to generate an SBOM, then validate it. This includes all checks from test <span>#</span>3, plus the following:
    - App provides a zero return code from validation
    - Output file is written to the specified location
    - Output file includes `"Result":"Success"` - it just looks for the snippet, rather than parsing the entire JSON file
5. Runs only on Windows. App is run to generate an SBOM, then redact it. This includes all checks from test <span>#</span>3, plus the following:
    - App provides a zero return code from redaction
    - Telemetry (based on verbose output) includes `Result=Success`
    - The redacted SBOM is created in the specified location and has a length > 0
    - The redacted SBOM file is smaller than the original SBOM file

On my build machine, these tests add about 30 seconds to the test execution time. If we wish, I'm happy (in a future PR) to add some sort of filtering to limit them to pipeline builds only.

Running tests 2-5 on non-Windows platforms fail, potentially because the tool doesn't have the execute bit set. I've tried some variations of using `chmod u+x` and the .NET 8 [File.SetUnixFileMode](https://learn.microsoft.com/en-us/dotnet/api/system.io.file.setunixfilemode?view=net-8.0) function without success, so I took the approach of "some improvement is better than none" and made the tests Windows-only.