### PR TITLE
Made the Timeout in LicenseInformationService configurable via CLI argument (#584)

### DIFF
--- a/docs/sbom-tool-arguments.md
+++ b/docs/sbom-tool-arguments.md
@@ -66,6 +66,8 @@ Actions
     DeleteManifestDirIfPresent (-D)           If set to true, we will delete any previous manifest directories that are already present in the ManifestDirPath without asking the user for confirmation. The new
                                               manifest directory will then be created at this location and the generated SBOM will be stored there.
     FetchLicenseInformation (-li)             If set to true, we will attempt to fetch license information of packages detected in the SBOM from the ClearlyDefinedApi.
+    LicenseInformationTimeoutInSeconds (-lto) Specifies the timeout in seconds for fetching the license information. Defaults to 30 seconds. Has no effect if
+                                              FetchLicenseInformation (-li) argument is false or not provided. A negative value specifies an infinite timeout.
     EnablePackageMetadataParsing (-pm)        If set to true, we will attempt to parse license and supplier info from the packages metadata file (RubyGems, NuGet, Maven, Npm).
     Verbosity (-V)                            Display this amount of detail in the logging output.
                                               Verbose

--- a/docs/sbom-tool-arguments.md
+++ b/docs/sbom-tool-arguments.md
@@ -67,7 +67,8 @@ Actions
                                               manifest directory will then be created at this location and the generated SBOM will be stored there.
     FetchLicenseInformation (-li)             If set to true, we will attempt to fetch license information of packages detected in the SBOM from the ClearlyDefinedApi.
     LicenseInformationTimeoutInSeconds (-lto) Specifies the timeout in seconds for fetching the license information. Defaults to 30 seconds. Has no effect if
-                                              FetchLicenseInformation (-li) argument is false or not provided. A negative value specifies an infinite timeout.
+                                              FetchLicenseInformation (-li) argument is false or not provided. Valid values are from 1 to 86400. Negative values use the default
+                                              value and Values exceeding the maximum are truncated to the maximum. 
     EnablePackageMetadataParsing (-pm)        If set to true, we will attempt to parse license and supplier info from the packages metadata file (RubyGems, NuGet, Maven, Npm).
     Verbosity (-V)                            Display this amount of detail in the logging output.
                                               Verbose

--- a/src/Microsoft.Sbom.Api/Config/Args/GenerationArgs.cs
+++ b/src/Microsoft.Sbom.Api/Config/Args/GenerationArgs.cs
@@ -117,6 +117,15 @@ public class GenerationArgs : GenerationAndValidationCommonArgs
     public bool? FetchLicenseInformation { get; set; }
 
     /// <summary>
+    /// Specifies the timeout in seconds for fetching the license information. Defaults to 30 seconds. Has no effect if
+    /// FetchLicenseInformation (li) argument is false or not provided.
+    /// </summary>
+    [ArgShortcut("lto")]
+    [ArgDescription("Specifies the timeout in seconds for fetching the license information. Defaults to 30 seconds. " +
+        "Has no effect if the FetchLicenseInformation (li) argument is false or not provided. ")]
+    public int? LicenseInformationTimeout { get; set; }
+
+    /// <summary>
     /// If set to true, we will attempt to parse license and supplier info from the packages metadata file.
     /// </summary>
     [ArgShortcut("pm")]

--- a/src/Microsoft.Sbom.Api/Config/Args/GenerationArgs.cs
+++ b/src/Microsoft.Sbom.Api/Config/Args/GenerationArgs.cs
@@ -118,12 +118,13 @@ public class GenerationArgs : GenerationAndValidationCommonArgs
 
     /// <summary>
     /// Specifies the timeout in seconds for fetching the license information. Defaults to 30 seconds. Has no effect if
-    /// FetchLicenseInformation (li) argument is false or not provided.
+    /// FetchLicenseInformation (li) argument is false or not provided. A negative value corresponds to an infinite timeout.
     /// </summary>
     [ArgShortcut("lto")]
     [ArgDescription("Specifies the timeout in seconds for fetching the license information. Defaults to 30 seconds. " +
-        "Has no effect if the FetchLicenseInformation (li) argument is false or not provided. ")]
-    public int? LicenseInformationTimeout { get; set; }
+        "Has no effect if the FetchLicenseInformation (li) argument is false or not provided. A negative value corresponds" +
+        "to an infinite timeout.")]
+    public int? LicenseInformationTimeoutInSeconds { get; set; }
 
     /// <summary>
     /// If set to true, we will attempt to parse license and supplier info from the packages metadata file.

--- a/src/Microsoft.Sbom.Api/Executors/ComponentDetectionBaseWalker.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ComponentDetectionBaseWalker.cs
@@ -138,13 +138,19 @@ public abstract class ComponentDetectionBaseWalker
                     licenseInformationRetrieved = true;
 
                     List<string> apiResponses;
-                    if (configuration.LicenseInformationTimeout is null)
+                    var licenseInformationFetcher2 = licenseInformationFetcher as ILicenseInformationFetcher2;
+                    if (licenseInformationFetcher2 != null && (bool)!configuration.LicenseInformationTimeoutInSeconds?.IsDefaultSource)
+                    {
+                        log.Warning("Timeout value is specified, but ILicenseInformationFetcher2 is not implemented for the licenseInformationFetcher");
+                    }
+
+                    if (licenseInformationFetcher2 is null || configuration.LicenseInformationTimeoutInSeconds is null)
                     {
                         apiResponses = await licenseInformationFetcher.FetchLicenseInformationAsync(listOfComponentsForApi);
                     }
                     else
                     {
-                        apiResponses = await licenseInformationFetcher.FetchLicenseInformationAsync(listOfComponentsForApi, configuration.LicenseInformationTimeout.Value);
+                        apiResponses = await licenseInformationFetcher2.FetchLicenseInformationAsync(listOfComponentsForApi, configuration.LicenseInformationTimeoutInSeconds.Value);
                     }
 
                     foreach (var response in apiResponses)

--- a/src/Microsoft.Sbom.Api/Executors/ComponentDetectionBaseWalker.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ComponentDetectionBaseWalker.cs
@@ -137,7 +137,15 @@ public abstract class ComponentDetectionBaseWalker
                 {
                     licenseInformationRetrieved = true;
 
-                    var apiResponses = await licenseInformationFetcher.FetchLicenseInformationAsync(listOfComponentsForApi);
+                    List<string> apiResponses;
+                    if (configuration.LicenseInformationTimeout is null)
+                    {
+                        apiResponses = await licenseInformationFetcher.FetchLicenseInformationAsync(listOfComponentsForApi);
+                    }
+                    else
+                    {
+                        apiResponses = await licenseInformationFetcher.FetchLicenseInformationAsync(listOfComponentsForApi, configuration.LicenseInformationTimeout.Value);
+                    }
 
                     foreach (var response in apiResponses)
                     {

--- a/src/Microsoft.Sbom.Api/Executors/ComponentDetectionBaseWalker.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ComponentDetectionBaseWalker.cs
@@ -139,7 +139,7 @@ public abstract class ComponentDetectionBaseWalker
 
                     List<string> apiResponses;
                     var licenseInformationFetcher2 = licenseInformationFetcher as ILicenseInformationFetcher2;
-                    if (licenseInformationFetcher2 != null && (bool)!configuration.LicenseInformationTimeoutInSeconds?.IsDefaultSource)
+                    if (licenseInformationFetcher2 is null && (bool)!configuration.LicenseInformationTimeoutInSeconds?.IsDefaultSource)
                     {
                         log.Warning("Timeout value is specified, but ILicenseInformationFetcher2 is not implemented for the licenseInformationFetcher");
                     }

--- a/src/Microsoft.Sbom.Api/Executors/ILicenseInformationFetcher.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ILicenseInformationFetcher.cs
@@ -17,12 +17,16 @@ public interface ILicenseInformationFetcher
     /// <returns></returns>
     List<string> ConvertComponentsToListForApi(IEnumerable<ScannedComponent> scannedComponents);
 
+    /// <inheritdoc cref="FetchLicenseInformationAsync(List{string}, int)"/>>
+    Task<List<string>> FetchLicenseInformationAsync(List<string> listOfComponentsForApi);
+
     /// <summary>
     /// Calls the ClearlyDefined API to get the license information for the list of components.
     /// </summary>
     /// <param name="listOfComponentsForApi"> A list of strings formatted into a list of strings that can be used to call the batch ClearlyDefined API.</param>
+    /// <param name="timeout">Timeout in seconds to use when making web requests</param>
     /// <returns></returns>
-    Task<List<string>> FetchLicenseInformationAsync(List<string> listOfComponentsForApi);
+    Task<List<string>> FetchLicenseInformationAsync(List<string> listOfComponentsForApi, int timeout);
 
     /// <summary>
     /// Gets the dictionary of licenses that were fetched from the ClearlyDefined API.

--- a/src/Microsoft.Sbom.Api/Executors/ILicenseInformationFetcher.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ILicenseInformationFetcher.cs
@@ -17,16 +17,12 @@ public interface ILicenseInformationFetcher
     /// <returns></returns>
     List<string> ConvertComponentsToListForApi(IEnumerable<ScannedComponent> scannedComponents);
 
-    /// <inheritdoc cref="FetchLicenseInformationAsync(List{string}, int)"/>>
-    Task<List<string>> FetchLicenseInformationAsync(List<string> listOfComponentsForApi);
-
     /// <summary>
-    /// Calls the ClearlyDefined API to get the license information for the list of components.
+    /// Calls the ClearlyDefined API to get the license information for the list of components. Uses a default timeout specified in implementation
     /// </summary>
     /// <param name="listOfComponentsForApi"> A list of strings formatted into a list of strings that can be used to call the batch ClearlyDefined API.</param>
-    /// <param name="timeout">Timeout in seconds to use when making web requests</param>
     /// <returns></returns>
-    Task<List<string>> FetchLicenseInformationAsync(List<string> listOfComponentsForApi, int timeout);
+    Task<List<string>> FetchLicenseInformationAsync(List<string> listOfComponentsForApi);
 
     /// <summary>
     /// Gets the dictionary of licenses that were fetched from the ClearlyDefined API.

--- a/src/Microsoft.Sbom.Api/Executors/ILicenseInformationFetcher2.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ILicenseInformationFetcher2.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.ComponentDetection.Contracts.BcdeModels;
+
+namespace Microsoft.Sbom.Api.Executors;
+
+public interface ILicenseInformationFetcher2: ILicenseInformationFetcher
+{
+    /// <summary>
+    /// Calls the ClearlyDefined API to get the license information for the list of components.
+    /// </summary>
+    /// <param name="listOfComponentsForApi"> A list of strings formatted into a list of strings that can be used to call the batch ClearlyDefined API.</param>
+    /// <param name="timeoutInSeconds">Timeout in seconds to use when making web requests</param>
+    /// <returns></returns>
+    Task<List<string>> FetchLicenseInformationAsync(List<string> listOfComponentsForApi, int timeoutInSeconds);
+}

--- a/src/Microsoft.Sbom.Api/Executors/ILicenseInformationService.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ILicenseInformationService.cs
@@ -9,4 +9,6 @@ namespace Microsoft.Sbom.Api.Executors;
 public interface ILicenseInformationService
 {
     public Task<List<string>> FetchLicenseInformationFromAPI(List<string> listOfComponentsForApi);
+
+    public Task<List<string>> FetchLicenseInformationFromAPI(List<string> listOfComponentsForApi, int timeout);
 }

--- a/src/Microsoft.Sbom.Api/Executors/ILicenseInformationService2.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ILicenseInformationService2.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Sbom.Api.Executors;
 
-public interface ILicenseInformationService
+public interface ILicenseInformationService2 : ILicenseInformationService
 {
-    public Task<List<string>> FetchLicenseInformationFromAPI(List<string> listOfComponentsForApi);
+    public Task<List<string>> FetchLicenseInformationFromAPI(List<string> listOfComponentsForApi, int timeoutInSeconds);
 }

--- a/src/Microsoft.Sbom.Api/Executors/LicenseInformationFetcher.cs
+++ b/src/Microsoft.Sbom.Api/Executors/LicenseInformationFetcher.cs
@@ -84,7 +84,12 @@ public class LicenseInformationFetcher : ILicenseInformationFetcher
 
     public async Task<List<string>> FetchLicenseInformationAsync(List<string> listOfComponentsForApi)
     {
-        return await licenseInformationService.FetchLicenseInformationFromAPI(listOfComponentsForApi);
+        return await FetchLicenseInformationAsync(listOfComponentsForApi, 30);
+    }
+
+    public async Task<List<string>> FetchLicenseInformationAsync(List<string> listOfComponentsForApi, int timeout)
+    {
+        return await licenseInformationService.FetchLicenseInformationFromAPI(listOfComponentsForApi, timeout);
     }
 
     // Will attempt to extract license information from a clearlyDefined batch API response. Will always return a dictionary which may be empty depending on the response.

--- a/src/Microsoft.Sbom.Api/Executors/LicenseInformationFetcher.cs
+++ b/src/Microsoft.Sbom.Api/Executors/LicenseInformationFetcher.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Sbom.Api.Executors;
 
 public class LicenseInformationFetcher : ILicenseInformationFetcher2
 {
-    public const int DefaultTimeoutInSeconds = 30;
     private readonly ILogger log;
     private readonly IRecorder recorder;
     private readonly ILicenseInformationService licenseInformationService;
@@ -85,7 +84,7 @@ public class LicenseInformationFetcher : ILicenseInformationFetcher2
 
     public async Task<List<string>> FetchLicenseInformationAsync(List<string> listOfComponentsForApi)
     {
-        return await FetchLicenseInformationAsync(listOfComponentsForApi, DefaultTimeoutInSeconds);
+        return await licenseInformationService.FetchLicenseInformationFromAPI(listOfComponentsForApi);
     }
 
     public async Task<List<string>> FetchLicenseInformationAsync(List<string> listOfComponentsForApi, int timeoutInSeconds)

--- a/src/Microsoft.Sbom.Api/Executors/LicenseInformationService.cs
+++ b/src/Microsoft.Sbom.Api/Executors/LicenseInformationService.cs
@@ -20,7 +20,6 @@ public class LicenseInformationService : ILicenseInformationService
     private readonly ILogger log;
     private readonly IRecorder recorder;
     private readonly HttpClient httpClient;
-    private const int ClientTimeoutSeconds = 30;
 
     public LicenseInformationService(ILogger log, IRecorder recorder, HttpClient httpClient)
     {
@@ -31,6 +30,11 @@ public class LicenseInformationService : ILicenseInformationService
 
     public async Task<List<string>> FetchLicenseInformationFromAPI(List<string> listOfComponentsForApi)
     {
+        return await FetchLicenseInformationFromAPI(listOfComponentsForApi, 30);
+    }
+
+    public async Task<List<string>> FetchLicenseInformationFromAPI(List<string> listOfComponentsForApi, int timeout)
+    {
         var batchSize = 500;
         var responses = new List<HttpResponseMessage>();
         var responseContent = new List<string>();
@@ -38,7 +42,7 @@ public class LicenseInformationService : ILicenseInformationService
         var uri = new Uri("https://api.clearlydefined.io/definitions?expand=-files");
 
         httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-        httpClient.Timeout = TimeSpan.FromSeconds(ClientTimeoutSeconds);
+        httpClient.Timeout = TimeSpan.FromSeconds(timeout);
 
         for (var i = 0; i < listOfComponentsForApi.Count; i += batchSize)
         {

--- a/src/Microsoft.Sbom.Api/Executors/LicenseInformationService.cs
+++ b/src/Microsoft.Sbom.Api/Executors/LicenseInformationService.cs
@@ -17,7 +17,6 @@ namespace Microsoft.Sbom.Api.Executors;
 
 public class LicenseInformationService : ILicenseInformationService2
 {
-    private const int DefaultTimeoutInSeconds = LicenseInformationFetcher.DefaultTimeoutInSeconds;
     private readonly ILogger log;
     private readonly IRecorder recorder;
     private readonly HttpClient httpClient;
@@ -31,7 +30,7 @@ public class LicenseInformationService : ILicenseInformationService2
 
     public async Task<List<string>> FetchLicenseInformationFromAPI(List<string> listOfComponentsForApi)
     {
-        return await FetchLicenseInformationFromAPI(listOfComponentsForApi, DefaultTimeoutInSeconds);
+        return await FetchLicenseInformationFromAPI(listOfComponentsForApi, Common.Constants.MaxLicenseFetchTimeoutInSeconds);
     }
 
     public async Task<List<string>> FetchLicenseInformationFromAPI(List<string> listOfComponentsForApi, int timeoutInSeconds)
@@ -43,14 +42,10 @@ public class LicenseInformationService : ILicenseInformationService2
         var uri = new Uri("https://api.clearlydefined.io/definitions?expand=-files");
 
         httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-        if (timeoutInSeconds >= 0)
+        if (timeoutInSeconds > 0)
         {
             httpClient.Timeout = TimeSpan.FromSeconds(timeoutInSeconds);
-        }
-        else
-        {
-            httpClient.Timeout = System.Threading.Timeout.InfiniteTimeSpan;
-        }
+        } // The else cases should be sanitized in Config Sanitizer, and even if not, it'll just use httpClient's default timeout
 
         for (var i = 0; i < listOfComponentsForApi.Count; i += batchSize)
         {

--- a/src/Microsoft.Sbom.Common/Config/Configuration.cs
+++ b/src/Microsoft.Sbom.Common/Config/Configuration.cs
@@ -310,9 +310,9 @@ public class Configuration : IConfiguration
         set => fetchLicenseInformation.Value = value;
     }
 
-    /// <inheritdoc cref="IConfiguration.LicenseInformationTimeout" />
+    /// <inheritdoc cref="IConfiguration.LicenseInformationTimeoutInSeconds" />
     [DefaultValue(30)]
-    public ConfigurationSetting<int> LicenseInformationTimeout
+    public ConfigurationSetting<int> LicenseInformationTimeoutInSeconds
     {
         get => licenseInformationTimeout.Value;
         set => licenseInformationTimeout.Value = value;

--- a/src/Microsoft.Sbom.Common/Config/Configuration.cs
+++ b/src/Microsoft.Sbom.Common/Config/Configuration.cs
@@ -311,7 +311,7 @@ public class Configuration : IConfiguration
     }
 
     /// <inheritdoc cref="IConfiguration.LicenseInformationTimeoutInSeconds" />
-    [DefaultValue(30)]
+    [DefaultValue(Constants.DefaultLicenseFetchTimeoutInSeconds)]
     public ConfigurationSetting<int> LicenseInformationTimeoutInSeconds
     {
         get => licenseInformationTimeout.Value;

--- a/src/Microsoft.Sbom.Common/Config/Configuration.cs
+++ b/src/Microsoft.Sbom.Common/Config/Configuration.cs
@@ -47,6 +47,7 @@ public class Configuration : IConfiguration
     private static readonly AsyncLocal<ConfigurationSetting<string>> generationTimestamp = new();
     private static readonly AsyncLocal<ConfigurationSetting<bool>> followSymlinks = new();
     private static readonly AsyncLocal<ConfigurationSetting<bool>> fetchLicenseInformation = new();
+    private static readonly AsyncLocal<ConfigurationSetting<int>> licenseInformationTimeout = new();
     private static readonly AsyncLocal<ConfigurationSetting<bool>> enablePackageMetadataParsing = new();
     private static readonly AsyncLocal<ConfigurationSetting<bool>> deleteManifestDirIfPresent = new();
     private static readonly AsyncLocal<ConfigurationSetting<bool>> failIfNoPackages = new();
@@ -307,6 +308,14 @@ public class Configuration : IConfiguration
     {
         get => fetchLicenseInformation.Value;
         set => fetchLicenseInformation.Value = value;
+    }
+
+    /// <inheritdoc cref="IConfiguration.LicenseInformationTimeout" />
+    [DefaultValue(30)]
+    public ConfigurationSetting<int> LicenseInformationTimeout
+    {
+        get => licenseInformationTimeout.Value;
+        set => licenseInformationTimeout.Value = value;
     }
 
     /// <inheritdoc cref="IConfiguration.EnablePackageMetadataParsing" />

--- a/src/Microsoft.Sbom.Common/Config/IConfiguration.cs
+++ b/src/Microsoft.Sbom.Common/Config/IConfiguration.cs
@@ -196,9 +196,9 @@ public interface IConfiguration
 
     /// <summary>
     /// Specifies the timeout in seconds for fetching the license information. Defaults to 30 seconds. Has no effect if
-    /// FetchLicenseInformation (li) argument is false or not provided.
+    /// FetchLicenseInformation (li) argument is false or not provided. Negative values correspond to an infinite timeout
     /// </summary>
-    ConfigurationSetting<int> LicenseInformationTimeout { get; set; }
+    ConfigurationSetting<int> LicenseInformationTimeoutInSeconds { get; set; }
 
     /// <summary>
     /// If set to true, we will attempt to locate and parse package metadata files for additional information to include in the SBOM such as .nuspec/.pom files in the local package cache.

--- a/src/Microsoft.Sbom.Common/Config/IConfiguration.cs
+++ b/src/Microsoft.Sbom.Common/Config/IConfiguration.cs
@@ -195,6 +195,12 @@ public interface IConfiguration
     ConfigurationSetting<bool> FetchLicenseInformation { get; set; }
 
     /// <summary>
+    /// Specifies the timeout in seconds for fetching the license information. Defaults to 30 seconds. Has no effect if
+    /// FetchLicenseInformation (li) argument is false or not provided.
+    /// </summary>
+    ConfigurationSetting<int> LicenseInformationTimeout { get; set; }
+
+    /// <summary>
     /// If set to true, we will attempt to locate and parse package metadata files for additional information to include in the SBOM such as .nuspec/.pom files in the local package cache.
     /// </summary>
     ConfigurationSetting<bool> EnablePackageMetadataParsing { get; set; }

--- a/src/Microsoft.Sbom.Common/Config/IConfiguration.cs
+++ b/src/Microsoft.Sbom.Common/Config/IConfiguration.cs
@@ -195,8 +195,9 @@ public interface IConfiguration
     ConfigurationSetting<bool> FetchLicenseInformation { get; set; }
 
     /// <summary>
-    /// Specifies the timeout in seconds for fetching the license information. Defaults to 30 seconds. Has no effect if
-    /// FetchLicenseInformation (li) argument is false or not provided. Negative values correspond to an infinite timeout
+    /// Specifies the timeout in seconds for fetching the license information. Defaults to <see cref="Constants.DefaultLicenseFetchTimeoutInSeconds"/>.
+    /// Has no effect if FetchLicenseInformation (li) argument is false or not provided. Negative values are set to the default and values exceeding the
+    /// maximum are truncated to <see cref="Constants.MaxLicenseFetchTimeoutInSeconds"/>
     /// </summary>
     ConfigurationSetting<int> LicenseInformationTimeoutInSeconds { get; set; }
 

--- a/src/Microsoft.Sbom.Common/Config/InputConfiguration.cs
+++ b/src/Microsoft.Sbom.Common/Config/InputConfiguration.cs
@@ -141,6 +141,10 @@ public class InputConfiguration : IConfiguration
     [DefaultValue(false)]
     public ConfigurationSetting<bool> FetchLicenseInformation { get; set; }
 
+    /// <inheritdoc cref="IConfiguration.LicenseInformationTimeout" />
+    [DefaultValue(30)]
+    public ConfigurationSetting<int> LicenseInformationTimeout { get; set; }
+
     [DefaultValue(false)]
     public ConfigurationSetting<bool> EnablePackageMetadataParsing { get; set; }
 

--- a/src/Microsoft.Sbom.Common/Config/InputConfiguration.cs
+++ b/src/Microsoft.Sbom.Common/Config/InputConfiguration.cs
@@ -142,7 +142,7 @@ public class InputConfiguration : IConfiguration
     public ConfigurationSetting<bool> FetchLicenseInformation { get; set; }
 
     /// <inheritdoc cref="IConfiguration.LicenseInformationTimeoutInSeconds" />
-    [DefaultValue(30)]
+    [DefaultValue(Constants.DefaultLicenseFetchTimeoutInSeconds)]
     public ConfigurationSetting<int> LicenseInformationTimeoutInSeconds { get; set; }
 
     [DefaultValue(false)]

--- a/src/Microsoft.Sbom.Common/Config/InputConfiguration.cs
+++ b/src/Microsoft.Sbom.Common/Config/InputConfiguration.cs
@@ -141,9 +141,9 @@ public class InputConfiguration : IConfiguration
     [DefaultValue(false)]
     public ConfigurationSetting<bool> FetchLicenseInformation { get; set; }
 
-    /// <inheritdoc cref="IConfiguration.LicenseInformationTimeout" />
+    /// <inheritdoc cref="IConfiguration.LicenseInformationTimeoutInSeconds" />
     [DefaultValue(30)]
-    public ConfigurationSetting<int> LicenseInformationTimeout { get; set; }
+    public ConfigurationSetting<int> LicenseInformationTimeoutInSeconds { get; set; }
 
     [DefaultValue(false)]
     public ConfigurationSetting<bool> EnablePackageMetadataParsing { get; set; }

--- a/src/Microsoft.Sbom.Common/Constants.cs
+++ b/src/Microsoft.Sbom.Common/Constants.cs
@@ -13,5 +13,8 @@ public static class Constants
     public const int DefaultParallelism = 8;
     public const int MaxParallelism = 48;
 
+    public const int DefaultLicenseFetchTimeoutInSeconds = 30;
+    public const int MaxLicenseFetchTimeoutInSeconds = 86400;
+
     public const LogEventLevel DefaultLogLevel = LogEventLevel.Warning;
 }

--- a/src/Microsoft.Sbom.Targets/README.md
+++ b/src/Microsoft.Sbom.Targets/README.md
@@ -36,6 +36,7 @@ The custom MSBuild task accepts most of the arguments available for the [SBOM CL
 | `<SbomGenerationNamespaceUriUniquePart>`            | N/A | No |
 | `<SbomGenerationExternalDocumentReferenceListFile>` | N/A | No |
 | `<SbomGenerationFetchLicenseInformation>`           | `false` | No |
+| `<SbomGenerationLicenseInformationTimeoutInSeconds>`| `30` | No |
 | `<SbomGenerationEnablePackageMetadataParsing>`      | `false` | No |
 | `<SbomGenerationVerbosity>`                         | `Information` | No |
 | `<SbomGenerationManifestInfo>`                      | `SPDX:2.2` | No |

--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigSanitizerTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigSanitizerTests.cs
@@ -354,9 +354,8 @@ public class ConfigSanitizerTests
     }
 
     [TestMethod]
-    [DataRow(int.MinValue, DisplayName = "Minimum Value")]
-    [DataRow(0, DisplayName = "Zero is allowed")]
-    [DataRow(int.MaxValue, DisplayName = "Maximum Value")]
+    [DataRow(1, DisplayName = "Minimum value of 1")]
+    [DataRow(Common.Constants.MaxLicenseFetchTimeoutInSeconds, DisplayName = "Maximum Value of 86400")]
     public void LicenseInformationTimeoutInSeconds_SanitizeMakesNoChanges(int value)
     {
         var config = GetConfigurationBaseObject();
@@ -368,6 +367,21 @@ public class ConfigSanitizerTests
     }
 
     [TestMethod]
+    [DataRow(int.MinValue, Common.Constants.DefaultLicenseFetchTimeoutInSeconds, DisplayName = "Negative Value is changed to Default")]
+    [DataRow(0, Common.Constants.DefaultLicenseFetchTimeoutInSeconds, DisplayName = "Zero is changed to Default")]
+    [DataRow(Common.Constants.MaxLicenseFetchTimeoutInSeconds + 1, Common.Constants.MaxLicenseFetchTimeoutInSeconds, DisplayName = "Max Value + 1 is truncated")]
+    [DataRow(int.MaxValue, Common.Constants.MaxLicenseFetchTimeoutInSeconds, DisplayName = "int.MaxValue is truncated")]
+    public void LicenseInformationTimeoutInSeconds_SanitizeExceedsLimits(int value, int expected)
+    {
+        var config = GetConfigurationBaseObject();
+        config.LicenseInformationTimeoutInSeconds = new(value, SettingSource.CommandLine);
+
+        configSanitizer.SanitizeConfig(config);
+
+        Assert.AreEqual(expected, config.LicenseInformationTimeoutInSeconds.Value, "The value of LicenseInformationTimeoutInSeconds should be sanitized to a valid value");
+    }
+
+    [TestMethod]
     public void LicenseInformationTimeoutInSeconds_SanitizeNull()
     {
         var config = GetConfigurationBaseObject();
@@ -375,7 +389,11 @@ public class ConfigSanitizerTests
 
         configSanitizer.SanitizeConfig(config);
 
-        Assert.AreEqual(LicenseInformationFetcher.DefaultTimeoutInSeconds, config.LicenseInformationTimeoutInSeconds.Value, "The value of LicenseInformationTimeoutInSeconds should be set to 30s when null");
+        Assert.AreEqual(
+            Common.Constants.DefaultLicenseFetchTimeoutInSeconds,
+            config.LicenseInformationTimeoutInSeconds.Value,
+            $"The value of LicenseInformationTimeoutInSeconds should be set to {Common.Constants.DefaultLicenseFetchTimeoutInSeconds}s when null");
+
         Assert.AreEqual(SettingSource.Default, config.LicenseInformationTimeoutInSeconds.Source, "The source of LicenseInformationTimeoutInSeconds should be set to Default when null");
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigSanitizerTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigSanitizerTests.cs
@@ -9,6 +9,7 @@ using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using Microsoft.Sbom.Api.Config;
 using Microsoft.Sbom.Api.Exceptions;
+using Microsoft.Sbom.Api.Executors;
 using Microsoft.Sbom.Api.Hashing;
 using Microsoft.Sbom.Api.Utils;
 using Microsoft.Sbom.Common;
@@ -350,5 +351,31 @@ public class ConfigSanitizerTests
             Assert.IsTrue(config.CatalogFilePath.Value.StartsWith($"/{nameof(config.CatalogFilePath)}/", StringComparison.Ordinal));
             Assert.IsTrue(config.TelemetryFilePath.Value.StartsWith($"/{nameof(config.TelemetryFilePath)}/", StringComparison.Ordinal));
         }
+    }
+
+    [TestMethod]
+    [DataRow(int.MinValue, DisplayName = "Minimum Value")]
+    [DataRow(0, DisplayName = "Zero is allowed")]
+    [DataRow(int.MaxValue, DisplayName = "Maximum Value")]
+    public void LicenseInformationTimeoutInSeconds_SanitizeMakesNoChanges(int value)
+    {
+        var config = GetConfigurationBaseObject();
+        config.LicenseInformationTimeoutInSeconds = new(value, SettingSource.CommandLine);
+
+        configSanitizer.SanitizeConfig(config);
+
+        Assert.AreEqual(value, config.LicenseInformationTimeoutInSeconds.Value, "The value of LicenseInformationTimeoutInSeconds should remain the same through the sanitization process");
+    }
+
+    [TestMethod]
+    public void LicenseInformationTimeoutInSeconds_SanitizeNull()
+    {
+        var config = GetConfigurationBaseObject();
+        config.LicenseInformationTimeoutInSeconds = null;
+
+        configSanitizer.SanitizeConfig(config);
+
+        Assert.AreEqual(LicenseInformationFetcher.DefaultTimeoutInSeconds, config.LicenseInformationTimeoutInSeconds.Value, "The value of LicenseInformationTimeoutInSeconds should be set to 30s when null");
+        Assert.AreEqual(SettingSource.Default, config.LicenseInformationTimeoutInSeconds.Source, "The source of LicenseInformationTimeoutInSeconds should be set to Default when null");
     }
 }


### PR DESCRIPTION
- Added new command line argument for generator (lto)
- Modified LicenseInformationService and LicenseInformationFetcher to allow passing timeout as an argument
- Removed hardcoded limit of 30 seconds