### PR TITLE
Use ComponentDetection 4.9.6

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
         </PackageVersion>
     </ItemDefinitionGroup>
     <PropertyGroup>
-        <ComponentDetectionPackageVersion>4.8.9</ComponentDetectionPackageVersion>
+        <ComponentDetectionPackageVersion>4.9.6</ComponentDetectionPackageVersion>
     </PropertyGroup>
     <ItemGroup>
         <PackageVersion Include="AutoMapper" Version="10.1.1" />


### PR DESCRIPTION
Update `Microsoft.ComponentDetection.*` packages from 4.8.9 to 4.9.6. This is centrally managed via `Directory.Packages.props`. We're picking up this version at the suggestion of the ComponentDetection team.