### PR TITLE
Update SPDX spec links to current

### DIFF
--- a/samples/About this sample.md
+++ b/samples/About this sample.md
@@ -2,4 +2,4 @@
 
 The [manifest.spdx.json](manifest.spdx.json) linked in this folder is the SBOM for the sbom-tool itself. It was generated using the sbom-tool, and is distributed along with every release.
 
-The SBOM is compatible with the SPDX 2.2 format, more information about SPDX 2.2 format can be found [here](https://spdx.github.io/spdx-spec/introduction/).
+The SBOM is compatible with the SPDX 2.2 format, more information about SPDX 2.2 format can be found [here](https://spdx.github.io/spdx-spec/v2.2.2/introduction/).

--- a/src/Microsoft.Sbom.Extensions/Entities/RelationshipType.cs
+++ b/src/Microsoft.Sbom.Extensions/Entities/RelationshipType.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Sbom.Extensions.Entities;
 /// target element.
 /// </summary>
 /// <remarks>
-/// See https://spdx.github.io/spdx-spec/relationships-between-SPDX-elements/.
+/// See https://spdx.github.io/spdx-spec/v2.2.2/relationships-between-SPDX-elements/.
 /// </remarks>
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum RelationshipType

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Enums/ExternalRepositoryType.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Enums/ExternalRepositoryType.cs
@@ -7,8 +7,8 @@ using System.Text.Json.Serialization;
 namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities.Enums;
 
 /// <summary>
-/// Type of the external reference. These are definined in an appendix in the SPDX specification.
-/// https://spdx.github.io/spdx-spec/appendix-VI-external-repository-identifiers/.
+/// Type of the external reference. These are defined in an appendix in the SPDX specification.
+/// https://spdx.github.io/spdx-spec/v2.2.2/external-repository-identifiers/.
 /// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter))]
 [SuppressMessage(

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Enums/ExternalRepositoryType.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Enums/ExternalRepositoryType.cs
@@ -7,7 +7,7 @@ using System.Text.Json.Serialization;
 namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities.Enums;
 
 /// <summary>
-/// Type of the external reference. These are defined in an appendix in the SPDX specification.
+/// Type of the external reference. These are definined in an appendix in the SPDX specification.
 /// https://spdx.github.io/spdx-spec/v2.2.2/external-repository-identifiers/.
 /// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter))]

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Enums/SPDXFileType.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Enums/SPDXFileType.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities.Enums;
 
 /// <summary>
 /// This field provides information about the type of file identified.
-/// Full definition here: https://spdx.github.io/spdx-spec/file-information/#83-file-type-field.
+/// Full definition here: https://spdx.github.io/spdx-spec/v2.2.2/file-information/#83-file-type-field.
 /// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum SPDXFileType

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Enums/SPDXRelationshipType.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Enums/SPDXRelationshipType.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities.Enums;
 /// Defines the type of <see cref="SPDXRelationship"/> between the source and the
 /// target element.
 ///
-/// Full definition here: https://spdx.github.io/spdx-spec/7-relationships-between-SPDX-elements/#71-relationship.
+/// Full definition here: https://spdx.github.io/spdx-spec/v2.2.2/relationships-between-SPDX-elements/.
 /// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum SPDXRelationshipType

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/ExternalReference.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/ExternalReference.cs
@@ -21,7 +21,7 @@ public class ExternalReference
 
     /// <summary>
     /// Gets or sets type of the external reference. These are defined in an appendix in the SPDX specification.
-    /// https://spdx.github.io/spdx-spec/appendix-VI-external-repository-identifiers/.
+    /// https://spdx.github.io/spdx-spec/v2.2.2/external-repository-identifiers/.
     /// </summary>
     [JsonPropertyName("referenceType")]
     public string Type { get; set; }

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/InternalMetadataProviderIdentityExtensions.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/InternalMetadataProviderIdentityExtensions.cs
@@ -54,7 +54,7 @@ public static class InternalMetadataProviderIdentityExtensions
     /// <summary>
     /// Generates the package verification code for a given package using the SPDX 2.2 specification.
     ///
-    /// Algorithm defined here https://spdx.github.io/spdx-spec/3-package-information/#39-package-verification-code.
+    /// Algorithm defined here https://spdx.github.io/spdx-spec/v2.2.2/package-information/.
     /// </summary>
     /// <param name="internalMetadataProvider"></param>
     /// <returns></returns>


### PR DESCRIPTION
Existing links are dead-links due to website structure changes.

For example, https://spdx.github.io/spdx-spec/introduction/ is a dead link.
That page is now at https://spdx.github.io/spdx-spec/v2.2.2/introduction/.

--

SPDX 2.2.2 is a patch version of 2.2.

There is no technical differences between 2.2, 2.2.1, and 2.2.2 (2.2.1 is a reformat and renumbering of chapters/annexes for ISO submission, 2.2.2 is a grammar/typo fix of 2.2.1, according to https://github.com/spdx/using/blob/main/docs/diffs-from-previous-editions.md#a4-differences-between-v221-and-v22- and https://spdx.github.io/spdx-spec/v2.2.2/diffs-from-previous-editions/ )