### PR TITLE
Update NuGet Package Format and Surface Errors

### DIFF
--- a/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.targets
+++ b/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.targets
@@ -74,10 +74,15 @@
 
   <!-- Specify the SBOM files to copy into the nuget package -->
   <Target Name="CopySbomOutput" DependsOnTargets="GenerateSbomTarget">
+    <PropertyGroup>
+      <!--When building frameworks such as net8.0-windows, the platform version is appended to the framework in the NuGet package-->
+      <TargetFrameworkWithPlatformVersion Condition="$(TargetPlatformVersion) != ''">$(TargetFramework)$(TargetPlatformVersion)</TargetFrameworkWithPlatformVersion>
+      <TargetFrameworkWithPlatformVersion Condition="$(TargetPlatformVersion) == ''">$(TargetFramework)</TargetFrameworkWithPlatformVersion>
+    </PropertyGroup>
     <ItemGroup>
       <!--Add manifest and SHA file from the GenerateSbom target execution-->
       <TfmSpecificPackageFile Include="$(SbomPathResult)\$(SbomSpecification)\**">
-        <PackagePath>$(BuildOutputTargetFolder)/$(TargetFramework)/$(ManifestFolderName)/$(SbomSpecification)</PackagePath>
+        <PackagePath>$(BuildOutputTargetFolder)/$(TargetFrameworkWithPlatformVersion)/$(ManifestFolderName)/$(SbomSpecification)</PackagePath>
       </TfmSpecificPackageFile>
     </ItemGroup>
   </Target>

--- a/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.targets
+++ b/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.targets
@@ -29,10 +29,25 @@
   <!--Based on the MSBuild runtime, GenerateSbom will either pull the GenerateSbomTask or SbomCLIToolTask logic-->
   <UsingTask TaskName="Microsoft.Sbom.Targets.GenerateSbom" AssemblyFile="$(MSBuildThisFileDirectory)\..\tasks\$(GenerateSbom_TFM)\Microsoft.Sbom.Targets.dll" />
 
-  <Import Project="$(MSBuildThisFileDirectory)\Microsoft.Sbom.Targets.props" />
+  <PropertyGroup>
+    <GenerateSBOM Condition=" '$(GenerateSBOM)' == '' ">false</GenerateSBOM>
+    <SbomGenerationBuildDropPath Condition=" '$(SbomGenerationBuildDropPath)' == '' ">$(OutDir)</SbomGenerationBuildDropPath>
+    <SbomGenerationBuildComponentPath Condition=" '$(SbomGenerationBuildComponentPath)' == '' ">$(MSBuildProjectDirectory)</SbomGenerationBuildComponentPath>
+    <SbomGenerationPackageSupplier Condition=" '$(SbomGenerationPackageSupplier)' == '' And $(Authors) != '' ">$(Authors)</SbomGenerationPackageSupplier>
+    <SbomGenerationPackageSupplier Condition=" '$(SbomGenerationPackageSupplier)' == '' And $(Authors) == '' ">$(AssemblyName)</SbomGenerationPackageSupplier>
+    <SbomGenerationPackageName Condition=" '$(SbomGenerationPackageName)' == '' And $(PackageId) != '' ">$(PackageId)</SbomGenerationPackageName>
+    <SbomGenerationPackageName Condition=" '$(SbomGenerationPackageName)' == '' And $(PackageId) == '' ">$(AssemblyName)</SbomGenerationPackageName>
+    <SbomGenerationPackageVersion Condition=" '$(SbomGenerationPackageVersion)' == '' And $(Version) != '' ">$(Version)</SbomGenerationPackageVersion>
+    <SbomGenerationPackageVersion Condition=" '$(SbomGenerationPackageVersion)' == '' And $(Version) == '' ">1.0.0</SbomGenerationPackageVersion>
+    <SbomGenerationNamespaceBaseUri Condition=" '$(SbomGenerationNamespaceBaseUri)' == '' ">http://spdx.org/spdxdocs/$(SbomGenerationPackageName)"</SbomGenerationNamespaceBaseUri>
+    <SbomGenerationFetchLicenseInformation Condition=" '$(SbomGenerationFetchLicenseInformation)' == '' ">false</SbomGenerationFetchLicenseInformation>
+    <SbomGenerationEnablePackageMetadataParsing Condition=" '$(SbomGenerationEnablePackageMetadataParsing)' == '' ">false</SbomGenerationEnablePackageMetadataParsing>
+    <SbomGenerationVerbosity Condition=" '$(SbomGenerationVerbosity)' == '' ">LogAlways</SbomGenerationVerbosity>
+    <SbomGenerationManifestInfo Condition=" '$(SbomGenerationManifestInfo)' == '' ">SPDX:2.2</SbomGenerationManifestInfo>
+    <SbomGenerationDeleteManifestDirIfPresent Condition=" '$(SbomGenerationDeleteManifestDirIfPresent)' == '' ">true</SbomGenerationDeleteManifestDirIfPresent>
+  </PropertyGroup>
 
   <Target Name="GenerateSbomTarget" AfterTargets="Build" Condition=" '$(GenerateSBOM)' ==  'true'">
-    <!--TODO: Add arguments for ToolTask-->
     <GenerateSbom
         BuildDropPath="$(SbomGenerationBuildDropPath)"
         BuildComponentPath="$(SbomGenerationBuildComponentPath)"
@@ -57,7 +72,7 @@
   <!-- Specify the SBOM files to copy into the nuget package -->
   <Target Name="CopySbomOutput" DependsOnTargets="GenerateSbomTarget">
     <ItemGroup>
-      <!--Add manifest and SHA file from the GenerateSbomTask execution-->
+      <!--Add manifest and SHA file from the GenerateSbom target execution-->
       <BuildOutputInPackage 
 								  Include="$(SbomPathResult)\$(SbomSpecification)\manifest.spdx.json"
 								  TargetPath="$(ManifestFolderName)/$(SbomSpecification)/manifest.spdx.json"/>

--- a/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.targets
+++ b/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.targets
@@ -81,8 +81,8 @@
     </PropertyGroup>
     <ItemGroup>
       <!--Add manifest and SHA file from the GenerateSbom target execution-->
-      <TfmSpecificPackageFile Include="$(SbomPathResult)\$(SbomSpecification)\**">
-        <PackagePath>$(BuildOutputTargetFolder)/$(TargetFrameworkWithPlatformVersion)/$(ManifestFolderName)/$(SbomSpecification)</PackagePath>
+      <TfmSpecificPackageFile Include="$([System.IO.Path]::Combine($(SbomPathResult),$(SbomSpecification)))\**">
+        <PackagePath>$([System.IO.Path]::Combine($(BuildOutputTargetFolder),$(TargetFrameworkWithPlatformVersion),$(ManifestFolderName),$(SbomSpecification)))</PackagePath>
       </TfmSpecificPackageFile>
     </ItemGroup>
   </Target>

--- a/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.targets
+++ b/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.targets
@@ -64,22 +64,6 @@
       <BuildOutputInPackage
                   Include="$(SbomPathResult)\$(SbomSpecification)\manifest.spdx.json.sha256"
 								  TargetPath="$(ManifestFolderName)/$(SbomSpecification)/manifest.spdx.json.sha256"/>
-
-      <!--Add manifest and SHA file from the SbomCLIToolTask execution from the default manifest path --><!--
-      <BuildOutputInPackage Condition=" '$(MSBuildRuntimeType)' == 'Full' And '$(SbomGenerationManifestDirPath)' == ''"
-								  Include="$(SbomPathResult)\$(SbomSpecification)\manifest.spdx.json"
-								  TargetPath="$(ManifestFolderName)/$(SbomSpecification)/manifest.spdx.json"/>
-      <BuildOutputInPackage Condition=" '$(MSBuildRuntimeType)' == 'Full' And '$(SbomGenerationManifestDirPath)' == ''"
-								  Include="$(SbomPathResult)\$(SbomSpecification)\manifest.spdx.json.sha256"
-								  TargetPath="$(ManifestFolderName)/$(SbomSpecification)/manifest.spdx.json.sha256"/>-->
-
-      <!--Add manifest and SHA file from the SbomCLIToolTask execution if a manifest directory was specified --><!--
-      <BuildOutputInPackage Condition=" '$(MSBuildRuntimeType)' == 'Full'"
-								  Include="$(SbomPathResult)\$(SbomSpecification)\manifest.spdx.json"
-								  TargetPath="$(ManifestFolderName)/$(SbomSpecification)/manifest.spdx.json"/>
-      <BuildOutputInPackage Condition=" '$(MSBuildRuntimeType)' == 'Full'"
-								  Include="$(SbomPathResult)\$(SbomSpecification)\manifest.spdx.json.sha256"
-								  TargetPath="$(ManifestFolderName)/$(SbomSpecification)/manifest.spdx.json.sha256"/>-->
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.targets
+++ b/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.targets
@@ -12,22 +12,24 @@
     <GenerateSbom_TFM Condition=" '$(MSBuildRuntimeType)' == 'Full' ">net472</GenerateSbom_TFM>
     <GenerateSbom_TFM Condition=" '$(MSBuildRuntimeType)' == 'Core' ">net8.0</GenerateSbom_TFM>
 
+    <SbomToolBinaryOutputPath>$([System.IO.Path]::Combine($(MSBuildThisFileDirectory),..,tasks,$(GenerateSbom_TFM),sbom-tool))</SbomToolBinaryOutputPath>
+    <AssemblyFilePath>$([System.IO.Path]::Combine($(MSBuildThisFileDirectory),..,tasks,$(GenerateSbom_TFM),Microsoft.Sbom.Targets.dll))</AssemblyFilePath>
+
     <!--Set the SBOM CLI Tool path. This variable is only used in SbomCLIToolTask.cs-->
-    <SbomToolPath Condition=" '$(MSBuildRuntimeType)' == 'Full'">$(MSBuildThisFileDirectory)\..\tasks\$(GenerateSbom_TFM)\sbom-tool</SbomToolPath>
+    <SbomToolPath Condition=" '$(MSBuildRuntimeType)' == 'Full'">$(SbomToolBinaryOutputPath)</SbomToolPath>
     <ManifestFolderName>_manifest</ManifestFolderName>
     <SbomSpecification>spdx_2.2</SbomSpecification>
   </PropertyGroup>
 
   <!-- Copy the SBOM files to each respective target framework folder within the .nupkg -->
   <PropertyGroup>
-    <TargetsForTfmSpecificBuildOutput>
-      $(TargetsForTfmSpecificBuildOutput);CopySbomOutput
-    </TargetsForTfmSpecificBuildOutput>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.sha256</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <TargetsForTfmSpecificContentInPackage>
+      $(TargetsForTfmSpecificContentInPackage);CopySbomOutput
+    </TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
   
   <!--Based on the MSBuild runtime, GenerateSbom will either pull the GenerateSbomTask or SbomCLIToolTask logic-->
-  <UsingTask TaskName="Microsoft.Sbom.Targets.GenerateSbom" AssemblyFile="$(MSBuildThisFileDirectory)\..\tasks\$(GenerateSbom_TFM)\Microsoft.Sbom.Targets.dll" />
+  <UsingTask TaskName="Microsoft.Sbom.Targets.GenerateSbom" AssemblyFile="$(AssemblyFilePath)" />
 
   <PropertyGroup>
     <GenerateSBOM Condition=" '$(GenerateSBOM)' == '' ">false</GenerateSBOM>
@@ -48,6 +50,7 @@
   </PropertyGroup>
 
   <Target Name="GenerateSbomTarget" AfterTargets="Build" Condition=" '$(GenerateSBOM)' ==  'true'">
+    <Error Condition="'$(BuildOutputTargetFolder)' == ''" Text="The GenerationSbomTarget requires the BuildOutputTargetFolder property to be non-null. Please set a folder name."/>
     <GenerateSbom
         BuildDropPath="$(SbomGenerationBuildDropPath)"
         BuildComponentPath="$(SbomGenerationBuildComponentPath)"
@@ -73,12 +76,9 @@
   <Target Name="CopySbomOutput" DependsOnTargets="GenerateSbomTarget">
     <ItemGroup>
       <!--Add manifest and SHA file from the GenerateSbom target execution-->
-      <BuildOutputInPackage 
-								  Include="$(SbomPathResult)\$(SbomSpecification)\manifest.spdx.json"
-								  TargetPath="$(ManifestFolderName)/$(SbomSpecification)/manifest.spdx.json"/>
-      <BuildOutputInPackage
-                  Include="$(SbomPathResult)\$(SbomSpecification)\manifest.spdx.json.sha256"
-								  TargetPath="$(ManifestFolderName)/$(SbomSpecification)/manifest.spdx.json.sha256"/>
+      <TfmSpecificPackageFile Include="$(SbomPathResult)\$(SbomSpecification)\**">
+        <PackagePath>$(BuildOutputTargetFolder)/$(TargetFramework)/$(ManifestFolderName)/$(SbomSpecification)</PackagePath>
+      </TfmSpecificPackageFile>
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.targets
+++ b/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.targets
@@ -15,6 +15,15 @@
     <!--Set the SBOM CLI Tool path. This variable is only used in SbomCLIToolTask.cs-->
     <SbomToolPath Condition=" '$(MSBuildRuntimeType)' == 'Full'">$(MSBuildThisFileDirectory)\..\tasks\$(GenerateSbom_TFM)\sbom-tool</SbomToolPath>
     <ManifestFolderName>_manifest</ManifestFolderName>
+    <SbomSpecification>spdx_2.2</SbomSpecification>
+  </PropertyGroup>
+
+  <!-- Copy the SBOM files to each respective target framework folder within the .nupkg -->
+  <PropertyGroup>
+    <TargetsForTfmSpecificBuildOutput>
+      $(TargetsForTfmSpecificBuildOutput);CopySbomOutput
+    </TargetsForTfmSpecificBuildOutput>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.sha256</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   
   <!--Based on the MSBuild runtime, GenerateSbom will either pull the GenerateSbomTask or SbomCLIToolTask logic-->
@@ -58,23 +67,34 @@
       <Output TaskParameter="SbomPath" PropertyName="SbomPathResult" />
     </GenerateSbom>
     <Message Importance="High" Text="Task result: $(SbomPathResult)" />
+  </Target>
 
-    <!-- Include the generated SBOM contents within the consumer's nuget package -->
-    <ItemGroup >
-      <Content Condition=" '$(MSBuildRuntimeType)' == 'Core'" Include="$(SbomPathResult)\**">
-        <Pack>true</Pack>
-        <PackagePath>_manifest</PackagePath>
-      </Content>
+  <!-- Specify the SBOM files to copy into the nuget package -->
+  <Target Name="CopySbomOutput" DependsOnTargets="GenerateSbomTarget">
+    <ItemGroup>
+      <!--Add manifest and SHA file from the GenerateSbomTask execution-->
+      <BuildOutputInPackage Condition=" '$(MSBuildRuntimeType)' == 'Core'"
+								  Include="$(SbomPathResult)\$(SbomSpecification)\manifest.spdx.json"
+								  TargetPath="_manifest/$(SbomSpecification)/manifest.spdx.json"/>
+      <BuildOutputInPackage Condition=" '$(MSBuildRuntimeType)' == 'Core'"
+								  Include="$(SbomPathResult)\$(SbomSpecification)\manifest.spdx.json.sha256"
+								  TargetPath="_manifest/$(SbomSpecification)/manifest.spdx.json.sha256"/>
 
-      <Content Condition=" '$(MSBuildRuntimeType)' == 'Full' And '$(SbomGenerationManifestDirPath)' == '' " Include="$(SbomGenerationBuildDropPath)\$(ManifestFolderName)\**">
-        <Pack>true</Pack>
-        <PackagePath>_manifest</PackagePath>
-      </Content>
-      
-      <Content Condition=" '$(MSBuildRuntimeType)' == 'Full' And '$(SbomGenerationManifestDirPath)' != '' " Include="$(SbomGenerationManifestDirPath)\$(ManifestFolderName)\**">
-        <Pack>true</Pack>
-        <PackagePath>_manifest</PackagePath>
-      </Content>
+      <!--Add manifest and SHA file from the SbomCLIToolTask execution from the default manifest path -->
+      <BuildOutputInPackage Condition=" '$(MSBuildRuntimeType)' == 'Full' And '$(SbomGenerationManifestDirPath)' == ''"
+								  Include="$(SbomGenerationBuildDropPath)\$(ManifestFolderName)\$(SbomSpecification)\manifest.spdx.json"
+								  TargetPath="_manifest/$(SbomSpecification)/manifest.spdx.json"/>
+      <BuildOutputInPackage Condition=" '$(MSBuildRuntimeType)' == 'Full' And '$(SbomGenerationManifestDirPath)' == ''"
+								  Include="$(SbomGenerationBuildDropPath)\$(ManifestFolderName)\$(SbomSpecification)\manifest.spdx.json.sha256"
+								  TargetPath="_manifest/$(SbomSpecification)/manifest.spdx.json.sha256"/>
+
+      <!--Add manifest and SHA file from the SbomCLIToolTask execution if a manifest directory was specified -->
+      <BuildOutputInPackage Condition=" '$(MSBuildRuntimeType)' == 'Full' And '$(SbomGenerationManifestDirPath)' != ''"
+								  Include="$(SbomGenerationManifestDirPath)\$(ManifestFolderName)\$(SbomSpecification)\manifest.spdx.json"
+								  TargetPath="_manifest/$(SbomSpecification)/manifest.spdx.json"/>
+      <BuildOutputInPackage Condition=" '$(MSBuildRuntimeType)' == 'Full' And '$(SbomGenerationManifestDirPath)' != ''"
+								  Include="$(SbomGenerationManifestDirPath)\$(ManifestFolderName)\$(SbomSpecification)\manifest.spdx.json.sha256"
+								  TargetPath="_manifest/$(SbomSpecification)/manifest.spdx.json.sha256"/>
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.targets
+++ b/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.targets
@@ -29,25 +29,10 @@
   <!--Based on the MSBuild runtime, GenerateSbom will either pull the GenerateSbomTask or SbomCLIToolTask logic-->
   <UsingTask TaskName="Microsoft.Sbom.Targets.GenerateSbom" AssemblyFile="$(MSBuildThisFileDirectory)\..\tasks\$(GenerateSbom_TFM)\Microsoft.Sbom.Targets.dll" />
 
-  <PropertyGroup>
-    <GenerateSBOM Condition=" '$(GenerateSBOM)' == '' ">false</GenerateSBOM>
-    <SbomGenerationBuildDropPath Condition=" '$(SbomGenerationBuildDropPath)' == '' ">$(OutDir)</SbomGenerationBuildDropPath>
-    <SbomGenerationBuildComponentPath Condition=" '$(SbomGenerationBuildComponentPath)' == '' ">$(MSBuildProjectDirectory)</SbomGenerationBuildComponentPath>
-    <SbomGenerationPackageSupplier Condition=" '$(SbomGenerationPackageSupplier)' == '' And $(Authors) != '' ">$(Authors)</SbomGenerationPackageSupplier>
-    <SbomGenerationPackageSupplier Condition=" '$(SbomGenerationPackageSupplier)' == '' And $(Authors) == '' ">$(AssemblyName)</SbomGenerationPackageSupplier>
-    <SbomGenerationPackageName Condition=" '$(SbomGenerationPackageName)' == '' And $(PackageId) != '' ">$(PackageId)</SbomGenerationPackageName>
-    <SbomGenerationPackageName Condition=" '$(SbomGenerationPackageName)' == '' And $(PackageId) == '' ">$(AssemblyName)</SbomGenerationPackageName>
-    <SbomGenerationPackageVersion Condition=" '$(SbomGenerationPackageVersion)' == '' And $(Version) != '' ">$(Version)</SbomGenerationPackageVersion>
-    <SbomGenerationPackageVersion Condition=" '$(SbomGenerationPackageVersion)' == '' And $(Version) == '' ">1.0.0</SbomGenerationPackageVersion>
-    <SbomGenerationNamespaceBaseUri Condition=" '$(SbomGenerationNamespaceBaseUri)' == '' ">http://spdx.org/spdxdocs/$(SbomGenerationPackageName)"</SbomGenerationNamespaceBaseUri>
-    <SbomGenerationFetchLicenseInformation Condition=" '$(SbomGenerationFetchLicenseInformation)' == '' ">false</SbomGenerationFetchLicenseInformation>
-    <SbomGenerationEnablePackageMetadataParsing Condition=" '$(SbomGenerationEnablePackageMetadataParsing)' == '' ">false</SbomGenerationEnablePackageMetadataParsing>
-    <SbomGenerationVerbosity Condition=" '$(SbomGenerationVerbosity)' == '' ">LogAlways</SbomGenerationVerbosity>
-    <SbomGenerationManifestInfo Condition=" '$(SbomGenerationManifestInfo)' == '' ">SPDX:2.2</SbomGenerationManifestInfo>
-    <SbomGenerationDeleteManifestDirIfPresent Condition=" '$(SbomGenerationDeleteManifestDirIfPresent)' == '' ">true</SbomGenerationDeleteManifestDirIfPresent>
-  </PropertyGroup>
+  <Import Project="$(MSBuildThisFileDirectory)\Microsoft.Sbom.Targets.props" />
 
   <Target Name="GenerateSbomTarget" AfterTargets="Build" Condition=" '$(GenerateSBOM)' ==  'true'">
+    <!--TODO: Add arguments for ToolTask-->
     <GenerateSbom
         BuildDropPath="$(SbomGenerationBuildDropPath)"
         BuildComponentPath="$(SbomGenerationBuildComponentPath)"
@@ -73,28 +58,28 @@
   <Target Name="CopySbomOutput" DependsOnTargets="GenerateSbomTarget">
     <ItemGroup>
       <!--Add manifest and SHA file from the GenerateSbomTask execution-->
-      <BuildOutputInPackage Condition=" '$(MSBuildRuntimeType)' == 'Core'"
+      <BuildOutputInPackage 
 								  Include="$(SbomPathResult)\$(SbomSpecification)\manifest.spdx.json"
-								  TargetPath="_manifest/$(SbomSpecification)/manifest.spdx.json"/>
-      <BuildOutputInPackage Condition=" '$(MSBuildRuntimeType)' == 'Core'"
+								  TargetPath="$(ManifestFolderName)/$(SbomSpecification)/manifest.spdx.json"/>
+      <BuildOutputInPackage
+                  Include="$(SbomPathResult)\$(SbomSpecification)\manifest.spdx.json.sha256"
+								  TargetPath="$(ManifestFolderName)/$(SbomSpecification)/manifest.spdx.json.sha256"/>
+
+      <!--Add manifest and SHA file from the SbomCLIToolTask execution from the default manifest path --><!--
+      <BuildOutputInPackage Condition=" '$(MSBuildRuntimeType)' == 'Full' And '$(SbomGenerationManifestDirPath)' == ''"
+								  Include="$(SbomPathResult)\$(SbomSpecification)\manifest.spdx.json"
+								  TargetPath="$(ManifestFolderName)/$(SbomSpecification)/manifest.spdx.json"/>
+      <BuildOutputInPackage Condition=" '$(MSBuildRuntimeType)' == 'Full' And '$(SbomGenerationManifestDirPath)' == ''"
 								  Include="$(SbomPathResult)\$(SbomSpecification)\manifest.spdx.json.sha256"
-								  TargetPath="_manifest/$(SbomSpecification)/manifest.spdx.json.sha256"/>
+								  TargetPath="$(ManifestFolderName)/$(SbomSpecification)/manifest.spdx.json.sha256"/>-->
 
-      <!--Add manifest and SHA file from the SbomCLIToolTask execution from the default manifest path -->
-      <BuildOutputInPackage Condition=" '$(MSBuildRuntimeType)' == 'Full' And '$(SbomGenerationManifestDirPath)' == ''"
-								  Include="$(SbomGenerationBuildDropPath)\$(ManifestFolderName)\$(SbomSpecification)\manifest.spdx.json"
-								  TargetPath="_manifest/$(SbomSpecification)/manifest.spdx.json"/>
-      <BuildOutputInPackage Condition=" '$(MSBuildRuntimeType)' == 'Full' And '$(SbomGenerationManifestDirPath)' == ''"
-								  Include="$(SbomGenerationBuildDropPath)\$(ManifestFolderName)\$(SbomSpecification)\manifest.spdx.json.sha256"
-								  TargetPath="_manifest/$(SbomSpecification)/manifest.spdx.json.sha256"/>
-
-      <!--Add manifest and SHA file from the SbomCLIToolTask execution if a manifest directory was specified -->
-      <BuildOutputInPackage Condition=" '$(MSBuildRuntimeType)' == 'Full' And '$(SbomGenerationManifestDirPath)' != ''"
-								  Include="$(SbomGenerationManifestDirPath)\$(ManifestFolderName)\$(SbomSpecification)\manifest.spdx.json"
-								  TargetPath="_manifest/$(SbomSpecification)/manifest.spdx.json"/>
-      <BuildOutputInPackage Condition=" '$(MSBuildRuntimeType)' == 'Full' And '$(SbomGenerationManifestDirPath)' != ''"
-								  Include="$(SbomGenerationManifestDirPath)\$(ManifestFolderName)\$(SbomSpecification)\manifest.spdx.json.sha256"
-								  TargetPath="_manifest/$(SbomSpecification)/manifest.spdx.json.sha256"/>
+      <!--Add manifest and SHA file from the SbomCLIToolTask execution if a manifest directory was specified --><!--
+      <BuildOutputInPackage Condition=" '$(MSBuildRuntimeType)' == 'Full'"
+								  Include="$(SbomPathResult)\$(SbomSpecification)\manifest.spdx.json"
+								  TargetPath="$(ManifestFolderName)/$(SbomSpecification)/manifest.spdx.json"/>
+      <BuildOutputInPackage Condition=" '$(MSBuildRuntimeType)' == 'Full'"
+								  Include="$(SbomPathResult)\$(SbomSpecification)\manifest.spdx.json.sha256"
+								  TargetPath="$(ManifestFolderName)/$(SbomSpecification)/manifest.spdx.json.sha256"/>-->
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Microsoft.Sbom.Targets/SbomCLIToolTask.cs
+++ b/src/Microsoft.Sbom.Targets/SbomCLIToolTask.cs
@@ -23,12 +23,13 @@ public partial class GenerateSbom : ToolTask
         var taskResult = base.Execute();
         // Set the SbomPath output variable
         if (taskResult) {
+            var manifestFolderName = "_manifest";
             if (!string.IsNullOrWhiteSpace(this.ManifestDirPath))
             {
-                this.SbomPath = this.ManifestDirPath;
+                this.SbomPath = Path.Combine(this.ManifestDirPath, manifestFolderName);
             } else
             {
-                this.SbomPath = Path.Combine(this.BuildDropPath, "_manifest");
+                this.SbomPath = Path.Combine(this.BuildDropPath, manifestFolderName);
             }
         }
 

--- a/src/Microsoft.Sbom.Targets/SbomCLIToolTask.cs
+++ b/src/Microsoft.Sbom.Targets/SbomCLIToolTask.cs
@@ -123,31 +123,4 @@ public partial class GenerateSbom : ToolTask
 
         this.LogStandardErrorAsError = true;
     }
-
-    ///// <summary>
-    ///// Create the ManifestDirPath if it's specified by the user
-    ///// and doesn't exist. This is automatically done by the
-    ///// SBOM API, but not the SBOM CLI tool.
-    ///// </summary>
-    ///// <returns>Whether the directory creation succeeded</returns>
-    //private bool CreateManifestDirPathDirectory()
-    //{
-    //    try
-    //    {
-    //        if (!string.IsNullOrWhiteSpace(this.ManifestDirPath))
-    //        {
-    //            if (!Directory.Exists(this.ManifestDirPath))
-    //            {
-    //                Directory.CreateDirectory(this.ManifestDirPath);
-    //            }
-    //        }
-    //    }
-    //    catch (Exception e)
-    //    {
-    //        Log.LogError($"SBOM generation failed: Failed to create the 'ManifestDirPath' directory due to {e.Message}");
-    //        return false;
-    //    }
-
-    //    return true;
-    //}
 }

--- a/src/Microsoft.Sbom.Targets/SbomCLIToolTask.cs
+++ b/src/Microsoft.Sbom.Targets/SbomCLIToolTask.cs
@@ -14,6 +14,28 @@ public partial class GenerateSbom : ToolTask
     protected override string ToolName => "Microsoft.Sbom.Tool";
 
     /// <summary>
+    /// Executes the SBOM CLI Tool invocation. Need to add extra logic
+    /// to set SbomPath to the directory containing the SBOM.
+    /// </summary>
+    /// <returns></returns>
+    public override bool Execute()
+    {
+        var taskResult = base.Execute();
+        // Set the SbomPath output variable
+        if (taskResult) {
+            if (!string.IsNullOrWhiteSpace(this.ManifestDirPath))
+            {
+                this.SbomPath = this.ManifestDirPath;
+            } else
+            {
+                this.SbomPath = Path.Combine(this.BuildDropPath, "_manifest");
+            }
+        }
+
+        return taskResult;
+    }
+
+    /// <summary>
     /// Get full path to SBOM CLI tool.
     /// </summary>
     /// <returns></returns>

--- a/src/Microsoft.Sbom.Targets/SbomCLIToolTask.cs
+++ b/src/Microsoft.Sbom.Targets/SbomCLIToolTask.cs
@@ -97,7 +97,7 @@ public partial class GenerateSbom : ToolTask
     protected override bool ValidateParameters()
     {
         // Validate required args and args that take paths as input.
-        if (!ValidateAndSanitizeRequiredParams() || !ValidateAndSanitizeNamespaceUriUniquePart() || !CreateManifestDirPathDirectory())
+        if (!ValidateAndSanitizeRequiredParams() || !ValidateAndSanitizeNamespaceUriUniquePart())
         {
             return false;
         }
@@ -124,30 +124,30 @@ public partial class GenerateSbom : ToolTask
         this.LogStandardErrorAsError = true;
     }
 
-    /// <summary>
-    /// Create the ManifestDirPath if it's specified by the user
-    /// and doesn't exist. This is automatically done by the
-    /// SBOM API, but not the SBOM CLI tool.
-    /// </summary>
-    /// <returns>Whether the directory creation succeeded</returns>
-    private bool CreateManifestDirPathDirectory()
-    {
-        try
-        {
-            if (!string.IsNullOrWhiteSpace(this.ManifestDirPath))
-            {
-                if (!Directory.Exists(this.ManifestDirPath))
-                {
-                    Directory.CreateDirectory(this.ManifestDirPath);
-                }
-            }
-        }
-        catch (Exception e)
-        {
-            Log.LogError($"SBOM generation failed: Failed to create the 'ManifestDirPath' directory due to {e.Message}");
-            return false;
-        }
+    ///// <summary>
+    ///// Create the ManifestDirPath if it's specified by the user
+    ///// and doesn't exist. This is automatically done by the
+    ///// SBOM API, but not the SBOM CLI tool.
+    ///// </summary>
+    ///// <returns>Whether the directory creation succeeded</returns>
+    //private bool CreateManifestDirPathDirectory()
+    //{
+    //    try
+    //    {
+    //        if (!string.IsNullOrWhiteSpace(this.ManifestDirPath))
+    //        {
+    //            if (!Directory.Exists(this.ManifestDirPath))
+    //            {
+    //                Directory.CreateDirectory(this.ManifestDirPath);
+    //            }
+    //        }
+    //    }
+    //    catch (Exception e)
+    //    {
+    //        Log.LogError($"SBOM generation failed: Failed to create the 'ManifestDirPath' directory due to {e.Message}");
+    //        return false;
+    //    }
 
-        return true;
-    }
+    //    return true;
+    //}
 }

--- a/src/Microsoft.Sbom.Targets/SbomCLIToolTask.cs
+++ b/src/Microsoft.Sbom.Targets/SbomCLIToolTask.cs
@@ -27,10 +27,12 @@ public partial class GenerateSbom : ToolTask
             var manifestFolderName = "_manifest";
             if (!string.IsNullOrWhiteSpace(this.ManifestDirPath))
             {
-                this.SbomPath = Path.Combine(this.ManifestDirPath, manifestFolderName);
+                var fullManifestDirPath = Path.GetFullPath(this.ManifestDirPath);
+                this.SbomPath = Path.Combine(fullManifestDirPath, manifestFolderName);
             } else
             {
-                this.SbomPath = Path.Combine(this.BuildDropPath, manifestFolderName);
+                var fullBuidDropPath = Path.GetFullPath(this.BuildDropPath);
+                this.SbomPath = Path.Combine(fullBuidDropPath, manifestFolderName);
             }
         }
 

--- a/src/Microsoft.Sbom.Targets/SbomCLIToolTask.cs
+++ b/src/Microsoft.Sbom.Targets/SbomCLIToolTask.cs
@@ -3,7 +3,6 @@
 
 namespace Microsoft.Sbom.Targets;
 
-using System.Diagnostics.Tracing;
 using System.IO;
 using Microsoft.Build.Utilities;
 
@@ -97,5 +96,7 @@ public partial class GenerateSbom : ToolTask
         {
             this.StandardOutputImportance = "Low";
         }
+
+        this.LogStandardErrorAsError = true;
     }
 }


### PR DESCRIPTION
Modified our .targets files to use <TargetsForTfmSpecificContentInPackage> in order to copy the SBOM and sha256 hash into the user's nuget package near the binaries. For scenarios where users append "-windows" to the target framework, we also need to append the <TargetPlatformVersion> as well because NuGet renames the folder to "net8.0-windows7.0" in the nuget package.

These changes also set a ToolTask property that will log any errors from the CLI tool as ToolTask errors, so the messages will be surfaced to Visual Studio's output. There is also extra logic added to create the ManifestDirPath directory if it doesn't exist, minimizing the need for users to create it themselves. This is automatically done by the SBOM API, but is not done by the CLI tool; therefore, this logic was added to the ToolTask.



