### PR TITLE
Scrub dotnet 6 references

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,6 @@ jobs:
         uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25 # v4.1.0
         with:
           dotnet-version: |
-            6.0.x
             8.0.x
 
       - name: Run tests

--- a/docs/sbom-tool-api-reference.md
+++ b/docs/sbom-tool-api-reference.md
@@ -5,7 +5,7 @@ Users can use the C#-based SBOM API for calling the SBOM tool. This guide is int
 ## Prerequisites
 
 * A .NET project that can ingest packages from nuget.org.
-* Only projects that target .NET 6 or higher. This API currently provides no support for implementation of .NET Framework for the SBOM API.
+* Only projects that target .NET 8 or higher. This API currently provides no support for implementation of .NET Framework for the SBOM API.
 * Add the **SBOMToolsPublic** repository to the nuget.config.  Verify the project configuration by clicking the **'Connect to Feed'** button on the feed page [here](https://dev.azure.com/mseng/PipelineTools/_artifacts/feed/SBOMToolsPublic)
 
 ## Installation

--- a/docs/setting-up-ado-pipelines.md
+++ b/docs/setting-up-ado-pipelines.md
@@ -14,7 +14,7 @@ steps:
 - task: UseDotNet@2
   inputs:
     packageType: 'sdk'
-    version: '6.x'
+    version: '8.x'
 
 - script: |
     dotnet build $(Build.SourcesDirectory)/Demo.csproj --output $(Build.ArtifactStagingDirectory)
@@ -43,7 +43,7 @@ steps:
 - task: UseDotNet@2
   inputs:
     packageType: 'sdk'
-    version: '6.x'
+    version: '8.x'
 
 - script: |
     dotnet build $(Build.SourcesDirectory)/Demo.csproj --output $(Build.ArtifactStagingDirectory)

--- a/docs/setting-up-github-actions.md
+++ b/docs/setting-up-github-actions.md
@@ -22,7 +22,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
 
     - name: Build
       run: dotnet build Sample.sln --output buildOutput
@@ -58,7 +58,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
     - name: Build
       run: dotnet build Sample.sln --output buildOutput
       


### PR DESCRIPTION
Fix a few places where we were still referencing .NET 6 after updating to .NET 8.