### PR TITLE
Blunt update of SPDX version 2.2 -> 2.2.2

### DIFF
--- a/docs/sbom-tool-api-reference.md
+++ b/docs/sbom-tool-api-reference.md
@@ -106,7 +106,7 @@ The `SBOMSpecificiation` object represents a SBOM format. Each `SBOMSpecificatio
 ```C#
 using Microsoft.Sbom.Contracts;
 
-var spdx22Specification = new SBOMSpecification("SPDX", "2.2");
+var spdx22Specification = new SBOMSpecification("SPDX", "2.2.2");
 ```
 
 While this API supports the creation of a SBOM output file in multiple formats, it currently only supports the SPDX version 2.2 architecture. Users looking to implement other SBOM architectures can use this API call, which provides the full list of all supported formats.
@@ -118,7 +118,7 @@ var specifications = generator.GetSupportedSBOMSpecifications();
 
 Assert.True(specifications.Count() == 1);
 Assert.Equal("SPDX", specifications.First().Name);
-Assert.Equal("2.2", specifications.First().Version);
+Assert.Equal("2.2.2", specifications.First().Version);
 ```
 
 ### GetRequiredAlgorithms
@@ -306,7 +306,7 @@ namespace SBOMApiExample
             string outputPath = "C:/temp/ValidationOutput.json";
             IList<SbomSpecification> spdx22Specification = new List<SbomSpecification>()
             {
-                new SbomSpecification("SPDX","2.2")
+                new SbomSpecification("SPDX", "2.2.2")
             };
 
             RuntimeConfiguration configuration = new RuntimeConfiguration()

--- a/src/Microsoft.Sbom.Api/README.md
+++ b/src/Microsoft.Sbom.Api/README.md
@@ -32,7 +32,7 @@ namespace SBOMApiExample
 
             IList<SBOMSpecification> specifications = new List<SBOMSpecification>()
             {
-                new SBOMSpecification ("SPDX", "2.2")
+                new SBOMSpecification ("SPDX", "2.2.2")
             };
 
             RuntimeConfiguration configuration = new RuntimeConfiguration()
@@ -84,7 +84,7 @@ namespace SBOMApiExample
                                 sbomFiles,
                                 sbomPackages,
                                 metadata,
-                                new List<SBOMSpecification> { new("SPDX", "2.2") },
+                                new List<SBOMSpecification> { new("SPDX", "2.2.2") },
                                 new RuntimeConfiguration { DeleteManifestDirectoryIfPresent = true });
 
             hostApplicationLifetime.StopApplication();

--- a/src/Microsoft.Sbom.Api/Utils/Constants.cs
+++ b/src/Microsoft.Sbom.Api/Utils/Constants.cs
@@ -16,7 +16,7 @@ public static class Constants
     public static ManifestInfo SPDX22ManifestInfo = new ManifestInfo
     {
         Name = "SPDX",
-        Version = "2.2"
+        Version = "2.2.2"
     };
 
     public static SbomSpecification SPDX22Specification = SPDX22ManifestInfo.ToSBOMSpecification();

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Constants.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Constants.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Sbom.Parsers.Spdx22SbomParser;
 internal static class Constants
 {
     internal const string SPDXName = "SPDX";
-    internal const string SPDXVersion = "2.2";
+    internal const string SPDXVersion = "2.2.2";
     internal const string DataLicenceValue = "CC0-1.0";
     internal const string SPDXDocumentIdValue = "SPDXRef-DOCUMENT";
     internal const string RootPackageIdValue = "SPDXRef-RootPackage";

--- a/test/Microsoft.Sbom.Api.Tests/ApiConfigurationBuilderTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/ApiConfigurationBuilderTests.cs
@@ -50,12 +50,12 @@ public class ApiConfigurationBuilderTests
     public void GetConfiguration_PopulateAll()
     {
         var specs = new List<SbomSpecification>();
-        specs.Add(new SbomSpecification("spdx", "2.2"));
+        specs.Add(new SbomSpecification("spdx", "2.2.2"));
 
         var expectedManifestInfo = new ManifestInfo()
         {
             Name = "spdx",
-            Version = "2.2"
+            Version = "2.2.2"
         };
 
         var config = ApiConfigurationBuilder.GetConfiguration(RootPath, manifestDirPath, files, packages, metadata, specs, runtime, externalDocumentRefListFile, componentPath);

--- a/test/Microsoft.Sbom.Targets.E2E.Tests/GenerateSbomE2ETests.cs
+++ b/test/Microsoft.Sbom.Targets.E2E.Tests/GenerateSbomE2ETests.cs
@@ -28,7 +28,7 @@ public class GenerateSbomE2ETests
     private static string generateSbomTaskPath = Path.Combine(Directory.GetCurrentDirectory(), "Microsoft.Sbom.Targets.dll");
 
     private static string sbomSpecificationName = "SPDX";
-    private static string sbomSpecificationVersion = "2.2";
+    private static string sbomSpecificationVersion = "2.2.2";
     private static string sbomSpecificationDirectoryName = $"{sbomSpecificationName}_{sbomSpecificationVersion}".ToLowerInvariant();
     private string expectedPackageName;
     private string expectedVersion;

--- a/test/Microsoft.Sbom.Targets.Tests/GenerateSbomTaskSPDX_2_2Tests.cs
+++ b/test/Microsoft.Sbom.Targets.Tests/GenerateSbomTaskSPDX_2_2Tests.cs
@@ -18,5 +18,5 @@ public class GenerateSbomTaskSPDX_2_2Tests : AbstractGenerateSbomTaskTests
 {
     internal override string SbomSpecificationName => "SPDX";
 
-    internal override string SbomSpecificationVersion => "2.2";
+    internal override string SbomSpecificationVersion => "2.2.2";
 }


### PR DESCRIPTION
- This is a blunt and aggressive approach of making sbom-tool supporting SPDX 2.2.2 (in order to fix #738).
- It does not add 2.2.2 support AND keep 2.2 support, it is replacing 2.2 with 2.2.2. There will be no 2.2.
- It is basically replacing the version number (`SPDXConstants.SPDXVersion`) from "2.2" to "2.2.2" when creating `SbomSpecification`.
- As there's no technical differences between 2.2, 2.2.1, and 2.2.2, this can be a minimal way to support 2.2.2.
- Considering 2.2.2 is a patch version of 2.2 (and there's no technical differences), we may able to say it is still "supporting" 2.2.