### PR TITLE
Bump Microsoft.Extensions.Caching.Memory for CVE

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,6 +19,7 @@
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.7.8" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="8.0.2" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.6.1" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.6.1" />

--- a/src/Microsoft.Sbom.Api/Microsoft.Sbom.Api.csproj
+++ b/src/Microsoft.Sbom.Api/Microsoft.Sbom.Api.csproj
@@ -31,6 +31,11 @@
     </ItemGroup>
 
     <ItemGroup>
+        <!-- Pinned assemblies for transitive dependencies -->
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" /> <!-- Used by ComponentDetection -->
+    </ItemGroup>
+
+    <ItemGroup>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
             <_Parameter1>$(AssemblyName).Tests, PublicKey=$(StrongNameSigningPublicKey)</_Parameter1>
         </AssemblyAttribute>


### PR DESCRIPTION
CVE-2024-43483 requires that we bump `Microsoft.Extensions.Caching.Memory` from 8.0.0 to 8.0.1. This is a transitive dependency from Component Detection. that they are like to eventually pick up, at which time we can revert this change.

Redacted output from `dotnet nuget why` before the change -- version of Microsoft.Extensions.Caching.Memory is 8.0.0:
```
>dotnet nuget why Microsoft.Sbom.sln  Microsoft.Extensions.Caching.Memory
Project 'Microsoft.Sbom.Tool' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   ├─ Microsoft.Sbom.Api (v1.0.0)
   │  ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
   │  │  └─ Microsoft.Extensions.Caching.Memory (v8.0.0)
   │  └─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
   │     └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
   │        └─ Microsoft.Extensions.Caching.Memory (v8.0.0)
   └─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
      └─ Microsoft.Sbom.Api (v1.0.0)
         ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
         │  └─ Microsoft.Extensions.Caching.Memory (v8.0.0)
         └─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
            └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
               └─ Microsoft.Extensions.Caching.Memory (v8.0.0)

Project 'Microsoft.Sbom.Api' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
   │  └─ Microsoft.Extensions.Caching.Memory (v8.0.0)
   └─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
      └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
         └─ Microsoft.Extensions.Caching.Memory (v8.0.0)

Project 'Microsoft.Sbom.Api.Tests' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   └─ Microsoft.Sbom.Api (v1.0.0)
      ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
      │  └─ Microsoft.Extensions.Caching.Memory (v8.0.0)
      └─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
         └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
            └─ Microsoft.Extensions.Caching.Memory (v8.0.0)

Project 'Microsoft.Sbom.DotNetTool' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   ├─ Microsoft.Sbom.Api (v1.0.0)
   │  ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
   │  │  └─ Microsoft.Extensions.Caching.Memory (v8.0.0)
   │  └─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
   │     └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
   │        └─ Microsoft.Extensions.Caching.Memory (v8.0.0)
   └─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
      └─ Microsoft.Sbom.Api (v1.0.0)
         ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
         │  └─ Microsoft.Extensions.Caching.Memory (v8.0.0)
         └─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
            └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
               └─ Microsoft.Extensions.Caching.Memory (v8.0.0)

Project 'Microsoft.Sbom.Extensions.DependencyInjection' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   └─ Microsoft.Sbom.Api (v1.0.0)
      ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
      │  └─ Microsoft.Extensions.Caching.Memory (v8.0.0)
      └─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
         └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
            └─ Microsoft.Extensions.Caching.Memory (v8.0.0)

Project 'Microsoft.Sbom.Extensions.DependencyInjection.Tests' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   └─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
      └─ Microsoft.Sbom.Api (v1.0.0)
         ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
         │  └─ Microsoft.Extensions.Caching.Memory (v8.0.0)
         └─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
            └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
               └─ Microsoft.Extensions.Caching.Memory (v8.0.0)

Project 'Microsoft.Sbom.Targets' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   ├─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
   │  └─ Microsoft.Sbom.Api (v1.0.0)
   │     ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
   │     │  └─ Microsoft.Extensions.Caching.Memory (v8.0.0)
   │     └─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
   │        └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
   │           └─ Microsoft.Extensions.Caching.Memory (v8.0.0)
   └─ Microsoft.Sbom.Tool (v1.0.0)
      ├─ Microsoft.Sbom.Api (v1.0.0)
      │  ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
      │  │  └─ Microsoft.Extensions.Caching.Memory (v8.0.0)
      │  └─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
      │     └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
      │        └─ Microsoft.Extensions.Caching.Memory (v8.0.0)
      └─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
         └─ Microsoft.Sbom.Api (v1.0.0)
            ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
            │  └─ Microsoft.Extensions.Caching.Memory (v8.0.0)
            └─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
               └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
                  └─ Microsoft.Extensions.Caching.Memory (v8.0.0)

Project 'Microsoft.Sbom.Targets.Tests' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   ├─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
   │  └─ Microsoft.Sbom.Api (v1.0.0)
   │     ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
   │     │  └─ Microsoft.Extensions.Caching.Memory (v8.0.0)
   │     └─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
   │        └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
   │           └─ Microsoft.Extensions.Caching.Memory (v8.0.0)
   └─ Microsoft.Sbom.Tool (v1.0.0)
      ├─ Microsoft.Sbom.Api (v1.0.0)
      │  ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
      │  │  └─ Microsoft.Extensions.Caching.Memory (v8.0.0)
      │  └─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
      │     └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
      │        └─ Microsoft.Extensions.Caching.Memory (v8.0.0)
      └─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
         └─ Microsoft.Sbom.Api (v1.0.0)
            ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
            │  └─ Microsoft.Extensions.Caching.Memory (v8.0.0)
            └─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
               └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
                  └─ Microsoft.Extensions.Caching.Memory (v8.0.0)

Project 'Microsoft.Sbom.Tool.Tests' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   └─ Microsoft.Sbom.Tool (v1.0.0)
      ├─ Microsoft.Sbom.Api (v1.0.0)
      │  ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
      │  │  └─ Microsoft.Extensions.Caching.Memory (v8.0.0)
      │  └─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
      │     └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
      │        └─ Microsoft.Extensions.Caching.Memory (v8.0.0)
      └─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
         └─ Microsoft.Sbom.Api (v1.0.0)
            ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
            │  └─ Microsoft.Extensions.Caching.Memory (v8.0.0)
            └─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
               └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
                  └─ Microsoft.Extensions.Caching.Memory (v8.0.0)

Project 'Microsoft.Sbom.Targets.E2E.Tests' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   └─ Microsoft.Sbom.Tool (v1.0.0)
      ├─ Microsoft.Sbom.Api (v1.0.0)
      │  ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
      │  │  └─ Microsoft.Extensions.Caching.Memory (v8.0.0)
      │  └─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
      │     └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
      │        └─ Microsoft.Extensions.Caching.Memory (v8.0.0)
      └─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
         └─ Microsoft.Sbom.Api (v1.0.0)
            ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
            │  └─ Microsoft.Extensions.Caching.Memory (v8.0.0)
            └─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
               └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
                  └─ Microsoft.Extensions.Caching.Memory (v8.0.0)
```

Redacted output from `dotnet nuget why` before the change -- version of Microsoft.Extensions.Caching.Memory is 8.0.1:

```
>dotnet nuget why Microsoft.Sbom.sln  Microsoft.Extensions.Caching.Memory
Project 'Microsoft.Sbom.Tool' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   ├─ Microsoft.Sbom.Api (v1.0.0)
   │  ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
   │  │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   │  ├─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
   │  │  └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
   │  │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   └─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
      └─ Microsoft.Sbom.Api (v1.0.0)
         ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
         │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
         ├─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
         │  └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
         │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
         └─ Microsoft.Extensions.Caching.Memory (v8.0.1)

Project 'Microsoft.Sbom.Api' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
   │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   ├─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
   │  └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
   │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   └─ Microsoft.Extensions.Caching.Memory (v8.0.1)

Project 'Microsoft.Sbom.Api.Tests' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   └─ Microsoft.Sbom.Api (v1.0.0)
      ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
      │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      ├─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
      │  └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
      │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      └─ Microsoft.Extensions.Caching.Memory (v8.0.1)

Project 'Microsoft.Sbom.DotNetTool' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   ├─ Microsoft.Sbom.Api (v1.0.0)
   │  ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
   │  │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   │  ├─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
   │  │  └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
   │  │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   └─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
      └─ Microsoft.Sbom.Api (v1.0.0)
         ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
         │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
         ├─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
         │  └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
         │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
         └─ Microsoft.Extensions.Caching.Memory (v8.0.1)

Project 'Microsoft.Sbom.Extensions.DependencyInjection' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   └─ Microsoft.Sbom.Api (v1.0.0)
      ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
      │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      ├─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
      │  └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
      │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      └─ Microsoft.Extensions.Caching.Memory (v8.0.1)

Project 'Microsoft.Sbom.Extensions.DependencyInjection.Tests' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   └─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
      └─ Microsoft.Sbom.Api (v1.0.0)
         ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
         │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
         ├─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
         │  └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
         │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
         └─ Microsoft.Extensions.Caching.Memory (v8.0.1)

Project 'Microsoft.Sbom.Targets' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   ├─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
   │  └─ Microsoft.Sbom.Api (v1.0.0)
   │     ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
   │     │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   │     ├─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
   │     │  └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
   │     │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   └─ Microsoft.Sbom.Tool (v1.0.0)
      ├─ Microsoft.Sbom.Api (v1.0.0)
      │  ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
      │  │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      │  ├─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
      │  │  └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
      │  │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      └─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
         └─ Microsoft.Sbom.Api (v1.0.0)
            ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
            │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
            ├─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
            │  └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
            │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
            └─ Microsoft.Extensions.Caching.Memory (v8.0.1)

Project 'Microsoft.Sbom.Targets.Tests' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   ├─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
   │  └─ Microsoft.Sbom.Api (v1.0.0)
   │     ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
   │     │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   │     ├─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
   │     │  └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
   │     │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   └─ Microsoft.Sbom.Tool (v1.0.0)
      ├─ Microsoft.Sbom.Api (v1.0.0)
      │  ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
      │  │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      │  ├─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
      │  │  └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
      │  │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      └─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
         └─ Microsoft.Sbom.Api (v1.0.0)
            ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
            │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
            ├─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
            │  └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
            │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
            └─ Microsoft.Extensions.Caching.Memory (v8.0.1)

Project 'Microsoft.Sbom.Tool.Tests' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   └─ Microsoft.Sbom.Tool (v1.0.0)
      ├─ Microsoft.Sbom.Api (v1.0.0)
      │  ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
      │  │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      │  ├─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
      │  │  └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
      │  │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      └─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
         └─ Microsoft.Sbom.Api (v1.0.0)
            ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
            │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
            ├─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
            │  └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
            │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
            └─ Microsoft.Extensions.Caching.Memory (v8.0.1)

Project 'Microsoft.Sbom.Targets.E2E.Tests' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   └─ Microsoft.Sbom.Tool (v1.0.0)
      ├─ Microsoft.Sbom.Api (v1.0.0)
      │  ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
      │  │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      │  ├─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
      │  │  └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
      │  │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      └─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
         └─ Microsoft.Sbom.Api (v1.0.0)
            ├─ Microsoft.ComponentDetection.Detectors (v5.1.5)
            │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
            ├─ Microsoft.ComponentDetection.Orchestrator (v5.1.5)
            │  └─ Microsoft.ComponentDetection.Detectors (v5.1.5)
            │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
            └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
```