### PR TITLE
Add dependency graph support to remaining ecosystems

### DIFF
--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/CargoComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/CargoComponentExtensions.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.Sbom.Adapters.ComponentDetection;
 
+using System.Linq;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.Sbom.Contracts;
 
@@ -29,5 +30,6 @@ internal static class CargoComponentExtensions
         },
         FilesAnalyzed = false,
         Type = "cargo",
+        DependOn = component.AncestralReferrers?.FirstOrDefault()?.Id,
     };
 }

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/NpmComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/NpmComponentExtensions.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.Sbom.Adapters.ComponentDetection;
 
 using System;
+using System.Linq;
 using Microsoft.ComponentDetection.Contracts.Internal;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.Sbom.Contracts;
@@ -39,6 +40,7 @@ internal static class NpmComponentExtensions
         },
         FilesAnalyzed = false,
         Type = "npm",
+        DependOn = component.AncestralReferrers?.FirstOrDefault()?.Id,
     };
 
     /// <summary>

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/PipComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/PipComponentExtensions.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.Sbom.Adapters.ComponentDetection;
 
+using System.Linq;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.Sbom.Contracts;
 
@@ -29,5 +30,6 @@ internal static class PipComponentExtensions
         },
         FilesAnalyzed = false,
         Type = "python",
+        DependOn = component.AncestralReferrers?.FirstOrDefault()?.Id,
     };
 }

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/PodComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/PodComponentExtensions.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.Sbom.Adapters.ComponentDetection;
 
+using System.Linq;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.Sbom.Contracts;
 
@@ -30,5 +31,6 @@ internal static class PodComponentExtensions
         },
         FilesAnalyzed = false,
         Type = "pod",
+        DependOn = component.AncestralReferrers?.FirstOrDefault()?.Id,
     };
 }

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/RubyGemsComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/RubyGemsComponentExtensions.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.Sbom.Adapters.ComponentDetection;
 
+using System.Linq;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.Sbom.Contracts;
 
@@ -32,5 +33,6 @@ internal static class RubyGemsComponentExtensions
         },
         FilesAnalyzed = false,
         Type = "ruby",
+        DependOn = component.AncestralReferrers?.FirstOrDefault()?.Id,
     };
 }


### PR DESCRIPTION
This PR builds off of #746 to add support for ancestral dependencies of the remaining ecosystems supported by CD. The list of ecosystems supporting graph creation [can be found here](https://github.com/microsoft/component-detection?tab=readme-ov-file#features).