### PR TITLE
Update Sbom targets E2E tests to .net8

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,63 +1,65 @@
 <!-- All csproj package references should not include version numbers. The version numbers are set using this props file. -->
 <Project>
-    <ItemDefinitionGroup>
-        <PackageVersion>
-            <!-- Do not share compile-time dependencies transitively.  This requires that all projects reference all packages -->
-            <PrivateAssets>Compile</PrivateAssets>
-        </PackageVersion>
-    </ItemDefinitionGroup>
-    <PropertyGroup>
-        <ComponentDetectionPackageVersion>4.9.6</ComponentDetectionPackageVersion>
-    </PropertyGroup>
-    <ItemGroup>
-        <PackageVersion Include="AutoMapper" Version="10.1.1" />
-        <PackageVersion Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
-        <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-        <PackageVersion Include="FluentAssertions" Version="6.12.1" />
-        <PackageVersion Include="Microsoft.Build" Version="17.3.2" />
-        <PackageVersion Include="Microsoft.Build.Framework" Version="17.11.4" />
-        <PackageVersion Include="Microsoft.Build.Locator" Version="1.7.8" />
-        <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
-        <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
-        <PackageVersion Include="MSTest.TestAdapter" Version="3.6.0" />
-        <PackageVersion Include="MSTest.TestFramework" Version="3.6.0" />
-        <PackageVersion Include="Microsoft.ComponentDetection.Common" Version="$(ComponentDetectionPackageVersion)" />
-        <PackageVersion Include="Microsoft.ComponentDetection.Contracts" Version="$(ComponentDetectionPackageVersion)" />
-        <PackageVersion Include="Microsoft.ComponentDetection.Detectors" Version="$(ComponentDetectionPackageVersion)" />
-        <PackageVersion Include="Microsoft.ComponentDetection.Orchestrator" Version="$(ComponentDetectionPackageVersion)" />
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
-        <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-        <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
-        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-        <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.11.20" />
-        <PackageVersion Include="MinVer" Version="5.0.0" />
-        <PackageVersion Include="Moq" Version="4.20.72" />
-        <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageVersion Include="NuGet.Configuration" Version="6.11.0" />
-        <PackageVersion Include="NuGet.Frameworks" Version="6.11.0" />
-        <PackageVersion Include="packageurl-dotnet" Version="1.1.0" />
-        <PackageVersion Include="PowerArgs" Version="3.6.0" />
-        <PackageVersion Include="Scrutor" Version="4.2.2" />
-        <PackageVersion Include="Serilog.Extensions.Hosting" Version="7.0.0" />
-        <PackageVersion Include="Serilog.Sinks.Async" Version="2.0.0" />
-        <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
-        <PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />
-        <PackageVersion Include="Serilog.Sinks.Map" Version="2.0.0" />
-        <PackageVersion Include="Spectre.Console.Cli" Version="0.49.1" />
-        <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
-        <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
-        <PackageVersion Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
-        <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
-        <PackageVersion Include="System.Memory" Version="4.5.5" />
-        <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
-        <PackageVersion Include="System.Reactive" Version="5.0.0" />
-        <PackageVersion Include="System.Runtime.Loader" Version="4.3.0" />
-        <PackageVersion Include="System.Text.Json" Version="8.0.4" />
-        <PackageVersion Include="System.Threading.Channels" Version="6.0.0" />
-        <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="4.11.1" />
-        <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    </ItemGroup>
+  <ItemDefinitionGroup>
+    <PackageVersion>
+      <!-- Do not share compile-time dependencies transitively.  This requires that all projects reference all packages -->
+      <PrivateAssets>Compile</PrivateAssets>
+    </PackageVersion>
+  </ItemDefinitionGroup>
+  <PropertyGroup>
+    <ComponentDetectionPackageVersion>4.9.6</ComponentDetectionPackageVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="AutoMapper" Version="10.1.1" />
+    <PackageVersion Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.1" />
+    <PackageVersion Include="Microsoft.Build" Version="17.3.2" />
+    <PackageVersion Include="Microsoft.Build.Framework" Version="17.11.4" />
+    <PackageVersion Include="Microsoft.Build.Locator" Version="1.7.8" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
+    <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="8.0.1" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.6.0" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.6.0" />
+    <PackageVersion Include="Microsoft.ComponentDetection.Common" Version="$(ComponentDetectionPackageVersion)" />
+    <PackageVersion Include="Microsoft.ComponentDetection.Contracts" Version="$(ComponentDetectionPackageVersion)" />
+    <PackageVersion Include="Microsoft.ComponentDetection.Detectors" Version="$(ComponentDetectionPackageVersion)" />
+    <PackageVersion Include="Microsoft.ComponentDetection.Orchestrator" Version="$(ComponentDetectionPackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.11.20" />
+    <PackageVersion Include="MinVer" Version="5.0.0" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="NuGet.Configuration" Version="6.11.0" />
+    <PackageVersion Include="NuGet.Frameworks" Version="6.11.1" />
+    <PackageVersion Include="NuGet.ProjectModel" Version="6.11.1" />
+    <PackageVersion Include="packageurl-dotnet" Version="1.1.0" />
+    <PackageVersion Include="PowerArgs" Version="3.6.0" />
+    <PackageVersion Include="Scrutor" Version="4.2.2" />
+    <PackageVersion Include="Serilog.Extensions.Hosting" Version="7.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Async" Version="2.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Map" Version="2.0.0" />
+    <PackageVersion Include="Spectre.Console.Cli" Version="0.49.1" />
+    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
+    <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
+    <PackageVersion Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
+    <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
+    <PackageVersion Include="System.Memory" Version="4.5.5" />
+    <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
+    <PackageVersion Include="System.Reactive" Version="5.0.0" />
+    <PackageVersion Include="System.Runtime.Loader" Version="4.3.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
+    <PackageVersion Include="System.Threading.Channels" Version="6.0.0" />
+    <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="4.11.1" />
+    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+  </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,65 +1,65 @@
 <!-- All csproj package references should not include version numbers. The version numbers are set using this props file. -->
 <Project>
-  <ItemDefinitionGroup>
-    <PackageVersion>
-      <!-- Do not share compile-time dependencies transitively.  This requires that all projects reference all packages -->
-      <PrivateAssets>Compile</PrivateAssets>
-    </PackageVersion>
-  </ItemDefinitionGroup>
-  <PropertyGroup>
-    <ComponentDetectionPackageVersion>4.9.6</ComponentDetectionPackageVersion>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageVersion Include="AutoMapper" Version="10.1.1" />
-    <PackageVersion Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.1" />
-    <PackageVersion Include="Microsoft.Build" Version="17.3.2" />
-    <PackageVersion Include="Microsoft.Build.Framework" Version="17.11.4" />
-    <PackageVersion Include="Microsoft.Build.Locator" Version="1.7.8" />
-    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
-    <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="8.0.1" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="3.6.0" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.6.0" />
-    <PackageVersion Include="Microsoft.ComponentDetection.Common" Version="$(ComponentDetectionPackageVersion)" />
-    <PackageVersion Include="Microsoft.ComponentDetection.Contracts" Version="$(ComponentDetectionPackageVersion)" />
-    <PackageVersion Include="Microsoft.ComponentDetection.Detectors" Version="$(ComponentDetectionPackageVersion)" />
-    <PackageVersion Include="Microsoft.ComponentDetection.Orchestrator" Version="$(ComponentDetectionPackageVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.11.20" />
-    <PackageVersion Include="MinVer" Version="5.0.0" />
-    <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="NuGet.Configuration" Version="6.11.0" />
-    <PackageVersion Include="NuGet.Frameworks" Version="6.11.1" />
-    <PackageVersion Include="NuGet.ProjectModel" Version="6.11.1" />
-    <PackageVersion Include="packageurl-dotnet" Version="1.1.0" />
-    <PackageVersion Include="PowerArgs" Version="3.6.0" />
-    <PackageVersion Include="Scrutor" Version="4.2.2" />
-    <PackageVersion Include="Serilog.Extensions.Hosting" Version="7.0.0" />
-    <PackageVersion Include="Serilog.Sinks.Async" Version="2.0.0" />
-    <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
-    <PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />
-    <PackageVersion Include="Serilog.Sinks.Map" Version="2.0.0" />
-    <PackageVersion Include="Spectre.Console.Cli" Version="0.49.1" />
-    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
-    <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
-    <PackageVersion Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
-    <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
-    <PackageVersion Include="System.Memory" Version="4.5.5" />
-    <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
-    <PackageVersion Include="System.Reactive" Version="5.0.0" />
-    <PackageVersion Include="System.Runtime.Loader" Version="4.3.0" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
-    <PackageVersion Include="System.Threading.Channels" Version="6.0.0" />
-    <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="4.11.1" />
-    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-  </ItemGroup>
+    <ItemDefinitionGroup>
+        <PackageVersion>
+            <!-- Do not share compile-time dependencies transitively.  This requires that all projects reference all packages -->
+            <PrivateAssets>Compile</PrivateAssets>
+        </PackageVersion>
+    </ItemDefinitionGroup>
+    <PropertyGroup>
+        <ComponentDetectionPackageVersion>4.9.6</ComponentDetectionPackageVersion>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageVersion Include="AutoMapper" Version="10.1.1" />
+        <PackageVersion Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
+        <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+        <PackageVersion Include="FluentAssertions" Version="6.12.1" />
+        <PackageVersion Include="Microsoft.Build" Version="17.3.2" />
+        <PackageVersion Include="Microsoft.Build.Framework" Version="17.11.4" />
+        <PackageVersion Include="Microsoft.Build.Locator" Version="1.7.8" />
+        <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
+        <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
+        <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="8.0.1" />
+        <PackageVersion Include="MSTest.TestAdapter" Version="3.6.0" />
+        <PackageVersion Include="MSTest.TestFramework" Version="3.6.0" />
+        <PackageVersion Include="Microsoft.ComponentDetection.Common" Version="$(ComponentDetectionPackageVersion)" />
+        <PackageVersion Include="Microsoft.ComponentDetection.Contracts" Version="$(ComponentDetectionPackageVersion)" />
+        <PackageVersion Include="Microsoft.ComponentDetection.Detectors" Version="$(ComponentDetectionPackageVersion)" />
+        <PackageVersion Include="Microsoft.ComponentDetection.Orchestrator" Version="$(ComponentDetectionPackageVersion)" />
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+        <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+        <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.11.20" />
+        <PackageVersion Include="MinVer" Version="5.0.0" />
+        <PackageVersion Include="Moq" Version="4.20.72" />
+        <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageVersion Include="NuGet.Configuration" Version="6.11.0" />
+        <PackageVersion Include="NuGet.Frameworks" Version="6.11.1" />
+        <PackageVersion Include="NuGet.ProjectModel" Version="6.11.1" />
+        <PackageVersion Include="packageurl-dotnet" Version="1.1.0" />
+        <PackageVersion Include="PowerArgs" Version="3.6.0" />
+        <PackageVersion Include="Scrutor" Version="4.2.2" />
+        <PackageVersion Include="Serilog.Extensions.Hosting" Version="7.0.0" />
+        <PackageVersion Include="Serilog.Sinks.Async" Version="2.0.0" />
+        <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
+        <PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />
+        <PackageVersion Include="Serilog.Sinks.Map" Version="2.0.0" />
+        <PackageVersion Include="Spectre.Console.Cli" Version="0.49.1" />
+        <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
+        <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
+        <PackageVersion Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
+        <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
+        <PackageVersion Include="System.Memory" Version="4.5.5" />
+        <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
+        <PackageVersion Include="System.Reactive" Version="5.0.0" />
+        <PackageVersion Include="System.Runtime.Loader" Version="4.3.0" />
+        <PackageVersion Include="System.Text.Json" Version="8.0.4" />
+        <PackageVersion Include="System.Threading.Channels" Version="6.0.0" />
+        <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="4.11.1" />
+        <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+    </ItemGroup>
 </Project>

--- a/test/Microsoft.Sbom.Targets.E2E.Tests/GenerateSbomE2ETests.cs
+++ b/test/Microsoft.Sbom.Targets.E2E.Tests/GenerateSbomE2ETests.cs
@@ -148,7 +148,7 @@ public class GenerateSbomE2ETests
         }
     }
 
-    //[TestMethod]
+    [TestMethod]
     public void SbomGenerationSucceedsForDefaultProperties()
     {
         if (!IsWindows)
@@ -167,7 +167,7 @@ public class GenerateSbomE2ETests
         InspectPackageIsWellFormed();
     }
 
-    //[TestMethod]
+    [TestMethod]
     public void SbomGenerationSucceedsForValidNamespaceBaseUriUniquePart()
     {
         if (!IsWindows)
@@ -309,7 +309,7 @@ public class GenerateSbomE2ETests
         InspectPackageIsWellFormed(isManifestPathGenerated: false);
     }
 
-    //[TestMethod]
+    [TestMethod]
     public void SbomGenerationSucceedsForMultiTargetedProject()
     {
         if (!IsWindows)
@@ -323,7 +323,7 @@ public class GenerateSbomE2ETests
 
         // Set multi-target frameworks
         sampleProject.SetProperty("TargetFramework", string.Empty);
-        sampleProject.SetProperty("TargetFrameworks", "net472;net6.0");
+        sampleProject.SetProperty("TargetFrameworks", "net472;net8.0");
 
         // Restore, build, and pack the project
         RestoreBuildPack(sampleProject);

--- a/test/Microsoft.Sbom.Targets.E2E.Tests/GenerateSbomE2ETests.cs
+++ b/test/Microsoft.Sbom.Targets.E2E.Tests/GenerateSbomE2ETests.cs
@@ -19,10 +19,8 @@ public class GenerateSbomE2ETests
     /*
      * The following tests validate the end-to-end workflow for importing the Microsoft.Sbom.Targets.targets
      * into a .NET project, building it, packing it, and validating the generated SBOM contents.
-     *
-     * NOTE: These tests are only compatible with net472, as there are issues when resolving NuGet assemblies when
-     * targeting net8.0.
      */
+
     private static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
     private static string projectDirectory = Path.Combine(Directory.GetCurrentDirectory(), "ProjectSamples", "ProjectSample1");

--- a/test/Microsoft.Sbom.Targets.E2E.Tests/Microsoft.Sbom.Targets.E2E.Tests.csproj
+++ b/test/Microsoft.Sbom.Targets.E2E.Tests/Microsoft.Sbom.Targets.E2E.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <IsPackable>false</IsPackable>
     <SignAssembly>True</SignAssembly>
@@ -20,13 +20,16 @@
     <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Locator" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" />
+    <PackageReference Include="NuGet.Frameworks" />
+    <PackageReference Include="NuGet.ProjectModel" />
     <PackageReference Include="System.IO.Compression" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Condition="$(TargetFramework) == 'net6.0'" Include="..\..\src\Microsoft.Sbom.Targets\Microsoft.Sbom.Targets.csproj" AdditionalProperties="TargetFramework=net6.0" />
+    <ProjectReference Condition="$(TargetFramework) == 'net8.0'" Include="..\..\src\Microsoft.Sbom.Targets\Microsoft.Sbom.Targets.csproj" AdditionalProperties="TargetFramework=net8.0" />
     <ProjectReference Condition="$(TargetFramework) == 'net472'" Include="..\..\src\Microsoft.Sbom.Targets\Microsoft.Sbom.Targets.csproj" AdditionalProperties="TargetFramework=net472" />
-    <ProjectReference Condition="$(TargetFramework) == 'net6.0'" Include="..\..\src\Microsoft.Sbom.Tool\Microsoft.Sbom.Tool.csproj" />
+    <ProjectReference Condition="$(TargetFramework) == 'net8.0'" Include="..\..\src\Microsoft.Sbom.Tool\Microsoft.Sbom.Tool.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Sbom.Targets.E2E.Tests/ProjectSamples/ProjectSample1/ProjectSample1.csproj
+++ b/test/Microsoft.Sbom.Targets.E2E.Tests/ProjectSamples/ProjectSample1/ProjectSample1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <GenerateSBOM>true</GenerateSBOM>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Authors>ProjectSample</Authors>
     <Version>1.2.4</Version>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>


### PR DESCRIPTION
Added some NuGet packages that were required to make the E2E tests compatible with .NET8