### PR TITLE
Add support for go packages

### DIFF
--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/GoComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/GoComponentExtensions.cs
@@ -17,14 +17,18 @@ internal static class GoComponentExtensions
     /// Converts a <see cref="GoComponent" /> to an <see cref="SbomPackage" />.
     /// </summary>
     /// <param name="goComponent">The <see cref="GoComponent" /> to convert.</param>
+    /// <param name="component">The <see cref="ExtendedScannedComponent"/> version of the GoComponent</param>
     /// <returns>The converted <see cref="SbomPackage" />.</returns>
-    public static SbomPackage ToSbomPackage(this GoComponent goComponent) => new()
+    public static SbomPackage ToSbomPackage(this GoComponent goComponent, ExtendedScannedComponent component) => new()
     {
         Id = goComponent.Id,
         PackageUrl = goComponent.PackageUrl?.ToString(),
         PackageName = goComponent.Name,
         PackageVersion = goComponent.Version,
-        LicenseInfo = string.IsNullOrWhiteSpace(component.LicenseConcluded) ? null : new LicenseInfo,
+        LicenseInfo = string.IsNullOrWhiteSpace(component.LicenseConcluded) ? null : new LicenseInfo
+        {
+            Concluded = component.LicenseConcluded,
+        },
         Checksum = new List<Checksum>
         {
             new()

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/GoComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/GoComponentExtensions.cs
@@ -24,6 +24,7 @@ internal static class GoComponentExtensions
         PackageUrl = goComponent.PackageUrl?.ToString(),
         PackageName = goComponent.Name,
         PackageVersion = goComponent.Version,
+        LicenseInfo = string.IsNullOrWhiteSpace(component.LicenseConcluded) ? null : new LicenseInfo,
         Checksum = new List<Checksum>
         {
             new()

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/ScannedComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/ScannedComponentExtensions.cs
@@ -26,7 +26,7 @@ public static class ScannedComponentExtensions
             CondaComponent condaComponent => condaComponent.ToSbomPackage(),
             DockerImageComponent dockerImageComponent => dockerImageComponent.ToSbomPackage(),
             GitComponent gitComponent => gitComponent.ToSbomPackage(),
-            GoComponent goComponent => goComponent.ToSbomPackage(),
+            GoComponent goComponent => goComponent.ToSbomPackage(component),
             LinuxComponent linuxComponent => linuxComponent.ToSbomPackage(),
             MavenComponent mavenComponent => mavenComponent.ToSbomPackage(component),
             NpmComponent npmComponent => npmComponent.ToSbomPackage(component),

--- a/src/Microsoft.Sbom.Api/Executors/LicenseInformationFetcher.cs
+++ b/src/Microsoft.Sbom.Api/Executors/LicenseInformationFetcher.cs
@@ -71,6 +71,9 @@ public class LicenseInformationFetcher : ILicenseInformationFetcher
                     case "cocoapods":
                         listOfComponentsForApi.Add($"pod/{componentType}/{clearlyDefinedNamespace}/{componentName}/{componentVersion}");
                         break;
+                    case "go":
+                        listOfComponentsForApi.Add($"go/golang/{Uri.EscapeDataString(clearlyDefinedNamespace)}/{componentName}/{componentVersion}");
+                        break;
 
                     default:
                         log.Debug($"License retrieval for component type {componentType} is not supported yet.");

--- a/src/Microsoft.Sbom.Api/Executors/LicenseInformationFetcher.cs
+++ b/src/Microsoft.Sbom.Api/Executors/LicenseInformationFetcher.cs
@@ -72,6 +72,7 @@ public class LicenseInformationFetcher : ILicenseInformationFetcher
                         listOfComponentsForApi.Add($"pod/{componentType}/{clearlyDefinedNamespace}/{componentName}/{componentVersion}");
                         break;
                     case "golang":
+                        //  Go packages are URLs so we need to convert characters such as '/' into '%2f'.
                         listOfComponentsForApi.Add($"go/golang/{Uri.EscapeDataString(clearlyDefinedNamespace)}/{componentName}/{componentVersion}");
                         break;
 

--- a/src/Microsoft.Sbom.Api/Executors/LicenseInformationFetcher.cs
+++ b/src/Microsoft.Sbom.Api/Executors/LicenseInformationFetcher.cs
@@ -71,7 +71,7 @@ public class LicenseInformationFetcher : ILicenseInformationFetcher
                     case "cocoapods":
                         listOfComponentsForApi.Add($"pod/{componentType}/{clearlyDefinedNamespace}/{componentName}/{componentVersion}");
                         break;
-                    case "go":
+                    case "golang":
                         listOfComponentsForApi.Add($"go/golang/{Uri.EscapeDataString(clearlyDefinedNamespace)}/{componentName}/{componentVersion}");
                         break;
 

--- a/test/Microsoft.Sbom.Api.Tests/Executors/LicenseInformationFetcherTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/LicenseInformationFetcherTests.cs
@@ -140,6 +140,24 @@ public class LicenseInformationFetcherTests
     }
 
     [TestMethod]
+    public void ConvertComponentToListForApi_Go()
+    {
+        var licenseInformationFetcher = new LicenseInformationFetcher(mockLogger.Object, mockRecorder.Object, mockLicenseInformationService.Object);
+
+        var scannedComponents = new List<ScannedComponent>
+        {
+            new ScannedComponent
+            {
+               Component = new GoComponent("example.com/namespace/pkgname", "1.0.0")
+            }
+        };
+
+        var listOfComponentsForApi = licenseInformationFetcher.ConvertComponentsToListForApi(scannedComponents);
+
+        Assert.AreEqual("go/golang/example.com%2fnamespace/pkgname/1.0.0", listOfComponentsForApi[0]);
+    }
+
+    [TestMethod]
     public void ConvertClearlyDefinedApiResponseToList_GoodResponse()
     {
         var expectedKey = "json5@2.2.3";


### PR DESCRIPTION
I am not a c# developer but would love to see Golang support for this tool. Based this PR off an earlier PR , #369, to add support for additional package types.

An example of a go package available from clearly defined is [testify](https://clearlydefined.io/definitions/go/golang/github.com%2fstretchrcom/testify/v1.9.1-0.20241006154923-2fc4e3939413) so I believe the URL structure being used is correct. 