### PR TITLE
Add support for osx-arm64

### DIFF
--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -49,26 +49,18 @@ dotnet run --project src/Microsoft.Sbom.Tool generate -b <drop path> -bc <build 
 
 ## Building on ARM based devices running OSX
 
-The sbom-tool targets both .NET 6 and .NET 8 therefore it is possible to produce binaries for both. We have seen issues when attempting to run the tool using the .NET 6 binaries ([#223](https://github.com/microsoft/sbom-tool/issues/223)) so for these scenarios we recommend targeting .NET 8. You can do this by following these steps:
+The tool provides an osx-arm64 version of the tool. If you need to build one locally, you can build it as follows:
 
 The following command will produce a dll that can be executed on ARM based devices running OSX and can be modified to suit your needs:
 
 ```
- dotnet publish src/Microsoft.Sbom.Tool/Microsoft.Sbom.Tool.csproj --configuration Release --output bin --runtime osx-arm64 -p:TargetFramework=net8.0 -p:SelfContained=true -p:OFFICIAL_BUILD=true -p:MinVerVersionOverride=1.8.0 -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:IncludeAllContentForSelfExtract=true -p:DebugType=None -p:DebugSymbols=false
+ dotnet publish src/Microsoft.Sbom.Tool/Microsoft.Sbom.Tool.csproj --configuration Release --output bin --runtime osx-arm64 -p:TargetFramework=net8.0 -p:SelfContained=true -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true -p:IncludeAllContentForSelfExtract=true -p:DebugType=None
 ```
 
 After running this command you can execute the tool like this:
 
 ```
 ./bin/Microsoft.Sbom.Tool generate -b ~/tmp/sbom-tool/ -bc ~/tmp/sbom-tool/ -pn TestProject -pv 1.2.3 -ps Microsoft
-```
-
-## Using Dotnet Publish
-
-Because of our multi-targeting, a target framework must be specified when using the dotnet publish command:
-
-```
-dotnet publish -f net8.0
 ```
 
 ## Building using Codespaces

--- a/pipelines/sbom-tool-main-build.yaml
+++ b/pipelines/sbom-tool-main-build.yaml
@@ -21,9 +21,11 @@ variables:
   ForceSigning: 'false'
   WindowsNetRuntime: 'win-x64'
   MacOSNetRuntime: 'osx-x64'
+  MacOSArm64NetRuntime: 'osx-arm64'
   LinuxNetRuntime: 'linux-x64'
   BinaryNameWindows: 'sbom-tool-win-x64.exe'
   BinaryNameMacOS: 'sbom-tool-osx-x64'
+  BinaryNameMacOSArm64: 'sbom-tool-osx-arm64'
   BinaryNameLinux: 'sbom-tool-linux-x64'
 
 extends:
@@ -295,5 +297,55 @@ extends:
               del $(Build.ArtifactStagingDirectory)/CodeSignSummary-*.md
               mkdir $(Build.ArtifactStagingDirectory)/bin
               Move-Item -Path $(Build.ArtifactStagingDirectory)/osx/$(BinaryNameMacOS) -Destination $(Build.ArtifactStagingDirectory)/bin/$(BinaryNameMacOS)
+              Remove-Item $(Build.ArtifactStagingDirectory)/osx -Recurse
+            displayName: 'Restructure Artifact'
+
+        - job: Job_4
+          displayName: 'Build (macOS-arm64)'
+          templateContext:
+            outputs:
+            - output: pipelineArtifact
+              targetPath: $(Build.ArtifactStagingDirectory)
+              artifactName: '$(OutputArtifactName)-macOS-arm64'
+          pool:
+            name: Azure Pipelines
+            image: macos-latest
+            os: macOS
+          steps:
+          - task: UseDotNet@2
+            displayName: 'Use .NET Core'
+            inputs:
+              useGlobalJson: true
+
+          - task: DotNetCoreCLI@2
+            displayName: 'Restore solution'
+            inputs:
+              command: restore
+              feedsToUse: config
+              nugetConfigPath: nuget.config
+              verbosityRestore: Normal
+
+          - task: DotNetCoreCLI@2
+            displayName: Build
+            inputs:
+              arguments: '-c $(BuildConfiguration)'
+
+          - task: DotNetCoreCLI@2
+            displayName: 'Build self-contained binary'
+            inputs:
+              command: publish
+              publishWebProjects: false
+              projects: src/Microsoft.Sbom.Tool/Microsoft.Sbom.Tool.csproj
+              arguments: '-c $(BuildConfiguration) --no-restore --output $(Build.ArtifactStagingDirectory)/osx --self-contained --runtime $(MacOSArm64NetRuntime) -p:PublishSingleFile=true -p:DebugType=None -f net8.0'
+              zipAfterPublish: false
+              modifyOutputPath: false
+
+          - powershell: 'Rename-Item -Path $(Build.ArtifactStagingDirectory)\osx\Microsoft.Sbom.Tool -NewName $(BinaryNameMacOSArm64)'
+            displayName: 'Rename binaries'
+
+          - powershell: |
+              del $(Build.ArtifactStagingDirectory)/CodeSignSummary-*.md
+              mkdir $(Build.ArtifactStagingDirectory)/bin
+              Move-Item -Path $(Build.ArtifactStagingDirectory)/osx/$(BinaryNameMacOSArm64) -Destination $(Build.ArtifactStagingDirectory)/bin/$(BinaryNameMacOSArm64)
               Remove-Item $(Build.ArtifactStagingDirectory)/osx -Recurse
             displayName: 'Restructure Artifact'

--- a/pipelines/sbom-tool-main-build.yaml
+++ b/pipelines/sbom-tool-main-build.yaml
@@ -336,16 +336,16 @@ extends:
               command: publish
               publishWebProjects: false
               projects: src/Microsoft.Sbom.Tool/Microsoft.Sbom.Tool.csproj
-              arguments: '-c $(BuildConfiguration) --no-restore --output $(Build.ArtifactStagingDirectory)/osx --self-contained --runtime $(MacOSArm64NetRuntime) -p:PublishSingleFile=true -p:DebugType=None -f net8.0'
+              arguments: '-c $(BuildConfiguration) --no-restore --output $(Build.ArtifactStagingDirectory)/osx-arm64 --self-contained --runtime $(MacOSArm64NetRuntime) -p:PublishSingleFile=true -p:DebugType=None -f net8.0'
               zipAfterPublish: false
               modifyOutputPath: false
 
-          - powershell: 'Rename-Item -Path $(Build.ArtifactStagingDirectory)\osx\Microsoft.Sbom.Tool -NewName $(BinaryNameMacOSArm64)'
+          - powershell: 'Rename-Item -Path $(Build.ArtifactStagingDirectory)\osx-arm64\Microsoft.Sbom.Tool -NewName $(BinaryNameMacOSArm64)'
             displayName: 'Rename binaries'
 
           - powershell: |
               del $(Build.ArtifactStagingDirectory)/CodeSignSummary-*.md
               mkdir $(Build.ArtifactStagingDirectory)/bin
-              Move-Item -Path $(Build.ArtifactStagingDirectory)/osx/$(BinaryNameMacOSArm64) -Destination $(Build.ArtifactStagingDirectory)/bin/$(BinaryNameMacOSArm64)
-              Remove-Item $(Build.ArtifactStagingDirectory)/osx -Recurse
+              Move-Item -Path $(Build.ArtifactStagingDirectory)/osx-arm64/$(BinaryNameMacOSArm64) -Destination $(Build.ArtifactStagingDirectory)/bin/$(BinaryNameMacOSArm64)
+              Remove-Item $(Build.ArtifactStagingDirectory)/osx-arm64 -Recurse
             displayName: 'Restructure Artifact'

--- a/src/Microsoft.Sbom.Tool/Microsoft.Sbom.Tool.csproj
+++ b/src/Microsoft.Sbom.Tool/Microsoft.Sbom.Tool.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AssemblyName>Microsoft.Sbom.Tool</AssemblyName>
-    <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;osx-x64;osx-arm64;linux-x64</RuntimeIdentifiers>
     <IsPublishable>true</IsPublishable>
     <GenerateRuntimeConfigDevFile>true</GenerateRuntimeConfigDevFile>
     <Description>Highly scalable and enterprise ready tool to create SBOMs for any variety of artifacts.</Description>


### PR DESCRIPTION
This adds the ability to produce an `osx-arm64` version of the tool. It also includes a small doc change about building locally--local builds of arm-64 should not be treated as official since we will be publishing this as a separate package.