### PR TITLE
Expand osx coverage in PR builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
           - windows-latest
           - ubuntu-latest
           - macos-latest
+          - macos-latest-large
 
     env:
         OFFICIAL_BUILD: 'True'


### PR DESCRIPTION
Our current PR coverage matrix currently includes 3 environments, as mapped at https://github.com/actions/runner-images:
`os` in `build.yml` | Runner image | Equivalent .NET target
--- | --- | ---
`windows-latest` | [windows-2022](https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md) | `win-x64`
`ubuntu-latest` | [ubuntu-22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md) | `lnux_x64`
`macos-latest` | [macos-14-arm64](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md) | `osx-arm64`

This PR adds one more row to the matrix:
`os` in `build.yml` | Runner image | Equivalent .NET target
--- | --- | ---
`macos-latest-large` | [macos-14](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md) | `osx-x64`