### PR TITLE
Bump System.Text.Json to 8.0.4.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -50,7 +50,7 @@
         <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
         <PackageVersion Include="System.Reactive" Version="5.0.0" />
         <PackageVersion Include="System.Runtime.Loader" Version="4.3.0" />
-        <PackageVersion Include="System.Text.Json" Version="7.0.3" />
+        <PackageVersion Include="System.Text.Json" Version="8.0.4" />
         <PackageVersion Include="System.Threading.Channels" Version="6.0.0" />
         <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="4.11.1" />
         <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />


### PR DESCRIPTION
This PR is for addressing this vulnerability: https://github.com/advisories/GHSA-hh2w-p6rv-4g7w