### PR TITLE
Update to .NET 8 versions of Component Detection

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     </PackageVersion>
   </ItemDefinitionGroup>
   <PropertyGroup>
-    <ComponentDetectionPackageVersion>4.9.6</ComponentDetectionPackageVersion>
+    <ComponentDetectionPackageVersion>5.1.5</ComponentDetectionPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AutoMapper" Version="10.1.1" />


### PR DESCRIPTION
Pick up the most recent release of https://github.com/microsoft/component-detection. This includes deprecation of .NET 6 support, performance fixes, and being smarter about reaching out to untrusted network sources.