### PR TITLE
Bump CD version to support performance improvement on pip report

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
         </PackageVersion>
     </ItemDefinitionGroup>
     <PropertyGroup>
-        <ComponentDetectionPackageVersion>4.8.9</ComponentDetectionPackageVersion>
+        <ComponentDetectionPackageVersion>4.9.3</ComponentDetectionPackageVersion>
     </PropertyGroup>
     <ItemGroup>
         <PackageVersion Include="AutoMapper" Version="10.1.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
         </PackageVersion>
     </ItemDefinitionGroup>
     <PropertyGroup>
-        <ComponentDetectionPackageVersion>4.2.2</ComponentDetectionPackageVersion>
+        <ComponentDetectionPackageVersion>4.8.9</ComponentDetectionPackageVersion>
     </PropertyGroup>
     <ItemGroup>
         <PackageVersion Include="AutoMapper" Version="10.1.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,8 +32,8 @@
         <PackageVersion Include="Mono.Posix.NETStandard" Version="1.0.0" Condition="'$(TargetFramework)' == 'net6.0'"/>
         <PackageVersion Include="Moq" Version="4.17.2" />
         <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageVersion Include="NuGet.Configuration" Version="6.9.1" />
-        <PackageVersion Include="NuGet.Frameworks" Version="6.9.1" />
+        <PackageVersion Include="NuGet.Configuration" Version="6.10.1" />
+        <PackageVersion Include="NuGet.Frameworks" Version="6.10.1" />
         <PackageVersion Include="packageurl-dotnet" Version="1.1.0" />
         <PackageVersion Include="PowerArgs" Version="3.6.0" />
         <PackageVersion Include="Scrutor" Version="4.2.0" />


### PR DESCRIPTION
Component Detection 4.9.3 added the environment variable `PipReportPersistReports` that enables storing the pip reports for tasks running CD more than once inside it.