### PR TITLE
Use tool-driven indents for *.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,44 +1,44 @@
 <Project>
 
-    <PropertyGroup Label="Build">
-        <TargetFrameworks>net8.0</TargetFrameworks>
-        <LangVersion>latest</LangVersion>
-        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-        <RootNamespace>Microsoft.Sbom</RootNamespace>
-        <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-        <AnalysisLevel>latest</AnalysisLevel>
-        <AnalysisMode>AllEnabledByDefault</AnalysisMode>
-        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <NoWarn>$(NoWarn);CA1014;CS8002;CA1416</NoWarn>
-        <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
-    </PropertyGroup>
+  <PropertyGroup Label="Build">
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <RootNamespace>Microsoft.Sbom</RootNamespace>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>$(NoWarn);CA1014;CS8002;CA1416</NoWarn>
+    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
+  </PropertyGroup>
 
-    <PropertyGroup Label="Package">
-        <Authors>Microsoft</Authors>
-        <Company>Microsoft</Company>
-        <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-        <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <PackageProjectUrl>https://github.com/microsoft/sbom-tool</PackageProjectUrl>
-        <RepositoryUrl>https://github.com/microsoft/sbom-tool.git</RepositoryUrl>
-        <RepositoryType>git</RepositoryType>
-        <PackageReleaseNotes>https://github.com/microsoft/sbom-tool/releases</PackageReleaseNotes>
-    </PropertyGroup>
+  <PropertyGroup Label="Package">
+    <Authors>Microsoft</Authors>
+    <Company>Microsoft</Company>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/microsoft/sbom-tool</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/microsoft/sbom-tool.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageReleaseNotes>https://github.com/microsoft/sbom-tool/releases</PackageReleaseNotes>
+  </PropertyGroup>
 
-    <ItemGroup Label="Package References">
-        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="all"/>
-        <PackageReference Include="MinVer" PrivateAssets="all"/>
-        <PackageReference Include="StyleCop.Analyzers" PrivateAssets="all"/>
-    </ItemGroup>
+  <ItemGroup Label="Package References">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="all"/>
+    <PackageReference Include="MinVer" PrivateAssets="all"/>
+    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="all"/>
+  </ItemGroup>
 
   <PropertyGroup Label="SourceLink Configuration">
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 
-    <PropertyGroup Label="Strong Name Signing Variables">
-        <StrongNameSigningKeyFilePath>$(MSBuildThisFileDirectory)snsKey.snk</StrongNameSigningKeyFilePath>
-        <StrongNameSigningPublicKey>0024000004800000940000000602000000240000525341310004000001000100c1f8987b4994a7ec30c5ba8253a8a6322b40642ef9d5dbc96828bda61a5a8bf1fa1667ee6fdda72fc29b00686a2e8d37984c37ef90b2d51a5c8767c5e6fb35ff9d4516a77929626db1d06297f90c2950e87e1fcd335bd82d73e1c37d1da42afb1e41397be50aac74895b873a8bad90c2caee9d7c9e34b94ff255cb040630ad94</StrongNameSigningPublicKey>
-    </PropertyGroup>
+  <PropertyGroup Label="Strong Name Signing Variables">
+    <StrongNameSigningKeyFilePath>$(MSBuildThisFileDirectory)snsKey.snk</StrongNameSigningKeyFilePath>
+    <StrongNameSigningPublicKey>0024000004800000940000000602000000240000525341310004000001000100c1f8987b4994a7ec30c5ba8253a8a6322b40642ef9d5dbc96828bda61a5a8bf1fa1667ee6fdda72fc29b00686a2e8d37984c37ef90b2d51a5c8767c5e6fb35ff9d4516a77929626db1d06297f90c2950e87e1fcd335bd82d73e1c37d1da42afb1e41397be50aac74895b873a8bad90c2caee9d7c9e34b94ff255cb040630ad94</StrongNameSigningPublicKey>
+  </PropertyGroup>
 
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,10 +1,10 @@
 <Project>
 
-    <Target Name="Versioning" BeforeTargets="MinVer">
-        <PropertyGroup Label="Build">
-            <MinVerDefaultPreReleaseIdentifiers>preview.0</MinVerDefaultPreReleaseIdentifiers>
-            <MinVerTagPrefix>v</MinVerTagPrefix>
-        </PropertyGroup>
-    </Target>
+  <Target Name="Versioning" BeforeTargets="MinVer">
+    <PropertyGroup Label="Build">
+      <MinVerDefaultPreReleaseIdentifiers>preview.0</MinVerDefaultPreReleaseIdentifiers>
+      <MinVerTagPrefix>v</MinVerTagPrefix>
+    </PropertyGroup>
+  </Target>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,65 +1,65 @@
 <!-- All csproj package references should not include version numbers. The version numbers are set using this props file. -->
 <Project>
-    <ItemDefinitionGroup>
-        <PackageVersion>
-            <!-- Do not share compile-time dependencies transitively.  This requires that all projects reference all packages -->
-            <PrivateAssets>Compile</PrivateAssets>
-        </PackageVersion>
-    </ItemDefinitionGroup>
-    <PropertyGroup>
-        <ComponentDetectionPackageVersion>4.9.6</ComponentDetectionPackageVersion>
-    </PropertyGroup>
-    <ItemGroup>
-        <PackageVersion Include="AutoMapper" Version="10.1.1" />
-        <PackageVersion Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
-        <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-        <PackageVersion Include="FluentAssertions" Version="6.12.1" />
-        <PackageVersion Include="Microsoft.Build" Version="17.3.2" />
-        <PackageVersion Include="Microsoft.Build.Framework" Version="17.11.4" />
-        <PackageVersion Include="Microsoft.Build.Locator" Version="1.7.8" />
-        <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
-        <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
-        <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="8.0.2" />
-        <PackageVersion Include="MSTest.TestAdapter" Version="3.6.0" />
-        <PackageVersion Include="MSTest.TestFramework" Version="3.6.0" />
-        <PackageVersion Include="Microsoft.ComponentDetection.Common" Version="$(ComponentDetectionPackageVersion)" />
-        <PackageVersion Include="Microsoft.ComponentDetection.Contracts" Version="$(ComponentDetectionPackageVersion)" />
-        <PackageVersion Include="Microsoft.ComponentDetection.Detectors" Version="$(ComponentDetectionPackageVersion)" />
-        <PackageVersion Include="Microsoft.ComponentDetection.Orchestrator" Version="$(ComponentDetectionPackageVersion)" />
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
-        <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-        <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
-        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-        <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-        <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.11.20" />
-        <PackageVersion Include="MinVer" Version="6.0.0" />
-        <PackageVersion Include="Moq" Version="4.20.72" />
-        <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageVersion Include="NuGet.Configuration" Version="6.11.0" />
-        <PackageVersion Include="NuGet.Frameworks" Version="6.11.1" />
-        <PackageVersion Include="NuGet.ProjectModel" Version="6.11.1" />
-        <PackageVersion Include="packageurl-dotnet" Version="1.1.0" />
-        <PackageVersion Include="PowerArgs" Version="3.6.0" />
-        <PackageVersion Include="Scrutor" Version="5.0.0" />
-        <PackageVersion Include="Serilog.Extensions.Hosting" Version="7.0.0" />
-        <PackageVersion Include="Serilog.Sinks.Async" Version="2.0.0" />
-        <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
-        <PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />
-        <PackageVersion Include="Serilog.Sinks.Map" Version="2.0.0" />
-        <PackageVersion Include="Spectre.Console.Cli" Version="0.49.1" />
-        <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
-        <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
-        <PackageVersion Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
-        <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
-        <PackageVersion Include="System.Memory" Version="4.5.5" />
-        <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
-        <PackageVersion Include="System.Reactive" Version="5.0.0" />
-        <PackageVersion Include="System.Runtime.Loader" Version="4.3.0" />
-        <PackageVersion Include="System.Text.Json" Version="8.0.5" />
-        <PackageVersion Include="System.Threading.Channels" Version="6.0.0" />
-        <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="4.11.1" />
-        <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    </ItemGroup>
+  <ItemDefinitionGroup>
+    <PackageVersion>
+      <!-- Do not share compile-time dependencies transitively.  This requires that all projects reference all packages -->
+      <PrivateAssets>Compile</PrivateAssets>
+    </PackageVersion>
+  </ItemDefinitionGroup>
+  <PropertyGroup>
+    <ComponentDetectionPackageVersion>4.9.6</ComponentDetectionPackageVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="AutoMapper" Version="10.1.1" />
+    <PackageVersion Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.1" />
+    <PackageVersion Include="Microsoft.Build" Version="17.3.2" />
+    <PackageVersion Include="Microsoft.Build.Framework" Version="17.11.4" />
+    <PackageVersion Include="Microsoft.Build.Locator" Version="1.7.8" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
+    <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="8.0.2" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.6.0" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.6.0" />
+    <PackageVersion Include="Microsoft.ComponentDetection.Common" Version="$(ComponentDetectionPackageVersion)" />
+    <PackageVersion Include="Microsoft.ComponentDetection.Contracts" Version="$(ComponentDetectionPackageVersion)" />
+    <PackageVersion Include="Microsoft.ComponentDetection.Detectors" Version="$(ComponentDetectionPackageVersion)" />
+    <PackageVersion Include="Microsoft.ComponentDetection.Orchestrator" Version="$(ComponentDetectionPackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.11.20" />
+    <PackageVersion Include="MinVer" Version="6.0.0" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="NuGet.Configuration" Version="6.11.0" />
+    <PackageVersion Include="NuGet.Frameworks" Version="6.11.1" />
+    <PackageVersion Include="NuGet.ProjectModel" Version="6.11.1" />
+    <PackageVersion Include="packageurl-dotnet" Version="1.1.0" />
+    <PackageVersion Include="PowerArgs" Version="3.6.0" />
+    <PackageVersion Include="Scrutor" Version="5.0.0" />
+    <PackageVersion Include="Serilog.Extensions.Hosting" Version="7.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Async" Version="2.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Map" Version="2.0.0" />
+    <PackageVersion Include="Spectre.Console.Cli" Version="0.49.1" />
+    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
+    <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
+    <PackageVersion Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
+    <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
+    <PackageVersion Include="System.Memory" Version="4.5.5" />
+    <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
+    <PackageVersion Include="System.Reactive" Version="5.0.0" />
+    <PackageVersion Include="System.Runtime.Loader" Version="4.3.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+    <PackageVersion Include="System.Threading.Channels" Version="6.0.0" />
+    <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="4.11.1" />
+    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
_These changes are whitespace only_

We've had a couple of recent changes where Visual Studio had to touch a .props file and the indents in the file were impacted. We've manually kept the tabs consistent with the previous versions, but it's never a great plan to try to fight your development tools.

Looking at https://github.com/microsoft/sbom-tool/blob/main/.editorconfig#L34-L36, `.props` files are supposed to use 2 spaces for tab indents:
```
# XML Configuration Files
[*.{xml,config,props,targets,nuspec,resx,ruleset,vsixmanifest,vsct}]
indent_size = 2
```

Based on this config, Visual Studio is doing exactly what it should; the previous indents didn't match the `.editorconfig` file, so the style was updated when the file was saved. These edits were created by opening the files in Visual Studio and using the Format Document option, which enforces the styles from `.editorconfig`.

I also checked all other files in the repo that match the aforementioned file filter and they already match the config--it's just these 3 files are are out of sync.