### PR TITLE
Use the fully qualified name for the Zip and Unzip tasks

### DIFF
--- a/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.targets
+++ b/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.targets
@@ -47,7 +47,7 @@
         $([System.IO.Path]::Combine($(PackageOutputFullPath), $(PackageId).$(PackageVersion).$(ShortUnzipGuidFolder).temp))
       </NugetPackageUnzip>
     </PropertyGroup>
-    <Unzip DestinationFolder="$(NugetPackageUnzip)" SourceFiles="$(NugetPackage)" OverwriteReadOnlyFiles="true" ContinueOnError="ErrorAndContinue" />
+    <Microsoft.Build.Tasks.Unzip DestinationFolder="$(NugetPackageUnzip)" SourceFiles="$(NugetPackage)" OverwriteReadOnlyFiles="true" ContinueOnError="ErrorAndContinue" />
 
     <!--
       Call the SBOM task to generate a SBOM. The SBOM will be generated at the BuildDropPath location, which is the root folder
@@ -73,7 +73,7 @@
     </GenerateSbom>
 
     <!-- Zip the Nuget package back up and delete the temporary unzipped package. -->
-    <ZipDirectory SourceDirectory="$(NugetPackageUnzip)" DestinationFile="$(NugetPackage)" Overwrite="true" ContinueOnError="ErrorAndContinue" />
+    <Microsoft.Build.Tasks.ZipDirectory SourceDirectory="$(NugetPackageUnzip)" DestinationFile="$(NugetPackage)" Overwrite="true" ContinueOnError="ErrorAndContinue" />
     <RemoveDir Directories="$(NugetPackageUnzip)" ContinueOnError="WarnAndContinue" />
   </Target>
 </Project>


### PR DESCRIPTION
Use the fully qualified task names Microsoft.Build.Tasks.Unzip and Microsoft.Build.Tasks.ZipDirectory to avoid name collisions with other msbuild task packages. Changes to other msbuild tasks in use like RemoveDir are less necessary as they are less likely to have a name conflict. The Unzip and ZipDirectory are newer msbuild tasks so packages are more likely to have made tasks with the same name in lieu of them not being originally present in the core msbuild tasks.

Resolution to issue #801.

Tested task target changes locally with use of MSBuildCommunityTasks and successfully generated nuget packages that contained the SBOM file.