### PR TITLE
Raise dependabot PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 30  # Default value of 5 is too low as we catch up
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
By default, dependabot limits itself to only 5 PR's open at a time, meaning that a few "stuck" PR's can hide others waiting to be opened. Recent logs show that dependabot currently has about 20 updates that are not being applied due to the existing limit. This PR simply raises the limit to allow more PR's to be opened.