### PR TITLE
Fix several typos in Markdown files and in a comment

### DIFF
--- a/docs/building-from-source.md
+++ b/docs/building-from-source.md
@@ -41,7 +41,7 @@ In the user's shell of choice, ensure that the Dotnet SDK is installed and avail
 dotnet build
 ```
 
-Users can run the sbom tool using this command which contains the minimum required set of paramaters:
+Users can run the sbom tool using this command which contains the minimum required set of parameters:
 
 ```
 dotnet run --project src/Microsoft.Sbom.Tool generate -b <drop path> -bc <build components path> -pn <package name> -pv <package version> -ps <company name> -nsb <namespace uri base>

--- a/docs/sbom-tool-api-reference.md
+++ b/docs/sbom-tool-api-reference.md
@@ -101,7 +101,7 @@ Below are 2 additional helper methods.
 
 ### GetSupportedSBOMSpecifications
 
-The `SBOMSpecificiation` object represents a SBOM format. Each `SBOMSpecification` contains a `name` and a `version`. This structure defines a single format of SBOM.  Sample SPDX version 2.2 format representations include:
+The `SBOMSpecification` object represents a SBOM format. Each `SBOMSpecification` contains a `name` and a `version`. This structure defines a single format of SBOM.  Sample SPDX version 2.2 format representations include:
 
 ```C#
 using Microsoft.Sbom.Contracts;

--- a/docs/setting-up-github-actions.md
+++ b/docs/setting-up-github-actions.md
@@ -33,7 +33,7 @@ jobs:
         path: buildOutput
 ```
 
-Once the sbom tool produces SBOM, the user can see that the Actions run page now contains the newly generated binares and other file artifacts.
+Once the sbom tool produces SBOM, the user can see that the Actions run page now contains the newly generated binaries and other file artifacts.
 
 ![actions run](./images/github-workflow-run-details.png)
 ![actions-artifact-without-sbom](./images/github-downloaded-folder-without-sbom.png)

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Enums/ExternalRepositoryType.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Enums/ExternalRepositoryType.cs
@@ -7,7 +7,7 @@ using System.Text.Json.Serialization;
 namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities.Enums;
 
 /// <summary>
-/// Type of the external reference. These are definined in an appendix in the SPDX specification.
+/// Type of the external reference. These are defined in an appendix in the SPDX specification.
 /// https://spdx.github.io/spdx-spec/appendix-VI-external-repository-identifiers/.
 /// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter))]


### PR DESCRIPTION
In 3 Markdown files
- paramaters -> parameters
- SBOMSpecificiation -> SBOMSpecification
- binares -> binaries

In 1 C# file (comment line):
- definined -> defined

--

There are also 3 "arguement" typos in these test method names in 1 C# file (`test/ApiConfigurationBuilderTests.cs`):

- ThrowArguementExceptionOnRootPathValues
- ThrowArguementNulExceptionOnNullMetadata
- ThrowArguementExceptionOnSpecificationZero

Looks like it's save to rename since they ought to be used only for internal testing purpose but I'm not sure enough, so I leave them intact.

