### PR TITLE
Deprecate .NET 6 support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
     <PropertyGroup Label="Build">
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <LangVersion>latest</LangVersion>
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
         <RootNamespace>Microsoft.Sbom</RootNamespace>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,7 +34,6 @@
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
         <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.11.20" />
         <PackageVersion Include="MinVer" Version="5.0.0" />
-        <PackageVersion Include="Mono.Posix.NETStandard" Version="1.0.0" Condition="'$(TargetFramework)' == 'net6.0'"/>
         <PackageVersion Include="Moq" Version="4.20.72" />
         <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageVersion Include="NuGet.Configuration" Version="6.11.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,6 +19,7 @@
         <PackageVersion Include="Microsoft.Build.Locator" Version="1.7.8" />
         <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
         <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
+        <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="8.0.1" />
         <PackageVersion Include="MSTest.TestAdapter" Version="3.6.0" />
         <PackageVersion Include="MSTest.TestFramework" Version="3.6.0" />
         <PackageVersion Include="Microsoft.ComponentDetection.Common" Version="$(ComponentDetectionPackageVersion)" />
@@ -37,7 +38,8 @@
         <PackageVersion Include="Moq" Version="4.20.72" />
         <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageVersion Include="NuGet.Configuration" Version="6.11.0" />
-        <PackageVersion Include="NuGet.Frameworks" Version="6.11.0" />
+        <PackageVersion Include="NuGet.Frameworks" Version="6.11.1" />
+        <PackageVersion Include="NuGet.ProjectModel" Version="6.11.1" />
         <PackageVersion Include="packageurl-dotnet" Version="1.1.0" />
         <PackageVersion Include="PowerArgs" Version="3.6.0" />
         <PackageVersion Include="Scrutor" Version="4.2.2" />

--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -66,14 +66,8 @@ After running this command you can execute the tool like this:
 
 Because of our multi-targeting, a target framework must be specified when using the dotnet publish command:
 
-Either
-
 ```
 dotnet publish -f net8.0
-```
-Or
-```
-dotnet publish -f net6.0
 ```
 
 ## Building using Codespaces

--- a/docs/sbom-tool-api-reference.md
+++ b/docs/sbom-tool-api-reference.md
@@ -15,7 +15,7 @@ Add a reference to the [Microsoft.Sbom.Api](https://www.nuget.org/packages/Micro
 ```
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/pipelines/sbom-tool-main-build.yaml
+++ b/pipelines/sbom-tool-main-build.yaml
@@ -140,7 +140,7 @@ extends:
               command: publish
               publishWebProjects: false
               projects: src/Microsoft.Sbom.Tool/Microsoft.Sbom.Tool.csproj
-              arguments: '-c $(BuildConfiguration) --no-restore --output $(Build.ArtifactStagingDirectory)/win --self-contained --runtime $(WindowsNetRuntime) -p:PublishSingleFile=true -p:DebugType=None -f net6.0'
+              arguments: '-c $(BuildConfiguration) --no-restore --output $(Build.ArtifactStagingDirectory)/win --self-contained --runtime $(WindowsNetRuntime) -p:PublishSingleFile=true -p:DebugType=None -f net8.0'
               zipAfterPublish: false
               modifyOutputPath: false
 
@@ -234,7 +234,7 @@ extends:
               command: publish
               publishWebProjects: false
               projects: src/Microsoft.Sbom.Tool/Microsoft.Sbom.Tool.csproj
-              arguments: '-c $(BuildConfiguration) --no-restore --output $(Build.ArtifactStagingDirectory)/linux --self-contained --runtime $(LinuxNetRuntime) -p:PublishSingleFile=true -p:DebugType=None -f net6.0'
+              arguments: '-c $(BuildConfiguration) --no-restore --output $(Build.ArtifactStagingDirectory)/linux --self-contained --runtime $(LinuxNetRuntime) -p:PublishSingleFile=true -p:DebugType=None -f net8.0'
               zipAfterPublish: false
               modifyOutputPath: false
 
@@ -284,7 +284,7 @@ extends:
               command: publish
               publishWebProjects: false
               projects: src/Microsoft.Sbom.Tool/Microsoft.Sbom.Tool.csproj
-              arguments: '-c $(BuildConfiguration) --no-restore --output $(Build.ArtifactStagingDirectory)/osx --self-contained --runtime $(MacOSNetRuntime) -p:PublishSingleFile=true -p:DebugType=None -f net6.0'
+              arguments: '-c $(BuildConfiguration) --no-restore --output $(Build.ArtifactStagingDirectory)/osx --self-contained --runtime $(MacOSNetRuntime) -p:PublishSingleFile=true -p:DebugType=None -f net8.0'
               zipAfterPublish: false
               modifyOutputPath: false
 

--- a/src/Microsoft.Sbom.Common/Microsoft.Sbom.Common.csproj
+++ b/src/Microsoft.Sbom.Common/Microsoft.Sbom.Common.csproj
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Posix.NETStandard" Condition="'$(TargetFramework)' == 'net6.0'" />
     <PackageReference Include="Serilog.Sinks.Console" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" />
     <PackageReference Include="System.Private.Uri" />

--- a/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.csproj
+++ b/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>Microsoft.Sbom.Targets</AssemblyName>
-    <TargetFrameworks>net6.0;net8.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
     <IsPublishable>true</IsPublishable>
     <IsPackable>true</IsPackable>
@@ -69,9 +69,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Condition="'$(TargetFramework)'=='net8.0' or '$(TargetFramework)'=='net6.0'" Include="..\Microsoft.Sbom.Contracts\Microsoft.Sbom.Contracts.csproj" />
-    <ProjectReference Condition="'$(TargetFramework)'=='net8.0' or '$(TargetFramework)'=='net6.0'" Include="..\Microsoft.Sbom.Extensions.DependencyInjection\Microsoft.Sbom.Extensions.DependencyInjection.csproj" PrivateAssets="all" />
-    <ProjectReference Condition="'$(TargetFramework)'=='net8.0' or '$(TargetFramework)'=='net6.0'" Include="..\Microsoft.Sbom.Tool\Microsoft.Sbom.Tool.csproj" PrivateAssets="all" IncludeAssets="output" />
+    <ProjectReference Condition="'$(TargetFramework)'=='net8.0'" Include="..\Microsoft.Sbom.Contracts\Microsoft.Sbom.Contracts.csproj" />
+    <ProjectReference Condition="'$(TargetFramework)'=='net8.0'" Include="..\Microsoft.Sbom.Extensions.DependencyInjection\Microsoft.Sbom.Extensions.DependencyInjection.csproj" PrivateAssets="all" />
+    <ProjectReference Condition="'$(TargetFramework)'=='net8.0'" Include="..\Microsoft.Sbom.Tool\Microsoft.Sbom.Tool.csproj" PrivateAssets="all" IncludeAssets="output" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/test/Microsoft.Sbom.Targets.E2E.Tests/GenerateSbomE2ETests.cs
+++ b/test/Microsoft.Sbom.Targets.E2E.Tests/GenerateSbomE2ETests.cs
@@ -19,10 +19,8 @@ public class GenerateSbomE2ETests
     /*
      * The following tests validate the end-to-end workflow for importing the Microsoft.Sbom.Targets.targets
      * into a .NET project, building it, packing it, and validating the generated SBOM contents.
-     *
-     * NOTE: These tests are only compatible with net472, as there are issues when resolving NuGet assemblies when
-     * targeting net8.0.
      */
+
     private static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
     private static string projectDirectory = Path.Combine(Directory.GetCurrentDirectory(), "ProjectSamples", "ProjectSample1");
@@ -148,7 +146,7 @@ public class GenerateSbomE2ETests
         }
     }
 
-    //[TestMethod]
+    [TestMethod]
     public void SbomGenerationSucceedsForDefaultProperties()
     {
         if (!IsWindows)
@@ -167,7 +165,7 @@ public class GenerateSbomE2ETests
         InspectPackageIsWellFormed();
     }
 
-    //[TestMethod]
+    [TestMethod]
     public void SbomGenerationSucceedsForValidNamespaceBaseUriUniquePart()
     {
         if (!IsWindows)
@@ -309,7 +307,7 @@ public class GenerateSbomE2ETests
         InspectPackageIsWellFormed(isManifestPathGenerated: false);
     }
 
-    //[TestMethod]
+    [TestMethod]
     public void SbomGenerationSucceedsForMultiTargetedProject()
     {
         if (!IsWindows)
@@ -323,7 +321,7 @@ public class GenerateSbomE2ETests
 
         // Set multi-target frameworks
         sampleProject.SetProperty("TargetFramework", string.Empty);
-        sampleProject.SetProperty("TargetFrameworks", "net472;net6.0");
+        sampleProject.SetProperty("TargetFrameworks", "net472;net8.0");
 
         // Restore, build, and pack the project
         RestoreBuildPack(sampleProject);

--- a/test/Microsoft.Sbom.Targets.E2E.Tests/GenerateSbomE2ETests.cs
+++ b/test/Microsoft.Sbom.Targets.E2E.Tests/GenerateSbomE2ETests.cs
@@ -20,7 +20,7 @@ public class GenerateSbomE2ETests
      * The following tests validate the end-to-end workflow for importing the Microsoft.Sbom.Targets.targets
      * into a .NET project, building it, packing it, and validating the generated SBOM contents.
      *
-     * NOTE: These tests are only compatible with net6.0 and net472, as there are issues when resolving NuGet assemblies when
+     * NOTE: These tests are only compatible with net472, as there are issues when resolving NuGet assemblies when
      * targeting net8.0.
      */
     private static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
@@ -148,7 +148,7 @@ public class GenerateSbomE2ETests
         }
     }
 
-    [TestMethod]
+    //[TestMethod]
     public void SbomGenerationSucceedsForDefaultProperties()
     {
         if (!IsWindows)
@@ -167,7 +167,7 @@ public class GenerateSbomE2ETests
         InspectPackageIsWellFormed();
     }
 
-    [TestMethod]
+    //[TestMethod]
     public void SbomGenerationSucceedsForValidNamespaceBaseUriUniquePart()
     {
         if (!IsWindows)
@@ -309,7 +309,7 @@ public class GenerateSbomE2ETests
         InspectPackageIsWellFormed(isManifestPathGenerated: false);
     }
 
-    [TestMethod]
+    //[TestMethod]
     public void SbomGenerationSucceedsForMultiTargetedProject()
     {
         if (!IsWindows)

--- a/test/Microsoft.Sbom.Targets.E2E.Tests/Microsoft.Sbom.Targets.E2E.Tests.csproj
+++ b/test/Microsoft.Sbom.Targets.E2E.Tests/Microsoft.Sbom.Targets.E2E.Tests.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <IsPackable>false</IsPackable>
     <SignAssembly>True</SignAssembly>
     <RootNamespace>Microsoft.Sbom.Targets.E2E.Tests</RootNamespace>
-    <SbomCLIToolTargetFramework>net6.0</SbomCLIToolTargetFramework>
+    <SbomCLIToolTargetFramework>net8.0</SbomCLIToolTargetFramework>
     <SBOMCLIToolProjectDir>$(MSBuildThisFileDirectory)..\..\src\Microsoft.Sbom.Tool\</SBOMCLIToolProjectDir>
     <SBOMGenerationTargetsPath>$(MSBuildThisFileDirectory)..\..\src\Microsoft.Sbom.Targets\Microsoft.Sbom.Targets.targets</SBOMGenerationTargetsPath>
   </PropertyGroup>

--- a/test/Microsoft.Sbom.Targets.E2E.Tests/Microsoft.Sbom.Targets.E2E.Tests.csproj
+++ b/test/Microsoft.Sbom.Targets.E2E.Tests/Microsoft.Sbom.Targets.E2E.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <IsPackable>false</IsPackable>
     <SignAssembly>True</SignAssembly>
@@ -20,13 +20,16 @@
     <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="Runtime" />
     <PackageReference Include="Microsoft.Build.Locator" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="Runtime" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" />
+    <PackageReference Include="NuGet.Frameworks" />
+    <PackageReference Include="NuGet.ProjectModel" />
     <PackageReference Include="System.IO.Compression" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Condition="$(TargetFramework) == 'net6.0'" Include="..\..\src\Microsoft.Sbom.Targets\Microsoft.Sbom.Targets.csproj" AdditionalProperties="TargetFramework=net6.0" />
+    <ProjectReference Condition="$(TargetFramework) == 'net8.0'" Include="..\..\src\Microsoft.Sbom.Targets\Microsoft.Sbom.Targets.csproj" AdditionalProperties="TargetFramework=net8.0" />
     <ProjectReference Condition="$(TargetFramework) == 'net472'" Include="..\..\src\Microsoft.Sbom.Targets\Microsoft.Sbom.Targets.csproj" AdditionalProperties="TargetFramework=net472" />
-    <ProjectReference Condition="$(TargetFramework) == 'net6.0'" Include="..\..\src\Microsoft.Sbom.Tool\Microsoft.Sbom.Tool.csproj" />
+    <ProjectReference Condition="$(TargetFramework) == 'net8.0'" Include="..\..\src\Microsoft.Sbom.Tool\Microsoft.Sbom.Tool.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Sbom.Targets.E2E.Tests/ProjectSamples/ProjectSample1/ProjectSample1.csproj
+++ b/test/Microsoft.Sbom.Targets.E2E.Tests/ProjectSamples/ProjectSample1/ProjectSample1.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <GenerateSBOM>true</GenerateSBOM>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Authors>ProjectSample</Authors>
     <Version>1.2.4</Version>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>


### PR DESCRIPTION
.NET 6 will reach its end of support date on 12 November 2024, so we need to discontinue support for it. https://github.com/microsoft/component-detection has already dropped .NET 6 support, so this is a prerequisite to adopting the newer version of that library.

Special thanks to @vpatakottu who provided the changes necessary for the Microsoft.Sbom.Targets.E2E.Tests project.

We may want to bump the major version when we release this since removing .NET 6 support is a breaking change.