### PR TITLE
Address CVE-2024-43485 by updating System.Text.Json

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -57,7 +57,7 @@
         <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
         <PackageVersion Include="System.Reactive" Version="5.0.0" />
         <PackageVersion Include="System.Runtime.Loader" Version="4.3.0" />
-        <PackageVersion Include="System.Text.Json" Version="8.0.4" />
+        <PackageVersion Include="System.Text.Json" Version="8.0.5" />
         <PackageVersion Include="System.Threading.Channels" Version="6.0.0" />
         <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="4.11.1" />
         <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />


### PR DESCRIPTION
CVE-2024-43485 is showing up as a CG alert and is blocking PR builds from succeeding. This bumps `System.Text.Json` from 8.0.4 to 8.0.5, as called out at https://github.com/dotnet/announcements/issues/329 and https://github.com/advisories/GHSA-8g4q-xg66-9fp4