### PR TITLE
Modified pip extension - get license info from pipcomponent and added…

### DIFF
--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/PipComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/PipComponentExtensions.cs
@@ -24,10 +24,11 @@ internal static class PipComponentExtensions
         PackageUrl = pipComponent.PackageUrl?.ToString(),
         PackageName = pipComponent.Name,
         PackageVersion = pipComponent.Version,
-        LicenseInfo = string.IsNullOrWhiteSpace(component.LicenseConcluded) ? null : new LicenseInfo
+        LicenseInfo = string.IsNullOrWhiteSpace(pipComponent.License) ? null : new LicenseInfo
         {
-            Concluded = component.LicenseConcluded,
+            Declared = pipComponent.License,
         },
+        Supplier = pipComponent.Author,
         FilesAnalyzed = false,
         Type = "python",
         DependOn = component.AncestralReferrers?.FirstOrDefault()?.Id,


### PR DESCRIPTION
… supplier.

For #802 

Noticed that the `component.LicenseConcluded` never had the correct license info from the Component Detection scan manifest files but the `pipComponent` obj did in the `pipComponent.License` attribute.

Added the Supplier as the pipComponent Author. SPDX 2.2 requires the Supplier to be one of:
`Person: ...`
`Organization: ...`

but I think it's more important to capture the author as the supplier even if Person/Org isn't prepended to it. I will remove the supplier if the community does not agree with this.