### PR TITLE
Workaround for generating a SBOM manifest at the root level of the Nuget Package

### DIFF
--- a/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.csproj
+++ b/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.csproj
@@ -60,6 +60,7 @@
         by convention, the .NET SDK will look for build\<Package Id>.props and build\<Package Id>.targets
         for automatic inclusion in the build. -->
     <Content Include="Microsoft.Sbom.Targets.targets" PackagePath="\build" />
+    <Content Include="Microsoft.Sbom.Targets.targets" PackagePath="\buildMultiTargeting" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.targets
+++ b/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.targets
@@ -39,6 +39,7 @@
     <SbomGenerationVerbosity Condition=" '$(SbomGenerationVerbosity)' == '' ">information</SbomGenerationVerbosity>
     <SbomGenerationManifestInfo Condition=" '$(SbomGenerationManifestInfo)' == '' ">SPDX:2.2</SbomGenerationManifestInfo>
     <SbomGenerationDeleteManifestDirIfPresent Condition=" '$(SbomGenerationDeleteManifestDirIfPresent)' == '' ">true</SbomGenerationDeleteManifestDirIfPresent>
+    <UnzipGuid>$([System.Guid]::NewGuid())</UnzipGuid>
   </PropertyGroup>
 
   <!-- After the Nuget Package is generated, we will unzip, scan, generate the SBOM and zip again. -->
@@ -51,7 +52,7 @@
         $(PackageOutputPath)\$(PackageId).$(PackageVersion).nupkg
       </NugetPackage>
       <NugetPackageUnzip>
-        $(PackageOutputPath)\$(PackageId).$(PackageVersion).nupkg.unzip
+        $(PackageOutputPath)\$(PackageId).$(PackageVersion).$(UnzipGuid).temp
       </NugetPackageUnzip>
     </PropertyGroup>
     <Unzip DestinationFolder="$(NugetPackageUnzip)" SourceFiles="$(NugetPackage)" OverwriteReadOnlyFiles="true" />
@@ -79,6 +80,6 @@
 
     <!-- Zip the Nuget package back up and delete the temporary unzipped package. -->
     <ZipDirectory SourceDirectory="$(NugetPackageUnzip)" DestinationFile="$(NugetPackage)" Overwrite="true" />
-    <RemoveDir Directories="$(NugetPackageUnzip)" />
+    <RemoveDir Directories="$(NugetPackageUnzip)" ContinueOnError="true" />
   </Target>
 </Project>

--- a/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.targets
+++ b/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.targets
@@ -20,20 +20,12 @@
     <ManifestFolderName>_manifest</ManifestFolderName>
     <SbomSpecification>spdx_2.2</SbomSpecification>
   </PropertyGroup>
-
-  <!-- Copy the SBOM files to each respective target framework folder within the .nupkg -->
-  <PropertyGroup>
-    <TargetsForTfmSpecificContentInPackage>
-      $(TargetsForTfmSpecificContentInPackage);CopySbomOutput
-    </TargetsForTfmSpecificContentInPackage>
-  </PropertyGroup>
   
   <!--Based on the MSBuild runtime, GenerateSbom will either pull the GenerateSbomTask or SbomCLIToolTask logic-->
   <UsingTask TaskName="Microsoft.Sbom.Targets.GenerateSbom" AssemblyFile="$(AssemblyFilePath)" />
 
   <PropertyGroup>
     <GenerateSBOM Condition=" '$(GenerateSBOM)' == '' ">false</GenerateSBOM>
-    <SbomGenerationBuildDropPath Condition=" '$(SbomGenerationBuildDropPath)' == '' ">$(OutDir)</SbomGenerationBuildDropPath>
     <SbomGenerationBuildComponentPath Condition=" '$(SbomGenerationBuildComponentPath)' == '' ">$(MSBuildProjectDirectory)</SbomGenerationBuildComponentPath>
     <SbomGenerationPackageSupplier Condition=" '$(SbomGenerationPackageSupplier)' == '' And $(Authors) != '' ">$(Authors)</SbomGenerationPackageSupplier>
     <SbomGenerationPackageSupplier Condition=" '$(SbomGenerationPackageSupplier)' == '' And $(Authors) == '' ">$(AssemblyName)</SbomGenerationPackageSupplier>
@@ -49,10 +41,24 @@
     <SbomGenerationDeleteManifestDirIfPresent Condition=" '$(SbomGenerationDeleteManifestDirIfPresent)' == '' ">true</SbomGenerationDeleteManifestDirIfPresent>
   </PropertyGroup>
 
-  <Target Name="GenerateSbomTarget" AfterTargets="Build" Condition=" '$(GenerateSBOM)' ==  'true'">
+  <!-- After the Nuget Package is generated, we will unzip, scan, generate the SBOM and zip again. -->
+  <Target Name="GenerateSbomTarget" AfterTargets="Pack" Condition=" '$(GenerateSBOM)' ==  'true'" >
     <Error Condition="'$(BuildOutputTargetFolder)' == ''" Text="The GenerationSbomTarget requires the BuildOutputTargetFolder property to be non-null. Please set a folder name."/>
+
+    <!-- Unzip Nuget package, so it can be scanned by the SBOM Task. -->
+    <PropertyGroup>
+      <NugetPackage>
+        $(PackageOutputPath)\$(PackageId).$(PackageVersion).nupkg
+      </NugetPackage>
+      <NugetPackageUnzip>
+        $(PackageOutputPath)\$(PackageId).$(PackageVersion).nupkg.unzip
+      </NugetPackageUnzip>
+    </PropertyGroup>
+    <Unzip DestinationFolder="$(NugetPackageUnzip)" SourceFiles="$(NugetPackage)" OverwriteReadOnlyFiles="true" />
+
+    <!-- Call the SBOM Task to generate a SBOM. -->
     <GenerateSbom
-        BuildDropPath="$(SbomGenerationBuildDropPath)"
+        BuildDropPath="$(NugetPackageUnzip)"
         BuildComponentPath="$(SbomGenerationBuildComponentPath)"
         PackageSupplier="$(SbomGenerationPackageSupplier)"
         PackageName="$(SbomGenerationPackageName)"
@@ -70,20 +76,9 @@
       <Output TaskParameter="SbomPath" PropertyName="SbomPathResult" />
     </GenerateSbom>
     <Message Importance="High" Text="Task result: $(SbomPathResult)" />
-  </Target>
 
-  <!-- Specify the SBOM files to copy into the nuget package -->
-  <Target Name="CopySbomOutput" DependsOnTargets="GenerateSbomTarget">
-    <PropertyGroup>
-      <!--When building frameworks such as net8.0-windows, the platform version is appended to the framework in the NuGet package-->
-      <TargetFrameworkWithPlatformVersion Condition="$(TargetPlatformVersion) != ''">$(TargetFramework)$(TargetPlatformVersion)</TargetFrameworkWithPlatformVersion>
-      <TargetFrameworkWithPlatformVersion Condition="$(TargetPlatformVersion) == ''">$(TargetFramework)</TargetFrameworkWithPlatformVersion>
-    </PropertyGroup>
-    <ItemGroup>
-      <!--Add manifest and SHA file from the GenerateSbom target execution-->
-      <TfmSpecificPackageFile Include="$([System.IO.Path]::Combine($(SbomPathResult),$(SbomSpecification)))\**">
-        <PackagePath>$([System.IO.Path]::Combine($(BuildOutputTargetFolder),$(TargetFrameworkWithPlatformVersion),$(ManifestFolderName),$(SbomSpecification)))</PackagePath>
-      </TfmSpecificPackageFile>
-    </ItemGroup>
+    <!-- Zip the Nuget package back up and delete the temporary unzipped package. -->
+    <ZipDirectory SourceDirectory="$(NugetPackageUnzip)" DestinationFile="$(NugetPackage)" Overwrite="true" />
+    <RemoveDir Directories="$(NugetPackageUnzip)" />
   </Target>
 </Project>


### PR DESCRIPTION
# Issue
Ideally, we want a SBOM manifest that would include all the content of the Nuget Package, however it was concluded that the best way of doing this is by waiting for [the .NET Team to implement a pre-compress event that we can hook in](https://github.com/NuGet/Home/issues/13690). In the meantime, it was decided to at least generate smaller SBOMs that include the binaries that are produced during build. 

Unfortunately, we have encountered multiple issues, including dealing with file extensions that are not included by default in the Nuget Packages (such as .exe or .deps.json) but that were included in the SBOM manifest. This makes **the SBOM not able to be validated**.

# Workaround
Having said that, we propose a workaround for generating a SBOM at the root level, that is able to be validated, while we wait for the pre-compress hook. The proposal consists of unzipping the Nuget Package, generating the SBOM, and zipping again. 

## Performance
### .NET Standard project
In average, the workaround has a better performance than the original solution. I ran some performance tests using **a .NET Standard** project we use in production:
| | Generate SBOM per framework | Generate SBOM per package (with workaround) |
| -------- | ------- | -------- |
| Avg. Time | 2.95 | 2.85 |

However, in one of the performance tests, there was one outlier of 3.767 seconds for the workaround, probably due to a cold-start.

### Multi-framework project
I also ran some performance tests using a dummy multi-framework project:
| | Generate SBOM per framework | Generate SBOM per package (with workaround) |
| -------- | ------- | -------- |
| Avg. Time | 3.15 | 3.16 |

However, there were two cold-start runs that gave outlier results:
| | Generate SBOM per framework | Generate SBOM per package (with workaround) |
| -------- | ------- | -------- |
| Cold-Start Time | 4.98 | 4.22 |