### PR TITLE
Pack each project separately

### DIFF
--- a/pipelines/sbom-tool-main-build.yaml
+++ b/pipelines/sbom-tool-main-build.yaml
@@ -105,7 +105,6 @@ extends:
                 ]
             condition: and(succeeded(), startswith(variables['Build.SourceBranch'], 'refs/tags/'))
 
-          - powershell: 'dotnet pack Microsoft.Sbom.sln -c $(BuildConfiguration) --no-restore --no-build -o $(Build.ArtifactStagingDirectory)/nuget --include-symbols -p:SymbolPackageFormat=snupkg'
           - powershell: 'Get-ChildItem -Recurse -Filter *.csproj -Path src | ForEach-Object { dotnet pack $_.FullName  -c $(BuildConfiguration) --no-restore --no-build -o $(Build.ArtifactStagingDirectory)/nuget --include-symbols -p:SymbolPackageFormat=snupkg }'
             displayName: 'Pack NuGet package'
 

--- a/pipelines/sbom-tool-main-build.yaml
+++ b/pipelines/sbom-tool-main-build.yaml
@@ -106,6 +106,7 @@ extends:
             condition: and(succeeded(), startswith(variables['Build.SourceBranch'], 'refs/tags/'))
 
           - powershell: 'dotnet pack Microsoft.Sbom.sln -c $(BuildConfiguration) --no-restore --no-build -o $(Build.ArtifactStagingDirectory)/nuget --include-symbols -p:SymbolPackageFormat=snupkg'
+          - powershell: 'Get-ChildItem -Recurse -Filter *.csproj -Path src | ForEach-Object { dotnet pack $_.FullName  -c $(BuildConfiguration) --no-restore --no-build -o $(Build.ArtifactStagingDirectory)/nuget --include-symbols -p:SymbolPackageFormat=snupkg }'
             displayName: 'Pack NuGet package'
 
           - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@3


### PR DESCRIPTION
# Issue
feautre/sbom-targets-task's ADO pipeline is failing during the pack step. The errors is coming when trying to pack Microsoft.Sbom.Targets project, even though packing that project separately works.

# Findings
It is mentioned [here](https://learn.microsoft.com/en-us/visualstudio/msbuild/tutorial-custom-task-code-generation?view=vs-2022#generate-the-nuget-package) that for packing the task, we need to run `dotnet pack` from the folder of the task. However, I dont know if that's just an example of that's a limitation of the MSBuild tasks.

One alternative then, would be to pack each project separately.

# Change details
- Pack each project under the `src/` folder separately. The pipeline is now succeeding.