### PR TITLE
Unbreak build pipeline after most recent drop of Analyzers

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
     <AnalysisLevel>latest</AnalysisLevel>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>$(NoWarn);CA1014;CS8002;CA1416</NoWarn>
+    <NoWarn>$(NoWarn);CA1014;CS8002;CA1416;CA1515;CA1872;CA2263</NoWarn>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
   </PropertyGroup>
 

--- a/src/Microsoft.Sbom.Api/Microsoft.Sbom.Api.csproj
+++ b/src/Microsoft.Sbom.Api/Microsoft.Sbom.Api.csproj
@@ -33,6 +33,7 @@
     <ItemGroup>
         <!-- Pinned assemblies for transitive dependencies -->
         <PackageReference Include="Microsoft.Extensions.Caching.Memory" /> <!-- Used by ComponentDetection -->
+        <PackageReference Include="System.Net.Http" />                     <!-- Used by ComponentDetection -->
     </ItemGroup>
 
     <ItemGroup>

--- a/test/Microsoft.Sbom.Targets.E2E.Tests/GenerateSbomE2ETests.cs
+++ b/test/Microsoft.Sbom.Targets.E2E.Tests/GenerateSbomE2ETests.cs
@@ -310,6 +310,12 @@ public class GenerateSbomE2ETests
     [TestMethod]
     public void SbomGenerationSucceedsForMultiTargetedProject()
     {
+        if (!RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.Ordinal))
+        {
+            Assert.Inconclusive("This test needs to be updated to work with Visual Studio 17.12 and .NET 8. This is tracked at https://github.com/microsoft/sbom-tool/issues/815.");
+            return;
+        }
+
         if (!IsWindows)
         {
             Assert.Inconclusive("This test is not (yet) supported on non-Windows platforms.");

--- a/test/Microsoft.Sbom.Targets.E2E.Tests/Microsoft.Sbom.Targets.E2E.Tests.csproj
+++ b/test/Microsoft.Sbom.Targets.E2E.Tests/Microsoft.Sbom.Targets.E2E.Tests.csproj
@@ -9,6 +9,7 @@
     <SbomCLIToolTargetFramework>net8.0</SbomCLIToolTargetFramework>
     <SBOMCLIToolProjectDir>$(MSBuildThisFileDirectory)..\..\src\Microsoft.Sbom.Tool\</SBOMCLIToolProjectDir>
     <SBOMGenerationTargetsPath>$(MSBuildThisFileDirectory)..\..\src\Microsoft.Sbom.Targets\Microsoft.Sbom.Targets.targets</SBOMGenerationTargetsPath>
+    <NoWarn>CA1515;NU1701;NU1903</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/test/Microsoft.Sbom.Targets.E2E.Tests/Microsoft.Sbom.Targets.E2E.Tests.csproj
+++ b/test/Microsoft.Sbom.Targets.E2E.Tests/Microsoft.Sbom.Targets.E2E.Tests.csproj
@@ -9,7 +9,7 @@
     <SbomCLIToolTargetFramework>net8.0</SbomCLIToolTargetFramework>
     <SBOMCLIToolProjectDir>$(MSBuildThisFileDirectory)..\..\src\Microsoft.Sbom.Tool\</SBOMCLIToolProjectDir>
     <SBOMGenerationTargetsPath>$(MSBuildThisFileDirectory)..\..\src\Microsoft.Sbom.Targets\Microsoft.Sbom.Targets.targets</SBOMGenerationTargetsPath>
-    <NoWarn>CA1515;NU1701;NU1903</NoWarn>
+    <NoWarn>CA1515;NU1903</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/test/Microsoft.Sbom.Targets.E2E.Tests/ProjectSamples/ProjectSample1/ProjectSample1.csproj
+++ b/test/Microsoft.Sbom.Targets.E2E.Tests/ProjectSamples/ProjectSample1/ProjectSample1.csproj
@@ -9,6 +9,7 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+    <NoWarn>CA1515</NoWarn>
   </PropertyGroup>
 
   <!--Ignore errors related to selecting a nuget.config and dependency resolution-->

--- a/test/Microsoft.Sbom.Targets.Tests/Microsoft.Sbom.Targets.Tests.csproj
+++ b/test/Microsoft.Sbom.Targets.Tests/Microsoft.Sbom.Targets.Tests.csproj
@@ -8,7 +8,7 @@
     <RootNamespace>Microsoft.Sbom.Targets.Tests</RootNamespace>
     <SbomCLIToolTargetFramework>net8.0</SbomCLIToolTargetFramework>
     <SBOMCLIToolProjectDir>$(MSBuildThisFileDirectory)..\..\src\Microsoft.Sbom.Tool\</SBOMCLIToolProjectDir>
-    <NoWarn>CA1515;CA1872;NU1701;NU1903</NoWarn>
+    <NoWarn>CA1515;CA1872;NU1903</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/test/Microsoft.Sbom.Targets.Tests/Microsoft.Sbom.Targets.Tests.csproj
+++ b/test/Microsoft.Sbom.Targets.Tests/Microsoft.Sbom.Targets.Tests.csproj
@@ -8,6 +8,7 @@
     <RootNamespace>Microsoft.Sbom.Targets.Tests</RootNamespace>
     <SbomCLIToolTargetFramework>net8.0</SbomCLIToolTargetFramework>
     <SBOMCLIToolProjectDir>$(MSBuildThisFileDirectory)..\..\src\Microsoft.Sbom.Tool\</SBOMCLIToolProjectDir>
+    <NoWarn>CA1515;CA1872;NU1701;NU1903</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
VS just released a new drop with updated analyzers, and our build pipeline is breaking as a result of the new warnings. This PR is to unblock the pipeline, then I'll follow up with more targeted changes to remove as many of the changes as I can arrange. We are suppressing the following specific warnings:

Code | Info page
--- | --- 
`CA1515` | [Consider making public types internal](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1515)
`CA1872` | [Prefer 'Convert.ToHexString' and 'Convert.ToHexStringLower' over call chains based on 'BitConverter.ToString'](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1872)
`CA2263` | [Prefer generic overload when type is known](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2263)

There are known issues with the `net472` build of the `Microsoft.Sbom.Targets.Tests` and `Microsoft.Sbom.Targets.E2E.Tests` projects, caused by an incompatibility between `net472` and current versions of `Microsoft.IO.Redist`. Because of this, we are suppressing 2 additional warnings in just these 2 projects:

Code | Info page
--- | --- 
`NU1701` | [Package 'packageId' was restored using 'TargetFrameworkA' instead the project target framework 'TargetFrameworkB'. This package may not be fully compatible with your project](https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu1701)
`NU1903` | [Package ... has a known ... severity vulnerability](https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu1901-nu1904)

In the `Microsoft.Sbom.Api` project, we explicitly add `System.Net.Http` to force an update of the transitive dependency via the component detection code. We actually ship this assembly, so having the most updated bits felt like the correct approach.
