### PR TITLE
Update MSTest.Test* packages from 3.6.4 to 3.7.0, follow best practices

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,7 @@
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="8.0.2" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="3.6.4" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.7.0" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.7.0" />
     <PackageVersion Include="Microsoft.ComponentDetection.Common" Version="$(ComponentDetectionPackageVersion)" />
     <PackageVersion Include="Microsoft.ComponentDetection.Contracts" Version="$(ComponentDetectionPackageVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="8.0.2" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.6.4" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.6.4" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.7.0" />
     <PackageVersion Include="Microsoft.ComponentDetection.Common" Version="$(ComponentDetectionPackageVersion)" />
     <PackageVersion Include="Microsoft.ComponentDetection.Contracts" Version="$(ComponentDetectionPackageVersion)" />
     <PackageVersion Include="Microsoft.ComponentDetection.Detectors" Version="$(ComponentDetectionPackageVersion)" />

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup Label="Build">
-    <NoWarn>$(NoWarn);MSTEST0005;MSTEST0006;MSTEST0017;MSTEST0024;MSTEST0026;MSTEST0032;MSTEST0034;MSTEST0037</NoWarn>
+    <NoWarn>$(NoWarn);JSON002;MSTEST0005;MSTEST0006;MSTEST0017;MSTEST0024;MSTEST0026;MSTEST0032;MSTEST0034;MSTEST0037</NoWarn>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,5 +1,9 @@
 <Project>
 
+  <PropertyGroup Label="Build">
+    <NoWarn>$(NoWarn);MSTEST0005;MSTEST0006;MSTEST0017;MSTEST0024;MSTEST0026;MSTEST0032;MSTEST0034;MSTEST0037</NoWarn>
+  </PropertyGroup>
+
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>
 
   <ItemGroup Label="Package References">

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup Label="Build">
-    <NoWarn>$(NoWarn);JSON002;MSTEST0024;MSTEST0026;MSTEST0032;MSTEST0034;MSTEST0037</NoWarn>
+    <NoWarn>$(NoWarn);JSON002;MSTEST0026;MSTEST0032;MSTEST0034;MSTEST0037</NoWarn>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup Label="Build">
-    <NoWarn>$(NoWarn);JSON002;MSTEST0017;MSTEST0024;MSTEST0026;MSTEST0032;MSTEST0034;MSTEST0037</NoWarn>
+    <NoWarn>$(NoWarn);JSON002;MSTEST0024;MSTEST0026;MSTEST0032;MSTEST0034;MSTEST0037</NoWarn>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup Label="Build">
-    <NoWarn>$(NoWarn);JSON002;MSTEST0005;MSTEST0006;MSTEST0017;MSTEST0024;MSTEST0026;MSTEST0032;MSTEST0034;MSTEST0037</NoWarn>
+    <NoWarn>$(NoWarn);JSON002;MSTEST0006;MSTEST0017;MSTEST0024;MSTEST0026;MSTEST0032;MSTEST0034;MSTEST0037</NoWarn>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup Label="Build">
-    <NoWarn>$(NoWarn);JSON002;MSTEST0006;MSTEST0017;MSTEST0024;MSTEST0026;MSTEST0032;MSTEST0034;MSTEST0037</NoWarn>
+    <NoWarn>$(NoWarn);JSON002;MSTEST0017;MSTEST0024;MSTEST0026;MSTEST0032;MSTEST0034;MSTEST0037</NoWarn>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup Label="Build">
-    <NoWarn>$(NoWarn);JSON002;MSTEST0026;MSTEST0032;MSTEST0034;MSTEST0037</NoWarn>
+    <NoWarn>$(NoWarn);JSON002;MSTEST0026;MSTEST0032;MSTEST0037</NoWarn>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup Label="Build">
-    <NoWarn>$(NoWarn);JSON002;MSTEST0026;MSTEST0032;MSTEST0037</NoWarn>
+    <NoWarn>$(NoWarn);JSON002;MSTEST0026;MSTEST0032</NoWarn>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup Label="Build">
-    <NoWarn>$(NoWarn);JSON002;MSTEST0032</NoWarn>
+    <NoWarn>$(NoWarn);JSON002</NoWarn>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,9 +1,5 @@
 <Project>
 
-  <PropertyGroup Label="Build">
-    <NoWarn>$(NoWarn);JSON002</NoWarn>
-  </PropertyGroup>
-
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>
 
   <ItemGroup Label="Package References">

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup Label="Build">
-    <NoWarn>$(NoWarn);JSON002;MSTEST0026;MSTEST0032</NoWarn>
+    <NoWarn>$(NoWarn);JSON002;MSTEST0032</NoWarn>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>

--- a/test/Microsoft.Sbom.Adapters.Tests/ComponentDetectionToSBOMPackageAdapterTests.cs
+++ b/test/Microsoft.Sbom.Adapters.Tests/ComponentDetectionToSBOMPackageAdapterTests.cs
@@ -19,13 +19,7 @@ using Microsoft.Sbom.Adapters.ComponentDetection;
 [TestClass]
 public class ComponentDetectionToSBOMPackageAdapterTests
 {
-    private static TestContext testContext;
-
-    [ClassInitialize]
-    public static void SetUp(TestContext testContext)
-    {
-        ComponentDetectionToSBOMPackageAdapterTests.testContext = testContext;
-    }
+    public TestContext TestContext { get; set; }
 
     [TestMethod]
     public void BasicAdapterTest_Succeeds()
@@ -268,7 +262,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
 
     private (AdapterReport report, List<SbomPackage> packages) GenerateJsonFileForTestAndRun(string json)
     {
-        var baseDirectory = Path.Combine(testContext.TestRunDirectory, Guid.NewGuid().ToString());
+        var baseDirectory = Path.Combine(TestContext.TestRunDirectory, Guid.NewGuid().ToString());
         var bcdeOutputPath = Path.Combine(baseDirectory, "bcde-output.json");
 
         Directory.CreateDirectory(baseDirectory);

--- a/test/Microsoft.Sbom.Adapters.Tests/ComponentDetectionToSBOMPackageAdapterTests.cs
+++ b/test/Microsoft.Sbom.Adapters.Tests/ComponentDetectionToSBOMPackageAdapterTests.cs
@@ -53,7 +53,6 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         var (errors, packages) = GenerateJsonFileForTestAndRun(json);
 
         // Successful conversion
-        Assert.IsNotNull(errors.Report);
         Assert.AreEqual(1, errors.Report.Count);
         Assert.AreEqual(AdapterReportItemType.Success, errors.Report.First().Type);
 
@@ -85,7 +84,6 @@ public class ComponentDetectionToSBOMPackageAdapterTests
 
         Assert.IsNotNull(packages);
         Assert.AreEqual(0, packages.Count);
-        Assert.IsNotNull(errors.Report);
         Assert.AreEqual(1, errors.Report.Count); // Should still be successful even with no components
         Assert.AreEqual(AdapterReportItemType.Success, errors.Report.First().Type);
     }
@@ -96,7 +94,6 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         var json = "{";
         var (errors, packages) = GenerateJsonFileForTestAndRun(json);
 
-        Assert.IsNotNull(errors.Report);
         Assert.AreEqual(1, errors.Report.Count);
         Assert.AreEqual(AdapterReportItemType.Failure, errors.Report.First().Type);
         Assert.IsTrue(errors.Report.First().Details.Contains("Unable to parse bcde-output.json", StringComparison.Ordinal));

--- a/test/Microsoft.Sbom.Adapters.Tests/ComponentDetectionToSBOMPackageAdapterTests.cs
+++ b/test/Microsoft.Sbom.Adapters.Tests/ComponentDetectionToSBOMPackageAdapterTests.cs
@@ -54,11 +54,11 @@ public class ComponentDetectionToSBOMPackageAdapterTests
 
         // Successful conversion
         Assert.IsNotNull(errors.Report);
-        Assert.IsTrue(errors.Report?.Count == 1);
-        Assert.IsTrue(errors.Report.First().Type == AdapterReportItemType.Success);
+        Assert.AreEqual(1, errors.Report?.Count);
+        Assert.AreEqual(AdapterReportItemType.Success, errors.Report.First().Type);
 
         // Converted packaged is present and valid
-        Assert.IsTrue(packages?.Count == 1);
+        Assert.AreEqual(1, packages?.Count);
         Assert.IsNotNull(packages[0]);
         Assert.AreEqual("@microsoft/yarn-graph-builder", packages[0].PackageName);
         Assert.AreEqual("1.0.0", packages[0].PackageVersion);
@@ -66,7 +66,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         // This one contains no checksums, so verify that it is null
         Assert.IsNotNull(packages[0].Checksum);
         var checksums = packages[0].Checksum?.ToList();
-        Assert.IsTrue(checksums?.Count == 1);
+        Assert.AreEqual(1, checksums?.Count);
         Assert.IsNull(checksums[0].ChecksumValue);
     }
 
@@ -81,9 +81,9 @@ public class ComponentDetectionToSBOMPackageAdapterTests
                           }";
         var (errors, packages) = GenerateJsonFileForTestAndRun(json);
 
-        Assert.IsTrue(packages?.Count == 0);
-        Assert.IsTrue(errors.Report?.Count == 1); // Should still be successful even with no components
-        Assert.IsTrue(errors.Report.First().Type == AdapterReportItemType.Success);
+        Assert.AreEqual(0, packages?.Count);
+        Assert.AreEqual(1, errors.Report?.Count); // Should still be successful even with no components
+        Assert.AreEqual(AdapterReportItemType.Success, errors.Report.First().Type);
     }
 
     [TestMethod]
@@ -92,10 +92,10 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         var json = "{";
         var (errors, packages) = GenerateJsonFileForTestAndRun(json);
 
-        Assert.IsTrue(errors.Report?.Count == 1);
-        Assert.IsTrue(errors.Report.First().Type == AdapterReportItemType.Failure);
+        Assert.AreEqual(1, errors.Report?.Count);
+        Assert.AreEqual(AdapterReportItemType.Failure, errors.Report.First().Type);
         Assert.IsTrue(errors.Report.First().Details.Contains("Unable to parse bcde-output.json", StringComparison.Ordinal));
-        Assert.IsTrue(packages.Count == 0);
+        Assert.AreEqual(0, packages.Count);
     }
 
     [TestMethod]

--- a/test/Microsoft.Sbom.Adapters.Tests/ComponentDetectionToSBOMPackageAdapterTests.cs
+++ b/test/Microsoft.Sbom.Adapters.Tests/ComponentDetectionToSBOMPackageAdapterTests.cs
@@ -60,8 +60,8 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         // Converted packaged is present and valid
         Assert.IsTrue(packages?.Count == 1);
         Assert.IsNotNull(packages[0]);
-        Assert.AreEqual(packages[0].PackageName, "@microsoft/yarn-graph-builder");
-        Assert.AreEqual(packages[0].PackageVersion, "1.0.0");
+        Assert.AreEqual("@microsoft/yarn-graph-builder", packages[0].PackageName);
+        Assert.AreEqual("1.0.0", packages[0].PackageVersion);
 
         // This one contains no checksums, so verify that it is null
         Assert.IsNotNull(packages[0].Checksum);

--- a/test/Microsoft.Sbom.Adapters.Tests/ComponentDetectionToSBOMPackageAdapterTests.cs
+++ b/test/Microsoft.Sbom.Adapters.Tests/ComponentDetectionToSBOMPackageAdapterTests.cs
@@ -24,6 +24,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
     [TestMethod]
     public void BasicAdapterTest_Succeeds()
     {
+#pragma warning disable JSON002 // Probable JSON string detected
         var json = @"{
                            ""componentsFound"": [
                              {
@@ -50,6 +51,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
                            ""ContainerDetailsMap"": {},
                            ""resultCode"": ""Success""
                          }";
+#pragma warning restore JSON002 // Probable JSON string detected
         var (errors, packages) = GenerateJsonFileForTestAndRun(json);
 
         // Successful conversion
@@ -74,12 +76,14 @@ public class ComponentDetectionToSBOMPackageAdapterTests
     [TestMethod]
     public void NoComponents_Succeeds()
     {
+#pragma warning disable JSON002 // Probable JSON string detected
         var json = @"{
                             ""componentsFound"": [],
                             ""detectorsInScan"": [],
                             ""ContainerDetailsMap"": {},
                             ""resultCode"": ""Success""
                           }";
+#pragma warning restore JSON002 // Probable JSON string detected
         var (errors, packages) = GenerateJsonFileForTestAndRun(json);
 
         Assert.IsNotNull(packages);
@@ -153,8 +157,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
 
         Assert.AreEqual(condaComponent.Id, sbomPackage.Id);
-        Assert.IsNotNull(condaComponent.PackageUrl);
-        Assert.AreEqual(condaComponent.PackageUrl.ToString(), sbomPackage.PackageUrl);
+        AssertPackageUrlIsCorrect(condaComponent.PackageUrl, sbomPackage.PackageUrl);
         Assert.AreEqual(condaComponent.Name, sbomPackage.PackageName);
         Assert.AreEqual(condaComponent.Version, sbomPackage.PackageVersion);
         Assert.AreEqual(condaComponent.Url, sbomPackage.PackageSource);
@@ -170,8 +173,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
 
         Assert.AreEqual(dockerImageComponent.Id, sbomPackage.Id);
-        Assert.IsNotNull(dockerImageComponent.PackageUrl);
-        Assert.AreEqual(dockerImageComponent.PackageUrl.ToString(), sbomPackage.PackageUrl);
+        AssertPackageUrlIsCorrect(dockerImageComponent.PackageUrl, sbomPackage.PackageUrl);
         Assert.AreEqual(dockerImageComponent.Name, sbomPackage.PackageName);
         Assert.AreEqual(AlgorithmName.SHA256, sbomPackage.Checksum.First().Algorithm);
         Assert.AreEqual(dockerImageComponent.Digest, sbomPackage.Checksum.First().ChecksumValue);
@@ -218,7 +220,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
 
         Assert.AreEqual(nuGetComponent.Id, sbomPackage.Id);
-        Assert.IsNotNull(nuGetComponent.PackageUrl);
+        AssertPackageUrlIsCorrect(nuGetComponent.PackageUrl, sbomPackage.PackageUrl);
         Assert.AreEqual(nuGetComponent.PackageUrl.ToString(), sbomPackage.PackageUrl);
         Assert.AreEqual(nuGetComponent.Name, sbomPackage.PackageName);
         Assert.AreEqual(nuGetComponent.Version, sbomPackage.PackageVersion);
@@ -266,8 +268,18 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
 
         Assert.AreEqual(gitComponent.Id, sbomPackage.Id);
-        Assert.IsNotNull(gitComponent.PackageUrl);
-        Assert.AreEqual(gitComponent.PackageUrl.ToString(), sbomPackage.PackageUrl);
+        AssertPackageUrlIsCorrect(gitComponent.PackageUrl, sbomPackage.PackageUrl);
+    }
+
+    private void AssertPackageUrlIsCorrect(PackageUrl.PackageURL expectedPackageUrl, string actualPackageUrl)
+    {
+        if (expectedPackageUrl is null)
+        {
+            Assert.IsNull(actualPackageUrl);
+            return;
+        }
+
+        Assert.AreEqual(expectedPackageUrl.ToString(), actualPackageUrl);
     }
 
     private (AdapterReport report, List<SbomPackage> packages) GenerateJsonFileForTestAndRun(string json)

--- a/test/Microsoft.Sbom.Adapters.Tests/ComponentDetectionToSBOMPackageAdapterTests.cs
+++ b/test/Microsoft.Sbom.Adapters.Tests/ComponentDetectionToSBOMPackageAdapterTests.cs
@@ -54,11 +54,12 @@ public class ComponentDetectionToSBOMPackageAdapterTests
 
         // Successful conversion
         Assert.IsNotNull(errors.Report);
-        Assert.AreEqual(1, errors.Report?.Count);
+        Assert.AreEqual(1, errors.Report.Count);
         Assert.AreEqual(AdapterReportItemType.Success, errors.Report.First().Type);
 
         // Converted packaged is present and valid
-        Assert.AreEqual(1, packages?.Count);
+        Assert.IsNotNull(packages);
+        Assert.AreEqual(1, packages.Count);
         Assert.IsNotNull(packages[0]);
         Assert.AreEqual("@microsoft/yarn-graph-builder", packages[0].PackageName);
         Assert.AreEqual("1.0.0", packages[0].PackageVersion);
@@ -66,7 +67,8 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         // This one contains no checksums, so verify that it is null
         Assert.IsNotNull(packages[0].Checksum);
         var checksums = packages[0].Checksum?.ToList();
-        Assert.AreEqual(1, checksums?.Count);
+        Assert.IsNotNull(checksums);
+        Assert.AreEqual(1, checksums.Count);
         Assert.IsNull(checksums[0].ChecksumValue);
     }
 
@@ -81,8 +83,10 @@ public class ComponentDetectionToSBOMPackageAdapterTests
                           }";
         var (errors, packages) = GenerateJsonFileForTestAndRun(json);
 
-        Assert.AreEqual(0, packages?.Count);
-        Assert.AreEqual(1, errors.Report?.Count); // Should still be successful even with no components
+        Assert.IsNotNull(packages);
+        Assert.AreEqual(0, packages.Count);
+        Assert.IsNotNull(errors.Report);
+        Assert.AreEqual(1, errors.Report.Count); // Should still be successful even with no components
         Assert.AreEqual(AdapterReportItemType.Success, errors.Report.First().Type);
     }
 
@@ -92,7 +96,8 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         var json = "{";
         var (errors, packages) = GenerateJsonFileForTestAndRun(json);
 
-        Assert.AreEqual(1, errors.Report?.Count);
+        Assert.IsNotNull(errors.Report);
+        Assert.AreEqual(1, errors.Report.Count);
         Assert.AreEqual(AdapterReportItemType.Failure, errors.Report.First().Type);
         Assert.IsTrue(errors.Report.First().Details.Contains("Unable to parse bcde-output.json", StringComparison.Ordinal));
         Assert.AreEqual(0, packages.Count);
@@ -151,7 +156,8 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
 
         Assert.AreEqual(condaComponent.Id, sbomPackage.Id);
-        Assert.AreEqual(condaComponent.PackageUrl?.ToString(), sbomPackage.PackageUrl);
+        Assert.IsNotNull(condaComponent.PackageUrl);
+        Assert.AreEqual(condaComponent.PackageUrl.ToString(), sbomPackage.PackageUrl);
         Assert.AreEqual(condaComponent.Name, sbomPackage.PackageName);
         Assert.AreEqual(condaComponent.Version, sbomPackage.PackageVersion);
         Assert.AreEqual(condaComponent.Url, sbomPackage.PackageSource);
@@ -167,7 +173,8 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
 
         Assert.AreEqual(dockerImageComponent.Id, sbomPackage.Id);
-        Assert.AreEqual(dockerImageComponent.PackageUrl?.ToString(), sbomPackage.PackageUrl);
+        Assert.IsNotNull(dockerImageComponent.PackageUrl);
+        Assert.AreEqual(dockerImageComponent.PackageUrl.ToString(), sbomPackage.PackageUrl);
         Assert.AreEqual(dockerImageComponent.Name, sbomPackage.PackageName);
         Assert.AreEqual(AlgorithmName.SHA256, sbomPackage.Checksum.First().Algorithm);
         Assert.AreEqual(dockerImageComponent.Digest, sbomPackage.Checksum.First().ChecksumValue);
@@ -182,7 +189,8 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
 
         Assert.AreEqual(npmComponent.Id, sbomPackage.Id);
-        Assert.AreEqual(npmComponent.PackageUrl?.ToString(), sbomPackage.PackageUrl);
+        Assert.IsNotNull(npmComponent.PackageUrl);
+        Assert.AreEqual(npmComponent.PackageUrl.ToString(), sbomPackage.PackageUrl);
         Assert.AreEqual(npmComponent.Name, sbomPackage.PackageName);
         Assert.AreEqual(npmComponent.Version, sbomPackage.PackageVersion);
         Assert.AreEqual($"Organization: {npmComponent.Author.Name} ({npmComponent.Author.Email})", sbomPackage.Supplier);
@@ -197,7 +205,8 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
 
         Assert.AreEqual(npmComponent.Id, sbomPackage.Id);
-        Assert.AreEqual(npmComponent.PackageUrl?.ToString(), sbomPackage.PackageUrl);
+        Assert.IsNotNull(npmComponent.PackageUrl);
+        Assert.AreEqual(npmComponent.PackageUrl.ToString(), sbomPackage.PackageUrl);
         Assert.AreEqual(npmComponent.Name, sbomPackage.PackageName);
         Assert.AreEqual(npmComponent.Version, sbomPackage.PackageVersion);
         Assert.IsNull(sbomPackage.Supplier);
@@ -212,7 +221,8 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
 
         Assert.AreEqual(nuGetComponent.Id, sbomPackage.Id);
-        Assert.AreEqual(nuGetComponent.PackageUrl?.ToString(), sbomPackage.PackageUrl);
+        Assert.IsNotNull(nuGetComponent.PackageUrl);
+        Assert.AreEqual(nuGetComponent.PackageUrl.ToString(), sbomPackage.PackageUrl);
         Assert.AreEqual(nuGetComponent.Name, sbomPackage.PackageName);
         Assert.AreEqual(nuGetComponent.Version, sbomPackage.PackageVersion);
         Assert.AreEqual($"Organization: {nuGetComponent.Authors.First()}", sbomPackage.Supplier);
@@ -227,7 +237,8 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
 
         Assert.AreEqual(nuGetComponent.Id, sbomPackage.Id);
-        Assert.AreEqual(nuGetComponent.PackageUrl?.ToString(), sbomPackage.PackageUrl);
+        Assert.IsNotNull(nuGetComponent.PackageUrl);
+        Assert.AreEqual(nuGetComponent.PackageUrl.ToString(), sbomPackage.PackageUrl);
         Assert.AreEqual(nuGetComponent.Name, sbomPackage.PackageName);
         Assert.AreEqual(nuGetComponent.Version, sbomPackage.PackageVersion);
         Assert.IsNull(sbomPackage.Supplier);
@@ -242,7 +253,8 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
 
         Assert.AreEqual(pipComponent.Id, sbomPackage.Id);
-        Assert.AreEqual(pipComponent.PackageUrl?.ToString(), sbomPackage.PackageUrl);
+        Assert.IsNotNull(pipComponent.PackageUrl);
+        Assert.AreEqual(pipComponent.PackageUrl.ToString(), sbomPackage.PackageUrl);
         Assert.AreEqual(pipComponent.Name, sbomPackage.PackageName);
         Assert.AreEqual(pipComponent.Version, sbomPackage.PackageVersion);
     }
@@ -257,7 +269,8 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
 
         Assert.AreEqual(gitComponent.Id, sbomPackage.Id);
-        Assert.AreEqual(gitComponent.PackageUrl?.ToString(), sbomPackage.PackageUrl);
+        Assert.IsNotNull(gitComponent.PackageUrl);
+        Assert.AreEqual(gitComponent.PackageUrl.ToString(), sbomPackage.PackageUrl);
     }
 
     private (AdapterReport report, List<SbomPackage> packages) GenerateJsonFileForTestAndRun(string json)

--- a/test/Microsoft.Sbom.Api.Tests/ApiConfigurationBuilderTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/ApiConfigurationBuilderTests.cs
@@ -174,23 +174,20 @@ public class ApiConfigurationBuilderTests
     [TestMethod]
     [DataRow(" ")]
     [DataRow(null)]
-    [ExpectedException(typeof(ArgumentException))]
     public void ThrowArgumentExceptionOnRootPathValues(string input)
     {
-        ApiConfigurationBuilder.GetConfiguration(input, null, null, null, null);
+        Assert.ThrowsException<ArgumentException>(() => ApiConfigurationBuilder.GetConfiguration(input, null, null, null, null));
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentNullException))]
     public void ThrowArgumentNulExceptionOnNullMetadata()
     {
-        ApiConfigurationBuilder.GetConfiguration("random", null, null, null, null);
+        Assert.ThrowsException<ArgumentNullException>(() => ApiConfigurationBuilder.GetConfiguration("random", null, null, null, null));
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentException))]
     public void ThrowArgumentExceptionOnSpecificationZero()
     {
-        ApiConfigurationBuilder.GetConfiguration("random", null, null, null, metadata, new List<SbomSpecification>(), runtime);
+        Assert.ThrowsException<ArgumentException>(() => ApiConfigurationBuilder.GetConfiguration("random", null, null, null, metadata, new List<SbomSpecification>(), runtime));
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigSanitizerTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigSanitizerTests.cs
@@ -103,14 +103,13 @@ public class ConfigSanitizerTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ValidationArgException))]
     public void NoValueForManifestInfoForValidation_Throws()
     {
         var config = GetConfigurationBaseObject();
         config.ManifestToolAction = ManifestToolActions.Validate;
         config.ManifestInfo.Value.Clear();
 
-        configSanitizer.SanitizeConfig(config);
+        Assert.ThrowsException<ValidationArgException>(() => configSanitizer.SanitizeConfig(config));
     }
 
     [TestMethod]
@@ -190,13 +189,12 @@ public class ConfigSanitizerTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(UnsupportedHashAlgorithmException))]
     public void ForValidateBadAlgorithmNameGetsRealAlgorithmName_Throws()
     {
         var config = GetConfigurationBaseObject();
         config.HashAlgorithm.Value = new AlgorithmName("a", null);
         config.ManifestToolAction = ManifestToolActions.Validate;
-        configSanitizer.SanitizeConfig(config);
+        Assert.ThrowsException<UnsupportedHashAlgorithmException>(() => configSanitizer.SanitizeConfig(config));
     }
 
     [TestMethod]

--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigSanitizerTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigSanitizerTests.cs
@@ -317,7 +317,7 @@ public class ConfigSanitizerTests
         config.ManifestToolAction = ManifestToolActions.Validate;
         configSanitizer.SanitizeConfig(config);
 
-        Assert.AreEqual(actualOrg, config.PackageSupplier.Value);
+        Assert.AreEqual(config.PackageSupplier.Value, actualOrg);
     }
 
     [TestMethod]

--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForGeneration.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForGeneration.cs
@@ -82,8 +82,7 @@ public class ConfigurationBuilderTestsForGeneration : ConfigurationBuilderTestsB
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ValidationArgException))]
-    public async Task ConfigurationBuilderTest_Generation_BuildDropPathDoNotExist_Throws()
+    public void ConfigurationBuilderTest_Generation_BuildDropPathDoNotExist_Throws()
     {
         var configFileParser = new ConfigFileParser(fileSystemUtilsMock.Object);
         var cb = new ConfigurationBuilder<GenerationArgs>(mapper, configFileParser);
@@ -97,12 +96,11 @@ public class ConfigurationBuilderTestsForGeneration : ConfigurationBuilderTestsB
             PackageSupplier = "Contoso"
         };
 
-        var configuration = await cb.GetConfiguration(args);
+        Assert.ThrowsExceptionAsync<ValidationArgException>(() => cb.GetConfiguration(args));
     }
 
     [TestMethod]
-    [ExpectedException(typeof(AccessDeniedValidationArgException))]
-    public async Task ConfigurationBuilderTest_Generation_BuildDropPathNotWriteAccess_Throws()
+    public void ConfigurationBuilderTest_Generation_BuildDropPathNotWriteAccess_Throws()
     {
         var configFileParser = new ConfigFileParser(fileSystemUtilsMock.Object);
         var cb = new ConfigurationBuilder<GenerationArgs>(mapper, configFileParser);
@@ -118,7 +116,7 @@ public class ConfigurationBuilderTestsForGeneration : ConfigurationBuilderTestsB
             PackageSupplier = "Contoso"
         };
 
-        var configuration = await cb.GetConfiguration(args);
+        Assert.ThrowsExceptionAsync<AccessDeniedValidationArgException>(() => cb.GetConfiguration(args));
     }
 
     [TestMethod]
@@ -277,8 +275,7 @@ public class ConfigurationBuilderTestsForGeneration : ConfigurationBuilderTestsB
     [DataRow("https://")]
     [DataRow("ww.com")]
     [DataRow("https//test.com")]
-    [ExpectedException(typeof(ValidationArgException), "The value of NamespaceUriBase must be a valid URI.")]
-    public async Task ConfigurationBuilderTest_Generation_BadNSBaseUri_Fails(string badNsUri)
+    public void ConfigurationBuilderTest_Generation_BadNSBaseUri_Fails(string badNsUri)
     {
         var configFileParser = new ConfigFileParser(fileSystemUtilsMock.Object);
         var cb = new ConfigurationBuilder<GenerationArgs>(mapper, configFileParser);
@@ -296,6 +293,6 @@ public class ConfigurationBuilderTestsForGeneration : ConfigurationBuilderTestsB
             PackageSupplier = "Contoso"
         };
 
-        var config = await cb.GetConfiguration(args);
+        Assert.ThrowsExceptionAsync<ValidationArgException>(() => cb.GetConfiguration(args));
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForGeneration.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForGeneration.cs
@@ -82,7 +82,7 @@ public class ConfigurationBuilderTestsForGeneration : ConfigurationBuilderTestsB
     }
 
     [TestMethod]
-    public void ConfigurationBuilderTest_Generation_BuildDropPathDoNotExist_Throws()
+    public async Task ConfigurationBuilderTest_Generation_BuildDropPathDoNotExist_Throws()
     {
         var configFileParser = new ConfigFileParser(fileSystemUtilsMock.Object);
         var cb = new ConfigurationBuilder<GenerationArgs>(mapper, configFileParser);
@@ -96,11 +96,11 @@ public class ConfigurationBuilderTestsForGeneration : ConfigurationBuilderTestsB
             PackageSupplier = "Contoso"
         };
 
-        Assert.ThrowsExceptionAsync<ValidationArgException>(() => cb.GetConfiguration(args));
+        await Assert.ThrowsExceptionAsync<ValidationArgException>(() => cb.GetConfiguration(args));
     }
 
     [TestMethod]
-    public void ConfigurationBuilderTest_Generation_BuildDropPathNotWriteAccess_Throws()
+    public async Task ConfigurationBuilderTest_Generation_BuildDropPathNotWriteAccess_Throws()
     {
         var configFileParser = new ConfigFileParser(fileSystemUtilsMock.Object);
         var cb = new ConfigurationBuilder<GenerationArgs>(mapper, configFileParser);
@@ -116,7 +116,7 @@ public class ConfigurationBuilderTestsForGeneration : ConfigurationBuilderTestsB
             PackageSupplier = "Contoso"
         };
 
-        Assert.ThrowsExceptionAsync<AccessDeniedValidationArgException>(() => cb.GetConfiguration(args));
+        await Assert.ThrowsExceptionAsync<AccessDeniedValidationArgException>(() => cb.GetConfiguration(args));
     }
 
     [TestMethod]
@@ -275,7 +275,7 @@ public class ConfigurationBuilderTestsForGeneration : ConfigurationBuilderTestsB
     [DataRow("https://")]
     [DataRow("ww.com")]
     [DataRow("https//test.com")]
-    public void ConfigurationBuilderTest_Generation_BadNSBaseUri_Fails(string badNsUri)
+    public async Task ConfigurationBuilderTest_Generation_BadNSBaseUri_Fails(string badNsUri)
     {
         var configFileParser = new ConfigFileParser(fileSystemUtilsMock.Object);
         var cb = new ConfigurationBuilder<GenerationArgs>(mapper, configFileParser);
@@ -293,6 +293,6 @@ public class ConfigurationBuilderTestsForGeneration : ConfigurationBuilderTestsB
             PackageSupplier = "Contoso"
         };
 
-        Assert.ThrowsExceptionAsync<ValidationArgException>(() => cb.GetConfiguration(args), "The value of NamespaceUriBase must be a valid URI.");
+        await Assert.ThrowsExceptionAsync<ValidationArgException>(() => cb.GetConfiguration(args), "The value of NamespaceUriBase must be a valid URI.");
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForGeneration.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForGeneration.cs
@@ -293,6 +293,6 @@ public class ConfigurationBuilderTestsForGeneration : ConfigurationBuilderTestsB
             PackageSupplier = "Contoso"
         };
 
-        Assert.ThrowsExceptionAsync<ValidationArgException>(() => cb.GetConfiguration(args));
+        Assert.ThrowsExceptionAsync<ValidationArgException>(() => cb.GetConfiguration(args), "The value of NamespaceUriBase must be a valid URI.");
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForGeneration.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForGeneration.cs
@@ -45,9 +45,9 @@ public class ConfigurationBuilderTestsForGeneration : ConfigurationBuilderTestsB
 
         var configuration = await cb.GetConfiguration(args);
 
-        Assert.AreEqual(configuration.BuildDropPath.Source, SettingSource.CommandLine);
-        Assert.AreEqual(configuration.ConfigFilePath.Source, SettingSource.CommandLine);
-        Assert.AreEqual(configuration.ManifestInfo.Source, SettingSource.JsonConfig);
+        Assert.AreEqual(SettingSource.CommandLine, configuration.BuildDropPath.Source);
+        Assert.AreEqual(SettingSource.CommandLine, configuration.ConfigFilePath.Source);
+        Assert.AreEqual(SettingSource.JsonConfig, configuration.ManifestInfo.Source);
 
         fileSystemUtilsMock.VerifyAll();
     }
@@ -74,9 +74,9 @@ public class ConfigurationBuilderTestsForGeneration : ConfigurationBuilderTestsB
 
         var configuration = await cb.GetConfiguration(args);
 
-        Assert.AreEqual(configuration.BuildDropPath.Source, SettingSource.CommandLine);
-        Assert.AreEqual(configuration.ConfigFilePath.Source, SettingSource.CommandLine);
-        Assert.AreEqual(configuration.ManifestInfo.Source, SettingSource.JsonConfig);
+        Assert.AreEqual(SettingSource.CommandLine, configuration.BuildDropPath.Source);
+        Assert.AreEqual(SettingSource.CommandLine, configuration.ConfigFilePath.Source);
+        Assert.AreEqual(SettingSource.JsonConfig, configuration.ManifestInfo.Source);
 
         fileSystemUtilsMock.VerifyAll();
     }
@@ -173,7 +173,7 @@ public class ConfigurationBuilderTestsForGeneration : ConfigurationBuilderTestsB
         Assert.IsNotNull(config.ManifestDirPath);
 
         var expectedPath = Path.Join("ManifestDirPath", Constants.ManifestFolder);
-        Assert.AreEqual(Path.GetFullPath(expectedPath), Path.GetFullPath(config.ManifestDirPath.Value));
+        Assert.AreEqual(Path.GetFullPath(config.ManifestDirPath.Value), Path.GetFullPath(expectedPath));
 
         fileSystemUtilsMock.VerifyAll();
     }
@@ -203,7 +203,7 @@ public class ConfigurationBuilderTestsForGeneration : ConfigurationBuilderTestsB
         Assert.IsNotNull(config.ManifestDirPath);
 
         var expectedPath = Path.Join("ManifestDirPath", Constants.ManifestFolder);
-        Assert.AreEqual(Path.GetFullPath(expectedPath), Path.GetFullPath(config.ManifestDirPath.Value));
+        Assert.AreEqual(Path.GetFullPath(config.ManifestDirPath.Value), Path.GetFullPath(expectedPath));
 
         fileSystemUtilsMock.VerifyAll();
     }
@@ -235,7 +235,7 @@ public class ConfigurationBuilderTestsForGeneration : ConfigurationBuilderTestsB
         Assert.IsNotNull(config.ManifestDirPath);
 
         var expectedPath = Path.Join("ManifestDirPath", Constants.ManifestFolder);
-        Assert.AreEqual(Path.GetFullPath(expectedPath), Path.GetFullPath(config.ManifestDirPath.Value));
+        Assert.AreEqual(Path.GetFullPath(config.ManifestDirPath.Value), Path.GetFullPath(expectedPath));
 
         fileSystemUtilsMock.VerifyAll();
         mockAssemblyConfig.VerifyGet(a => a.DefaultSBOMNamespaceBaseUri);
@@ -265,7 +265,7 @@ public class ConfigurationBuilderTestsForGeneration : ConfigurationBuilderTestsB
         Assert.IsNotNull(config);
         Assert.IsNotNull(args.ManifestDirPath);
         Assert.IsNotNull(config.NamespaceUriBase);
-        Assert.AreEqual(Path.Join("ManifestDirPath", Constants.ManifestFolder), config.ManifestDirPath.Value);
+        Assert.AreEqual(config.ManifestDirPath.Value, Path.Join("ManifestDirPath", Constants.ManifestFolder));
 
         fileSystemUtilsMock.VerifyAll();
     }

--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForRedact.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForRedact.cs
@@ -46,8 +46,7 @@ public class ConfigurationBuilderTestsForRedact : ConfigurationBuilderTestsBase
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ValidationArgException))]
-    public async Task ConfigurationBuilderTest_Redact_OuputPathNotWriteAccess_Throws()
+    public void ConfigurationBuilderTest_Redact_OuputPathNotWriteAccess_Throws()
     {
         var configFileParser = new ConfigFileParser(fileSystemUtilsMock.Object);
         var cb = new ConfigurationBuilder<RedactArgs>(mapper, configFileParser);
@@ -62,6 +61,6 @@ public class ConfigurationBuilderTestsForRedact : ConfigurationBuilderTestsBase
             OutputPath = "OutputPath"
         };
 
-        var configuration = await cb.GetConfiguration(args);
+        Assert.ThrowsExceptionAsync<ValidationArgException>(() => cb.GetConfiguration(args));
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForRedact.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForRedact.cs
@@ -39,8 +39,8 @@ public class ConfigurationBuilderTestsForRedact : ConfigurationBuilderTestsBase
 
         var configuration = await cb.GetConfiguration(args);
 
-        Assert.AreEqual(configuration.SbomDir.Source, SettingSource.CommandLine);
-        Assert.AreEqual(configuration.OutputPath.Source, SettingSource.CommandLine);
+        Assert.AreEqual(SettingSource.CommandLine, configuration.SbomDir.Source);
+        Assert.AreEqual(SettingSource.CommandLine, configuration.OutputPath.Source);
 
         fileSystemUtilsMock.VerifyAll();
     }

--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForRedact.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForRedact.cs
@@ -46,7 +46,7 @@ public class ConfigurationBuilderTestsForRedact : ConfigurationBuilderTestsBase
     }
 
     [TestMethod]
-    public void ConfigurationBuilderTest_Redact_OuputPathNotWriteAccess_Throws()
+    public async Task ConfigurationBuilderTest_Redact_OuputPathNotWriteAccess_Throws()
     {
         var configFileParser = new ConfigFileParser(fileSystemUtilsMock.Object);
         var cb = new ConfigurationBuilder<RedactArgs>(mapper, configFileParser);
@@ -61,6 +61,6 @@ public class ConfigurationBuilderTestsForRedact : ConfigurationBuilderTestsBase
             OutputPath = "OutputPath"
         };
 
-        Assert.ThrowsExceptionAsync<ValidationArgException>(() => cb.GetConfiguration(args));
+        await Assert.ThrowsExceptionAsync<ValidationArgException>(() => cb.GetConfiguration(args));
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForValidation.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForValidation.cs
@@ -91,8 +91,7 @@ public class ConfigurationBuilderTestsForValidation : ConfigurationBuilderTestsB
     }
 
     [TestMethod]
-    [ExpectedException(typeof(AutoMapperMappingException))]
-    public async Task ConfigurationBuilderTest_CombinesConfigs_DuplicateConfig_Throws()
+    public void ConfigurationBuilderTest_CombinesConfigs_DuplicateConfig_Throws()
     {
         var configFileParser = new ConfigFileParser(fileSystemUtilsMock.Object);
         var cb = new ConfigurationBuilder<ValidationArgs>(mapper, configFileParser);
@@ -107,12 +106,11 @@ public class ConfigurationBuilderTestsForValidation : ConfigurationBuilderTestsB
             ManifestDirPath = "ManifestPath"
         };
 
-        var configuration = await cb.GetConfiguration(args);
+        Assert.ThrowsExceptionAsync<AutoMapperMappingException>(() => cb.GetConfiguration(args));
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ValidationArgException))]
-    public async Task ConfigurationBuilderTest_CombinesConfigs_NegativeParallism_Throws()
+    public void ConfigurationBuilderTest_CombinesConfigs_NegativeParallism_Throws()
     {
         var configFileParser = new ConfigFileParser(fileSystemUtilsMock.Object);
         var cb = new ConfigurationBuilder<ValidationArgs>(mapper, configFileParser);
@@ -127,7 +125,7 @@ public class ConfigurationBuilderTestsForValidation : ConfigurationBuilderTestsB
             Parallelism = -1
         };
 
-        var configuration = await cb.GetConfiguration(args);
+        Assert.ThrowsExceptionAsync<ValidationArgException>(() => cb.GetConfiguration(args));
     }
 
     [TestMethod]

--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForValidation.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForValidation.cs
@@ -46,12 +46,12 @@ public class ConfigurationBuilderTestsForValidation : ConfigurationBuilderTestsB
 
         var configuration = await cb.GetConfiguration(args);
 
-        Assert.AreEqual(configuration.BuildDropPath.Source, SettingSource.CommandLine);
-        Assert.AreEqual(configuration.ConfigFilePath.Source, SettingSource.CommandLine);
-        Assert.AreEqual(configuration.OutputPath.Source, SettingSource.CommandLine);
-        Assert.AreEqual(configuration.Parallelism.Source, SettingSource.Default);
-        Assert.AreEqual(configuration.Parallelism.Value, Common.Constants.DefaultParallelism);
-        Assert.AreEqual(configuration.HashAlgorithm.Source, SettingSource.CommandLine);
+        Assert.AreEqual(SettingSource.CommandLine, configuration.BuildDropPath.Source);
+        Assert.AreEqual(SettingSource.CommandLine, configuration.ConfigFilePath.Source);
+        Assert.AreEqual(SettingSource.CommandLine, configuration.OutputPath.Source);
+        Assert.AreEqual(SettingSource.Default, configuration.Parallelism.Source);
+        Assert.AreEqual(Common.Constants.DefaultParallelism, configuration.Parallelism.Value);
+        Assert.AreEqual(SettingSource.CommandLine, configuration.HashAlgorithm.Source);
         Assert.AreEqual(configuration.HashAlgorithm.Value, AlgorithmName.SHA512);
 
         fileSystemUtilsMock.VerifyAll();
@@ -80,12 +80,12 @@ public class ConfigurationBuilderTestsForValidation : ConfigurationBuilderTestsB
 
         var configuration = await cb.GetConfiguration(args);
 
-        Assert.AreEqual(configuration.BuildDropPath.Source, SettingSource.CommandLine);
-        Assert.AreEqual(configuration.ConfigFilePath.Source, SettingSource.CommandLine);
-        Assert.AreEqual(configuration.OutputPath.Source, SettingSource.CommandLine);
-        Assert.AreEqual(configuration.Parallelism.Source, SettingSource.CommandLine);
-        Assert.AreEqual(configuration.Verbosity.Value, Serilog.Events.LogEventLevel.Fatal);
-        Assert.AreEqual(configuration.Verbosity.Source, SettingSource.CommandLine);
+        Assert.AreEqual(SettingSource.CommandLine, configuration.BuildDropPath.Source);
+        Assert.AreEqual(SettingSource.CommandLine, configuration.ConfigFilePath.Source);
+        Assert.AreEqual(SettingSource.CommandLine, configuration.OutputPath.Source);
+        Assert.AreEqual(SettingSource.CommandLine, configuration.Parallelism.Source);
+        Assert.AreEqual(Serilog.Events.LogEventLevel.Fatal, configuration.Verbosity.Value);
+        Assert.AreEqual(SettingSource.CommandLine, configuration.Verbosity.Source);
 
         fileSystemUtilsMock.VerifyAll();
     }

--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForValidation.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForValidation.cs
@@ -91,7 +91,7 @@ public class ConfigurationBuilderTestsForValidation : ConfigurationBuilderTestsB
     }
 
     [TestMethod]
-    public void ConfigurationBuilderTest_CombinesConfigs_DuplicateConfig_Throws()
+    public async Task ConfigurationBuilderTest_CombinesConfigs_DuplicateConfig_Throws()
     {
         var configFileParser = new ConfigFileParser(fileSystemUtilsMock.Object);
         var cb = new ConfigurationBuilder<ValidationArgs>(mapper, configFileParser);
@@ -106,11 +106,11 @@ public class ConfigurationBuilderTestsForValidation : ConfigurationBuilderTestsB
             ManifestDirPath = "ManifestPath"
         };
 
-        Assert.ThrowsExceptionAsync<AutoMapperMappingException>(() => cb.GetConfiguration(args));
+        await Assert.ThrowsExceptionAsync<AutoMapperMappingException>(() => cb.GetConfiguration(args));
     }
 
     [TestMethod]
-    public void ConfigurationBuilderTest_CombinesConfigs_NegativeParallism_Throws()
+    public async Task ConfigurationBuilderTest_CombinesConfigs_NegativeParallism_Throws()
     {
         var configFileParser = new ConfigFileParser(fileSystemUtilsMock.Object);
         var cb = new ConfigurationBuilder<ValidationArgs>(mapper, configFileParser);
@@ -125,7 +125,7 @@ public class ConfigurationBuilderTestsForValidation : ConfigurationBuilderTestsB
             Parallelism = -1
         };
 
-        Assert.ThrowsExceptionAsync<ValidationArgException>(() => cb.GetConfiguration(args));
+        await Assert.ThrowsExceptionAsync<ValidationArgException>(() => cb.GetConfiguration(args));
     }
 
     [TestMethod]

--- a/test/Microsoft.Sbom.Api.Tests/Config/Validators/DirectoryPathIsWritableValidatorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/Validators/DirectoryPathIsWritableValidatorTests.cs
@@ -17,18 +17,16 @@ public class DirectoryPathIsWritableValidatorTests
     private readonly Mock<IAssemblyConfig> mockAssemblyConfig = new Mock<IAssemblyConfig>();
 
     [TestMethod]
-    [ExpectedException(typeof(ValidationArgException))]
     public void WhenDirectoryDoesNotExistsThrows()
     {
         var fileSystemUtilsMock = new Mock<IFileSystemUtils>();
         fileSystemUtilsMock.Setup(f => f.DirectoryExists(It.IsAny<string>())).Returns(false).Verifiable();
 
         var validator = new DirectoryPathIsWritableValidator(fileSystemUtilsMock.Object, mockAssemblyConfig.Object);
-        validator.ValidateInternal("property", "value", null);
+        Assert.ThrowsException<ValidationArgException>(() => validator.ValidateInternal("property", "value", null));
     }
 
     [TestMethod]
-    [ExpectedException(typeof(AccessDeniedValidationArgException))]
     public void WhenDirectoryDoesNotHaveWriteAccessThrows()
     {
         var fileSystemUtilsMock = new Mock<IFileSystemUtils>();
@@ -36,7 +34,7 @@ public class DirectoryPathIsWritableValidatorTests
         fileSystemUtilsMock.Setup(f => f.DirectoryHasWritePermissions(It.IsAny<string>())).Returns(false).Verifiable();
 
         var validator = new DirectoryPathIsWritableValidator(fileSystemUtilsMock.Object, mockAssemblyConfig.Object);
-        validator.ValidateInternal("property", "value", null);
+        Assert.ThrowsException<AccessDeniedValidationArgException>(() => validator.ValidateInternal("property", "value", null));
     }
 
     [TestMethod]

--- a/test/Microsoft.Sbom.Api.Tests/Converters/ComponentToExternalReferenceInfoConverterTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Converters/ComponentToExternalReferenceInfoConverterTests.cs
@@ -109,7 +109,7 @@ public class ComponentToExternalReferenceInfoConverterTests
         var refs = await results.ReadAllAsync().ToListAsync();
         var errorList = await errors.ReadAllAsync().ToListAsync();
 
-        Assert.IsTrue(errorList.Count == scannedComponents.Where(c => !(c.Component is SpdxComponent)).ToList().Count);
-        Assert.IsTrue(refs.Count == scannedComponents.Where(c => c.Component is SpdxComponent).ToList().Count);
+        Assert.AreEqual(scannedComponents.Where(c => !(c.Component is SpdxComponent)).ToList().Count, errorList.Count);
+        Assert.AreEqual(scannedComponents.Where(c => c.Component is SpdxComponent).ToList().Count, refs.Count);
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/Converters/ExternalReferenceInfoToPathConverterTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Converters/ExternalReferenceInfoToPathConverterTest.cs
@@ -69,7 +69,7 @@ public class ExternalReferenceInfoToPathConverterTest
             count++;
         }
 
-        Assert.IsTrue(paths.Count == externalDocRefs.Count);
+        Assert.AreEqual(externalDocRefs.Count, paths.Count);
     }
 
     [TestMethod]
@@ -113,7 +113,7 @@ public class ExternalReferenceInfoToPathConverterTest
             Assert.Fail($"Caught exception: {error.ErrorType}");
         }
 
-        Assert.IsTrue(paths.Count == 3);
-        Assert.IsTrue(errorList.Count == 1);
+        Assert.AreEqual(3, paths.Count);
+        Assert.AreEqual(1, errorList.Count);
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/Converters/SbomToolManifestPathConverterTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Converters/SbomToolManifestPathConverterTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Sbom.Common;
 using Microsoft.Sbom.Common.Config;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using PowerArgs;
 
 namespace Microsoft.Sbom.Api.Convertors.Tests;
 
@@ -161,7 +162,6 @@ public class SbomToolManifestPathConverterTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(InvalidPathException))]
     public void SbomToolManifestPathConverterTests_CaseSensitive_OSX_Fails()
     {
         var rootPath = @"C:\Sample\Root";
@@ -169,13 +169,10 @@ public class SbomToolManifestPathConverterTests
         osUtils.Setup(o => o.GetCurrentOSPlatform()).Returns(OSPlatform.OSX);
         fileSystemExtensionUtils.Setup(f => f.IsTargetPathInSource(It.IsAny<string>(), It.IsAny<string>())).Returns(false);
 
-        var (path, isOutsideDropPath) = converter.Convert(@"C:\sample\Root" + @"\hello\World");
-
-        Assert.AreEqual("/hello/World", path);
+        Assert.ThrowsException<InvalidPathException>(() => converter.Convert(@"C:\sample\Root" + @"\hello\World"));
     }
 
     [TestMethod]
-    [ExpectedException(typeof(InvalidPathException))]
     public void SbomToolManifestPathConverterTests_CaseSensitive_Linux_Fails()
     {
         var rootPath = @"C:\Sample\Root";
@@ -183,13 +180,10 @@ public class SbomToolManifestPathConverterTests
         osUtils.Setup(o => o.GetCurrentOSPlatform()).Returns(OSPlatform.Linux);
         fileSystemExtensionUtils.Setup(f => f.IsTargetPathInSource(It.IsAny<string>(), It.IsAny<string>())).Returns(false);
 
-        var (path, isOutsideDropPath) = converter.Convert(@"C:\sample\Root" + @"\hello\World");
-
-        Assert.AreEqual("/hello/World", path);
+        Assert.ThrowsException<InvalidPathException>(() => converter.Convert(@"C:\sample\Root" + @"\hello\World"));
     }
 
     [TestMethod]
-    [ExpectedException(typeof(InvalidPathException))]
     public void SbomToolManifestPathConverterTests_RootPathOutside_Fails()
     {
         var rootPath = @"C:\Sample\Root";
@@ -198,7 +192,7 @@ public class SbomToolManifestPathConverterTests
         osUtils.Setup(o => o.GetCurrentOSPlatform()).Returns(OSPlatform.Windows);
         fileSystemExtensionUtils.Setup(f => f.IsTargetPathInSource(It.IsAny<string>(), It.IsAny<string>())).Returns(false);
 
-        converter.Convert(@"d:\Root\hello\World");
+        Assert.ThrowsException<InvalidPathException>(() => converter.Convert(@"d:\Root\hello\World"));
     }
 
     [TestMethod]

--- a/test/Microsoft.Sbom.Api.Tests/Entities/FileValidationResultTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Entities/FileValidationResultTest.cs
@@ -22,12 +22,12 @@ public class FileValidationResultTest
     [DataRow(ErrorType.None, EntityErrorType.None)]
     [DataRow(ErrorType.PackageError, EntityErrorType.PackageError)]
     [DataRow(ErrorType.Other, EntityErrorType.Other)]
-    public void FileValidationResultErrorTypeMapping(ErrorType input, EntityErrorType output)
+    public void FileValidationResultErrorTypeMapping(ErrorType input, EntityErrorType expectedOutput)
     {
         var fileValidationResult = new FileValidationResult() { ErrorType = input, Path = "random" };
         var entityError = fileValidationResult.ToEntityError();
 
-        Assert.AreEqual(output, entityError.ErrorType);
+        Assert.AreEqual(expectedOutput, entityError.ErrorType);
         Assert.IsNull(entityError.Details);
 
         if (input == ErrorType.PackageError)

--- a/test/Microsoft.Sbom.Api.Tests/Entities/FileValidationResultTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Entities/FileValidationResultTest.cs
@@ -27,18 +27,18 @@ public class FileValidationResultTest
         var fileValidationResult = new FileValidationResult() { ErrorType = input, Path = "random" };
         var entityError = fileValidationResult.ToEntityError();
 
-        Assert.AreEqual(entityError.ErrorType, output);
-        Assert.AreEqual(entityError.Details, null);
+        Assert.AreEqual(output, entityError.ErrorType);
+        Assert.AreEqual(null, entityError.Details);
 
         if (input == ErrorType.PackageError)
         {
-            Assert.AreEqual(((PackageEntity)entityError.Entity).Path, "random");
-            Assert.AreEqual(((PackageEntity)entityError.Entity).Name, "random");
+            Assert.AreEqual("random", ((PackageEntity)entityError.Entity).Path);
+            Assert.AreEqual("random", ((PackageEntity)entityError.Entity).Name);
             Assert.AreEqual(entityError.Entity.GetType(), typeof(PackageEntity));
         }
         else
         {
-            Assert.AreEqual(((FileEntity)entityError.Entity).Path, "random");
+            Assert.AreEqual("random", ((FileEntity)entityError.Entity).Path);
             Assert.AreEqual(entityError.Entity.GetType(), typeof(FileEntity));
         }
     }

--- a/test/Microsoft.Sbom.Api.Tests/Entities/FileValidationResultTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Entities/FileValidationResultTest.cs
@@ -28,7 +28,7 @@ public class FileValidationResultTest
         var entityError = fileValidationResult.ToEntityError();
 
         Assert.AreEqual(output, entityError.ErrorType);
-        Assert.AreEqual(null, entityError.Details);
+        Assert.IsNull(entityError.Details);
 
         if (input == ErrorType.PackageError)
         {

--- a/test/Microsoft.Sbom.Api.Tests/Executors/ComponentToPackageInfoConverterTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/ComponentToPackageInfoConverterTests.cs
@@ -83,7 +83,8 @@ public class ComponentToPackageInfoConverterTests
 
         CollectionAssert.AreEquivalent(expectedPackageNames, output.Select(c => c.PackageName).ToList());
 
-        Assert.IsFalse(errors?.Any());
+        Assert.IsNotNull(errors);
+        Assert.IsFalse(errors.Any());
     }
 
     [TestMethod]
@@ -257,7 +258,8 @@ public class ComponentToPackageInfoConverterTests
 
         CollectionAssert.AreEquivalent(expectedPackageNames, output.Select(c => c.PackageName).ToList());
 
-        Assert.IsFalse(errors?.Any());
+        Assert.IsNotNull(errors);
+        Assert.IsFalse(errors.Any());
     }
 
     private async Task<PackageInfo> ConvertScannedComponent(ExtendedScannedComponent scannedComponent)

--- a/test/Microsoft.Sbom.Api.Tests/Executors/DirectoryWalkerTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/DirectoryWalkerTests.cs
@@ -64,12 +64,12 @@ public class DirectoryWalkerTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(InvalidPathException))]
     public void DirectoryWalkerTests_DirectoryDoesntExist_Fails()
     {
         var mockFSUtils = new Mock<IFileSystemUtils>();
         mockFSUtils.Setup(m => m.DirectoryExists(It.IsAny<string>())).Returns(false).Verifiable();
-        new DirectoryWalker(mockFSUtils.Object, mockLogger.Object, mockConfiguration.Object).GetFilesRecursively(@"BadDir");
+        Assert.ThrowsException<InvalidPathException>(() =>
+            new DirectoryWalker(mockFSUtils.Object, mockLogger.Object, mockConfiguration.Object).GetFilesRecursively(@"BadDir"));
         mockFSUtils.VerifyAll();
     }
 

--- a/test/Microsoft.Sbom.Api.Tests/Executors/DirectoryWalkerTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/DirectoryWalkerTests.cs
@@ -59,7 +59,7 @@ public class DirectoryWalkerTests
             Assert.Fail($"Error thrown for {error.Path}: {error.ErrorType}");
         }
 
-        Assert.IsTrue(files.Count == 0);
+        Assert.AreEqual(0, files.Count);
         mockFSUtils.VerifyAll();
     }
 
@@ -102,8 +102,8 @@ public class DirectoryWalkerTests
             Assert.IsTrue(files.Remove(file));
         }
 
-        Assert.IsTrue(errorCount == 1);
-        Assert.IsTrue(files.Count == 0);
+        Assert.AreEqual(1, errorCount);
+        Assert.AreEqual(0, files.Count);
         mockFSUtils.VerifyAll();
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/Executors/ExternalDocumentReferenceWriterTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/ExternalDocumentReferenceWriterTest.cs
@@ -78,8 +78,6 @@ public class ExternalDocumentReferenceWriterTest
         {
             var root = result.Document.RootElement;
 
-            Assert.IsNotNull(root);
-
             if (root.TryGetProperty("Document", out var documentNamespace))
             {
                 Assert.AreEqual("namespace", documentNamespace.GetString());

--- a/test/Microsoft.Sbom.Api.Tests/Executors/FileHasherTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/FileHasherTests.cs
@@ -97,7 +97,7 @@ public class FileHasherTests
             Assert.IsNull(fileHash.FileTypes);
         }
 
-        Assert.IsTrue(fileHashes.error.Count == 0);
+        Assert.AreEqual(0, fileHashes.error.Count);
         hashCodeGeneratorMock.VerifyAll();
         manifestPathConverter.VerifyAll();
         mockConfiguration.VerifyAll();
@@ -306,7 +306,7 @@ public class FileHasherTests
             Assert.IsNull(fileHash.FileTypes);
         }
 
-        Assert.IsTrue(fileHashes.error.Count == 0);
+        Assert.AreEqual(0, fileHashes.error.Count);
         hashCodeGeneratorMock.VerifyAll();
         manifestPathConverter.VerifyAll();
         mockConfiguration.VerifyAll();

--- a/test/Microsoft.Sbom.Api.Tests/Executors/FileListEnumeratorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/FileListEnumeratorTests.cs
@@ -51,8 +51,8 @@ public class FileListEnumeratorTests
             Assert.IsTrue(files.Remove(file));
         }
 
-        Assert.IsTrue(errorCount == 0);
-        Assert.IsTrue(files.Count == 0);
+        Assert.AreEqual(0, errorCount);
+        Assert.AreEqual(0, files.Count);
         mockFSUtils.VerifyAll();
     }
 
@@ -108,8 +108,8 @@ public class FileListEnumeratorTests
             Assert.IsTrue(files.Remove(file));
         }
 
-        Assert.IsTrue(errorCount == 1);
-        Assert.IsTrue(files.Count == 1);
+        Assert.AreEqual(1, errorCount);
+        Assert.AreEqual(1, files.Count);
         mockFSUtils.VerifyAll();
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/Executors/FileListEnumeratorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/FileListEnumeratorTests.cs
@@ -57,22 +57,20 @@ public class FileListEnumeratorTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentException))]
     public void ListWalkerTests_ListFile_Null_Fails()
     {
         var mockFSUtils = new Mock<IFileSystemUtils>();
-        mockFSUtils.Setup(m => m.DirectoryExists(It.IsAny<string>())).Returns(false).Verifiable();
-        new FileListEnumerator(mockFSUtils.Object, mockLogger.Object).GetFilesFromList(null);
+        Assert.ThrowsException<ArgumentException>(() =>
+            new FileListEnumerator(mockFSUtils.Object, mockLogger.Object).GetFilesFromList(null));
         mockFSUtils.VerifyAll();
     }
 
     [TestMethod]
-    [ExpectedException(typeof(InvalidPathException))]
     public void ListWalkerTests_DirectoryDoesntExist_Fails()
     {
         var mockFSUtils = new Mock<IFileSystemUtils>();
-        mockFSUtils.Setup(m => m.DirectoryExists(It.IsAny<string>())).Returns(false).Verifiable();
-        new FileListEnumerator(mockFSUtils.Object, mockLogger.Object).GetFilesFromList(@"BadDir");
+        Assert.ThrowsException<InvalidPathException>(() =>
+            new FileListEnumerator(mockFSUtils.Object, mockLogger.Object).GetFilesFromList(@"BadDir"));
         mockFSUtils.VerifyAll();
     }
 

--- a/test/Microsoft.Sbom.Api.Tests/Executors/HashValidatorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/HashValidatorTests.cs
@@ -56,7 +56,7 @@ public class HashValidatorTests
         }
 
         Assert.AreEqual(0, fileList.Count);
-        Assert.IsTrue(validationResults.errors.Count == 0);
+        Assert.AreEqual(0, validationResults.errors.Count);
     }
 
     [TestMethod]

--- a/test/Microsoft.Sbom.Api.Tests/Executors/PackagesWalkerTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/PackagesWalkerTests.cs
@@ -92,8 +92,8 @@ public class PackagesWalkerTests
             Assert.Fail($"Caught exception: {error.Message}");
         }
 
-        Assert.IsTrue(scannedComponents.Count == 1);
-        Assert.IsTrue(countDistinctComponents == 3);
+        Assert.AreEqual(1, scannedComponents.Count);
+        Assert.AreEqual(3, countDistinctComponents);
         mockDetector.VerifyAll();
     }
 
@@ -145,8 +145,8 @@ public class PackagesWalkerTests
             Assert.Fail($"Caught exception: {error.Message}");
         }
 
-        Assert.IsTrue(scannedComponents.Count == 1);
-        Assert.IsTrue(countDistinctComponents == 3);
+        Assert.AreEqual(1, scannedComponents.Count);
+        Assert.AreEqual(3, countDistinctComponents);
         mockDetector.VerifyAll();
     }
 
@@ -232,7 +232,7 @@ public class PackagesWalkerTests
             Assert.Fail($"Caught exception: {error.Message}");
         }
 
-        Assert.IsTrue(scannedComponents.Where(c => !(c.Component is SpdxComponent)).ToList().Count == discoveredComponents.Count);
+        Assert.AreEqual(discoveredComponents.Count, scannedComponents.Where(c => !(c.Component is SpdxComponent)).ToList().Count);
         mockDetector.VerifyAll();
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/Executors/RelationshipGeneratorTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/RelationshipGeneratorTest.cs
@@ -94,7 +94,7 @@ public class RelationshipGeneratorTest
 
         Assert.IsTrue(docs.Contains(j1));
         Assert.IsTrue(docs.Contains(j2));
-        Assert.IsTrue(docs.Count == 2);
+        Assert.AreEqual(2, docs.Count);
     }
 
     [TestMethod]
@@ -124,6 +124,6 @@ public class RelationshipGeneratorTest
             docs.Add(jsonDoc);
         }
 
-        Assert.IsTrue(docs.Count == 0);
+        Assert.AreEqual(0, docs.Count);
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/Executors/SBOMComponentsWalkerTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/SBOMComponentsWalkerTests.cs
@@ -79,7 +79,7 @@ public class SBOMComponentsWalkerTests
             Assert.Fail($"Caught exception: {error.Message}");
         }
 
-        Assert.IsTrue(scannedComponents.Count == discoveredComponents.Count);
+        Assert.AreEqual(discoveredComponents.Count, scannedComponents.Count);
         mockDetector.VerifyAll();
     }
 
@@ -124,7 +124,7 @@ public class SBOMComponentsWalkerTests
             Assert.Fail($"Caught exception: {error.Message}");
         }
 
-        Assert.IsTrue(scannedComponents.Where(c => c.Component is SpdxComponent).ToList().Count == discoveredComponents.Count);
+        Assert.AreEqual(discoveredComponents.Count, scannedComponents.Where(c => c.Component is SpdxComponent).ToList().Count);
         mockDetector.VerifyAll();
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/FormatValidator/FormatValidatorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/FormatValidator/FormatValidatorTests.cs
@@ -31,7 +31,7 @@ public class FormatValidatorTests
             Assert.AreEqual("CC0-1.0", rawspdx.DataLicense);
             Assert.AreEqual("sbom-tool 1.0.0", rawspdx.Name);
             Assert.AreEqual("https://microsoft.com/sbom-tool/test/sbom-tool/1.0.0/cuK7iCCPVEuSmgBfeFPc-g", rawspdx.DocumentNamespace);
-            Assert.AreEqual(rawspdx.CreationInfo.Created, "2024-05-08T15:58:25Z");
+            Assert.AreEqual("2024-05-08T15:58:25Z", rawspdx.CreationInfo.Created);
             Assert.IsNotNull(rawspdx.CreationInfo.Creators);
             Assert.IsNotNull(rawspdx.DocumentDescribes);
         }

--- a/test/Microsoft.Sbom.Api.Tests/FormatValidator/FormatValidatorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/FormatValidator/FormatValidatorTests.cs
@@ -25,7 +25,7 @@ public class FormatValidatorTests
             var details = await sbom.GetValidationResults();
 
             Assert.AreEqual(FormatValidationStatus.Valid, details.Status);
-            Assert.IsTrue(details.Errors.Count == 0);
+            Assert.AreEqual(0, details.Errors.Count);
             Assert.IsNotNull(rawspdx);
             Assert.AreEqual("SPDX-2.2", rawspdx.Version);
             Assert.AreEqual("CC0-1.0", rawspdx.DataLicense);

--- a/test/Microsoft.Sbom.Api.Tests/Hashing/HashCodeGeneratorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Hashing/HashCodeGeneratorTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Sbom.Contracts;
 using Microsoft.Sbom.Contracts.Enums;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using PowerArgs;
 
 namespace Microsoft.Sbom.Api.Hashing.Tests;
 
@@ -38,7 +39,6 @@ public class HashCodeGeneratorTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(IOException))]
     public void GenerateHashTest_FileReadFails_Throws()
     {
         var hashAlgorithmNames = new AlgorithmName[] { AlgorithmName.SHA256, AlgorithmName.SHA512 };
@@ -52,13 +52,12 @@ public class HashCodeGeneratorTests
         mockFileSystemUtils.Setup(f => f.OpenRead(It.IsAny<string>())).Throws(new IOException());
 
         var hashCodeGenerator = new HashCodeGenerator(mockFileSystemUtils.Object);
-        hashCodeGenerator.GenerateHashes("/tmp/file", hashAlgorithmNames);
+        Assert.ThrowsException<IOException>(() => hashCodeGenerator.GenerateHashes("/tmp/file", hashAlgorithmNames));
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentNullException))]
     public void GenerateHashTest_NullFileSystemUtils_Throws()
     {
-        _ = new HashCodeGenerator(null);
+        Assert.ThrowsException<ArgumentNullException>(() => new HashCodeGenerator(null));
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/Metadata/LocalMetadataProviderTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Metadata/LocalMetadataProviderTest.cs
@@ -6,6 +6,7 @@ using Microsoft.Sbom.Api.Metadata;
 using Microsoft.Sbom.Common.Config;
 using Microsoft.Sbom.Extensions.Entities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PowerArgs;
 
 namespace Microsoft.Sbom.Api.Tests.Metadata;
 
@@ -35,10 +36,9 @@ public class LocalMetadataProviderTest
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentNullException))]
     public void LocalMetadataProvider_WithNullConfiguration_ThrowArgumentNullException()
     {
-        new LocalMetadataProvider(null);
+        Assert.ThrowsException<ArgumentNullException>(() => new LocalMetadataProvider(null));
     }
 
     [TestMethod]

--- a/test/Microsoft.Sbom.Api.Tests/Metadata/LocalMetadataProviderTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Metadata/LocalMetadataProviderTest.cs
@@ -6,7 +6,6 @@ using Microsoft.Sbom.Api.Metadata;
 using Microsoft.Sbom.Common.Config;
 using Microsoft.Sbom.Extensions.Entities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using PowerArgs;
 
 namespace Microsoft.Sbom.Api.Tests.Metadata;
 

--- a/test/Microsoft.Sbom.Api.Tests/Metadata/SbomApiMetadataProviderTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Metadata/SbomApiMetadataProviderTest.cs
@@ -6,7 +6,6 @@ using Microsoft.Sbom.Api.Metadata;
 using Microsoft.Sbom.Common.Config;
 using Microsoft.Sbom.Contracts;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using PowerArgs;
 
 namespace Microsoft.Sbom.Api.Tests.Metadata;
 

--- a/test/Microsoft.Sbom.Api.Tests/Metadata/SbomApiMetadataProviderTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Metadata/SbomApiMetadataProviderTest.cs
@@ -49,7 +49,7 @@ public class SbomApiMetadataProviderTest
     public void SbomApiMetadataProvider_BuildEnvironmentName_WithoutMetadata()
     {
         var sbomApiMetadataProvider = new SBOMApiMetadataProvider(metadata, config);
-        Assert.AreEqual(null, sbomApiMetadataProvider.BuildEnvironmentName);
+        Assert.IsNull(sbomApiMetadataProvider.BuildEnvironmentName);
     }
 
     [TestMethod]

--- a/test/Microsoft.Sbom.Api.Tests/Metadata/SbomApiMetadataProviderTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Metadata/SbomApiMetadataProviderTest.cs
@@ -6,6 +6,7 @@ using Microsoft.Sbom.Api.Metadata;
 using Microsoft.Sbom.Common.Config;
 using Microsoft.Sbom.Contracts;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PowerArgs;
 
 namespace Microsoft.Sbom.Api.Tests.Metadata;
 
@@ -59,16 +60,14 @@ public class SbomApiMetadataProviderTest
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentNullException))]
     public void SbomApiMetadataProvider_WithNullConfiguration_ThrowArgumentNullException()
     {
-        new SBOMApiMetadataProvider(metadata, null);
+        Assert.ThrowsException<ArgumentNullException>(() => new SBOMApiMetadataProvider(metadata, null));
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentNullException))]
     public void SbomApiMetadataProvider_WithNullMetadata_ThrowArgumentNullException()
     {
-        new SBOMApiMetadataProvider(null, config);
+        Assert.ThrowsException<ArgumentNullException>(() => new SBOMApiMetadataProvider(null, config));
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/Output/ManifestToolJsonSerializerTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Output/ManifestToolJsonSerializerTests.cs
@@ -91,7 +91,6 @@ public class ManifestToolJsonSerializerTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ObjectDisposedException))]
     public void ManifestToolJsonSerializerTest_WriteDisposedJsonDocument_Fails()
     {
         var jsonDoc = JsonDocument.Parse("{\"hello\":\"world\"}");
@@ -103,7 +102,6 @@ public class ManifestToolJsonSerializerTests
 
         serializer.StartJsonObject();
         serializer.WriteJsonString(metadataString);
-        serializer.Write(jsonDoc);
-        serializer.FinalizeJsonObject();
+        Assert.ThrowsException<ObjectDisposedException>(() => serializer.Write(jsonDoc));
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/PackageDetails/RubyGemsUtilsTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/PackageDetails/RubyGemsUtilsTests.cs
@@ -68,7 +68,7 @@ public class RubyGemsUtilsTests
 
         var parsedGemspecInfo = rubyGemsUtils.ParseMetadata(gemspecContent);
 
-        Assert.AreEqual(null, parsedGemspecInfo.PackageDetails.License);
+        Assert.IsNull(parsedGemspecInfo.PackageDetails.License);
         Assert.AreEqual("John Doe", parsedGemspecInfo.PackageDetails.Supplier);
         Assert.AreEqual("sampleGem", parsedGemspecInfo.Name);
         Assert.AreEqual("1.0.0", parsedGemspecInfo.Version);
@@ -87,7 +87,7 @@ public class RubyGemsUtilsTests
         var parsedGemspecInfo = rubyGemsUtils.ParseMetadata(gemspecContent);
 
         Assert.AreEqual("MIT", parsedGemspecInfo.PackageDetails.License);
-        Assert.AreEqual(null, parsedGemspecInfo.PackageDetails.Supplier);
+        Assert.IsNull(parsedGemspecInfo.PackageDetails.Supplier);
         Assert.AreEqual("sampleGem", parsedGemspecInfo.Name);
         Assert.AreEqual("1.0.0", parsedGemspecInfo.Version);
     }

--- a/test/Microsoft.Sbom.Api.Tests/PackageDetails/RubyGemsUtilsTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/PackageDetails/RubyGemsUtilsTests.cs
@@ -32,10 +32,10 @@ public class RubyGemsUtilsTests
 
         var parsedGemspecInfo = rubyGemsUtils.ParseMetadata(gemspecContent);
 
-        Assert.AreEqual(parsedGemspecInfo.PackageDetails.License, "MIT, Ruby");
-        Assert.AreEqual(parsedGemspecInfo.PackageDetails.Supplier, "John Doe");
-        Assert.AreEqual(parsedGemspecInfo.Name, "sampleGem");
-        Assert.AreEqual(parsedGemspecInfo.Version, "1.0.0");
+        Assert.AreEqual("MIT, Ruby", parsedGemspecInfo.PackageDetails.License);
+        Assert.AreEqual("John Doe", parsedGemspecInfo.PackageDetails.Supplier);
+        Assert.AreEqual("sampleGem", parsedGemspecInfo.Name);
+        Assert.AreEqual("1.0.0", parsedGemspecInfo.Version);
     }
 
     [TestMethod]
@@ -50,10 +50,10 @@ public class RubyGemsUtilsTests
 
         var parsedGemspecInfo = rubyGemsUtils.ParseMetadata(gemspecContent);
 
-        Assert.AreEqual(parsedGemspecInfo.PackageDetails.License, "MIT");
-        Assert.AreEqual(parsedGemspecInfo.PackageDetails.Supplier, "John Doe");
-        Assert.AreEqual(parsedGemspecInfo.Name, "sampleGem");
-        Assert.AreEqual(parsedGemspecInfo.Version, "1.0.0");
+        Assert.AreEqual("MIT", parsedGemspecInfo.PackageDetails.License);
+        Assert.AreEqual("John Doe", parsedGemspecInfo.PackageDetails.Supplier);
+        Assert.AreEqual("sampleGem", parsedGemspecInfo.Name);
+        Assert.AreEqual("1.0.0", parsedGemspecInfo.Version);
     }
 
     [TestMethod]
@@ -68,10 +68,10 @@ public class RubyGemsUtilsTests
 
         var parsedGemspecInfo = rubyGemsUtils.ParseMetadata(gemspecContent);
 
-        Assert.AreEqual(parsedGemspecInfo.PackageDetails.License, null);
-        Assert.AreEqual(parsedGemspecInfo.PackageDetails.Supplier, "John Doe");
-        Assert.AreEqual(parsedGemspecInfo.Name, "sampleGem");
-        Assert.AreEqual(parsedGemspecInfo.Version, "1.0.0");
+        Assert.AreEqual(null, parsedGemspecInfo.PackageDetails.License);
+        Assert.AreEqual("John Doe", parsedGemspecInfo.PackageDetails.Supplier);
+        Assert.AreEqual("sampleGem", parsedGemspecInfo.Name);
+        Assert.AreEqual("1.0.0", parsedGemspecInfo.Version);
     }
 
     [TestMethod]
@@ -86,10 +86,10 @@ public class RubyGemsUtilsTests
 
         var parsedGemspecInfo = rubyGemsUtils.ParseMetadata(gemspecContent);
 
-        Assert.AreEqual(parsedGemspecInfo.PackageDetails.License, "MIT");
-        Assert.AreEqual(parsedGemspecInfo.PackageDetails.Supplier, null);
-        Assert.AreEqual(parsedGemspecInfo.Name, "sampleGem");
-        Assert.AreEqual(parsedGemspecInfo.Version, "1.0.0");
+        Assert.AreEqual("MIT", parsedGemspecInfo.PackageDetails.License);
+        Assert.AreEqual(null, parsedGemspecInfo.PackageDetails.Supplier);
+        Assert.AreEqual("sampleGem", parsedGemspecInfo.Name);
+        Assert.AreEqual("1.0.0", parsedGemspecInfo.Version);
     }
 
     [TestMethod]

--- a/test/Microsoft.Sbom.Api.Tests/SignValidator/SignValidationProviderTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/SignValidator/SignValidationProviderTests.cs
@@ -31,15 +31,12 @@ public class SignValidationProviderTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentNullException))]
     public void SignValidationProvider_NullValidators_Throws()
     {
         var mockOSUtils = new Mock<IOSUtils>();
         mockOSUtils.Setup(o => o.GetCurrentOSPlatform()).Returns(OSPlatform.Windows);
 
-        var signValidator = new SignValidationProvider(null, mockOSUtils.Object);
-        signValidator.Init();
-        signValidator.Get();
+        Assert.ThrowsException<ArgumentNullException>(() => new SignValidationProvider(null, mockOSUtils.Object));
     }
 
     [TestMethod]

--- a/test/Microsoft.Sbom.Api.Tests/Utils/ComponentDetectionCliArgumentBuilderTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Utils/ComponentDetectionCliArgumentBuilderTests.cs
@@ -146,27 +146,21 @@ public class ComponentDetectionCliArgumentBuilderTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentNullException))]
     public void Build_WithNullValue()
     {
-        var builder = new ComponentDetectionCliArgumentBuilder()
+        Assert.ThrowsException<ArgumentNullException>(() => new ComponentDetectionCliArgumentBuilder()
             .SourceDirectory("X:/")
             .AddArg("ManifestFile", null)
-            .AddArg("--DirectoryExclusionList", "X:/hello");
-
-        builder.Build();
+            .AddArg("--DirectoryExclusionList", "X:/hello"));
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentNullException))]
     public void Build_WithInvalidArg()
     {
-        var builder = new ComponentDetectionCliArgumentBuilder()
+        Assert.ThrowsException<ArgumentNullException>(() => new ComponentDetectionCliArgumentBuilder()
             .SourceDirectory("X:/")
             .AddArg("ManifestFile", "value")
-            .AddArg("--", "X:/hello");
-
-        builder.Build();
+            .AddArg("--", "X:/hello"));
     }
 
     [TestMethod]

--- a/test/Microsoft.Sbom.Api.Tests/Utils/ComponentDetectionCliArgumentBuilderTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Utils/ComponentDetectionCliArgumentBuilderTests.cs
@@ -146,21 +146,19 @@ public class ComponentDetectionCliArgumentBuilderTests
     }
 
     [TestMethod]
-    public void Build_WithNullValue()
+    public void AddArg_WithNullValue_Throws()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => new ComponentDetectionCliArgumentBuilder()
-            .SourceDirectory("X:/")
-            .AddArg("ManifestFile", null)
-            .AddArg("--DirectoryExclusionList", "X:/hello"));
+        var builder = new ComponentDetectionCliArgumentBuilder();
+
+        Assert.ThrowsException<ArgumentNullException>(() => builder.AddArg("ManifestFile", null));
     }
 
     [TestMethod]
-    public void Build_WithInvalidArg()
+    public void AddArg_WithInvalidArg_Throws()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => new ComponentDetectionCliArgumentBuilder()
-            .SourceDirectory("X:/")
-            .AddArg("ManifestFile", "value")
-            .AddArg("--", "X:/hello"));
+        var builder = new ComponentDetectionCliArgumentBuilder();
+
+        Assert.ThrowsException<ArgumentNullException>(() => builder.AddArg("--", "X:/hello"));
     }
 
     [TestMethod]

--- a/test/Microsoft.Sbom.Api.Tests/Utils/ComponentDetectorCachedExecutorTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Utils/ComponentDetectorCachedExecutorTest.cs
@@ -35,7 +35,7 @@ public class ComponentDetectorCachedExecutorTest
         detector.Setup(x => x.ScanAsync(arguments)).Returns(Task.FromResult(expectedResult));
         var result = await executor.ScanAsync(arguments);
         Assert.AreEqual(expectedResult, result);
-        Assert.IsTrue(detector.Invocations.Count == 1);
+        Assert.AreEqual(1, detector.Invocations.Count);
     }
 
     [TestMethod]
@@ -49,6 +49,6 @@ public class ComponentDetectorCachedExecutorTest
         await executor.ScanAsync(arguments);
         var result = await executor.ScanAsync(arguments);
         Assert.AreEqual(expectedResult, result);
-        Assert.IsTrue(detector.Invocations.Count == 1);
+        Assert.AreEqual(1, detector.Invocations.Count);
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/Utils/ComponentDetectorCachedExecutorTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Utils/ComponentDetectorCachedExecutorTest.cs
@@ -34,7 +34,7 @@ public class ComponentDetectorCachedExecutorTest
 
         detector.Setup(x => x.ScanAsync(arguments)).Returns(Task.FromResult(expectedResult));
         var result = await executor.ScanAsync(arguments);
-        Assert.AreEqual(result, expectedResult);
+        Assert.AreEqual(expectedResult, result);
         Assert.IsTrue(detector.Invocations.Count == 1);
     }
 
@@ -48,7 +48,7 @@ public class ComponentDetectorCachedExecutorTest
         detector.Setup(x => x.ScanAsync(arguments)).Returns(Task.FromResult(expectedResult));
         await executor.ScanAsync(arguments);
         var result = await executor.ScanAsync(arguments);
-        Assert.AreEqual(result, expectedResult);
+        Assert.AreEqual(expectedResult, result);
         Assert.IsTrue(detector.Invocations.Count == 1);
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/Utils/ExternalReferenceDeduplicatorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Utils/ExternalReferenceDeduplicatorTests.cs
@@ -135,6 +135,6 @@ public class ExternalReferenceDeduplicatorTests
         var deduplicator = new ExternalReferenceDeduplicator();
 
         Assert.AreEqual("http://sbom.test/1", deduplicator.GetKey(new ExternalDocumentReferenceInfo() { DocumentNamespace = "http://sbom.test/1" }));
-        Assert.AreEqual(null, deduplicator.GetKey(null));
+        Assert.IsNull(deduplicator.GetKey(null));
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/Utils/OSUtilsTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Utils/OSUtilsTest.cs
@@ -75,7 +75,7 @@ public class OSUtilsTest
         environment.Setup(o => o.GetEnvironmentVariables()).Returns(d);
         osUtils = new OSUtils(logger.Object, environment.Object);
 
-        Assert.AreEqual(null, osUtils.GetEnvironmentVariable(Variable));
+        Assert.IsNull(osUtils.GetEnvironmentVariable(Variable));
         environment.VerifyAll();
         logger.VerifyAll();
     }
@@ -88,7 +88,7 @@ public class OSUtilsTest
         environment.Setup(o => o.GetEnvironmentVariables()).Returns(d);
         osUtils = new OSUtils(logger.Object, environment.Object);
 
-        Assert.AreEqual(null, osUtils.GetEnvironmentVariable(Variable));
+        Assert.IsNull(osUtils.GetEnvironmentVariable(Variable));
         environment.VerifyAll();
         logger.VerifyAll();
     }

--- a/test/Microsoft.Sbom.Api.Tests/Utils/SBOMFileDedeplicatorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Utils/SBOMFileDedeplicatorTests.cs
@@ -135,6 +135,6 @@ public class SBOMFileDedeplicatorTests
         var deduplicator = new InternalSBOMFileInfoDeduplicator();
 
         Assert.AreEqual("./file1.txt", deduplicator.GetKey(new InternalSbomFileInfo() { Path = "./file1.txt" }));
-        Assert.AreEqual(null, deduplicator.GetKey(null));
+        Assert.IsNull(deduplicator.GetKey(null));
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/Helpers/SbomRedactorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/Helpers/SbomRedactorTests.cs
@@ -79,7 +79,7 @@ public class SbomRedactorTests
         };
         mockValidatedSbom.Setup(x => x.GetRawSPDXDocument()).ReturnsAsync(mockSbom);
         await testSubject.RedactSBOMAsync(mockValidatedSbom.Object);
-        Assert.AreEqual(mockSbom.Packages.Count(), 3);
+        Assert.AreEqual(3, mockSbom.Packages.Count());
         foreach (var package in mockSbom.Packages)
         {
             Assert.IsNull(package.HasFiles);
@@ -118,7 +118,7 @@ public class SbomRedactorTests
         };
         mockValidatedSbom.Setup(x => x.GetRawSPDXDocument()).ReturnsAsync(mockSbom);
         await testSubject.RedactSBOMAsync(mockValidatedSbom.Object);
-        Assert.AreEqual(mockSbom.Relationships.Count(), 1);
+        Assert.AreEqual(1, mockSbom.Relationships.Count());
         Assert.AreEqual(mockSbom.Relationships.First(), unredactedRelationship);
     }
 

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/ManifestGenerationWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/ManifestGenerationWorkflowTests.cs
@@ -330,9 +330,9 @@ public class ManifestGenerationWorkflowTests
         var result = Encoding.UTF8.GetString(manifestStream.ToArray());
         var resultJson = JObject.Parse(result);
 
-        Assert.AreEqual(resultJson["Version"], "1.0.0");
-        Assert.AreEqual(resultJson["Build"], 12);
-        Assert.AreEqual(resultJson["Definition"], "test");
+        Assert.AreEqual("1.0.0", resultJson["Version"]);
+        Assert.AreEqual(12, resultJson["Build"]);
+        Assert.AreEqual("test", resultJson["Definition"]);
 
         var outputs = resultJson["Outputs"];
         var sortedOutputs = new JArray(outputs.OrderBy(obj => (string)obj["Source"]));

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/ManifestGenerationWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/ManifestGenerationWorkflowTests.cs
@@ -339,7 +339,7 @@ public class ManifestGenerationWorkflowTests
         var expectedSortedOutputs = new JArray(outputs.OrderBy(obj => (string)obj["Source"]));
 
         var packages = resultJson["Packages"];
-        Assert.IsTrue(packages.Count() == 4);
+        Assert.AreEqual(4, packages.Count());
 
         Assert.IsTrue(JToken.DeepEquals(sortedOutputs, expectedSortedOutputs));
 

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/SbomRedactionWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/SbomRedactionWorkflowTests.cs
@@ -65,26 +65,23 @@ public class SbomRedactionWorkflowTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentException))]
-    public async Task SbomRedactionWorkflow_FailsOnNoSbomsProvided()
+    public void SbomRedactionWorkflow_FailsOnNoSbomsProvided()
     {
-        var result = await testSubject.RunAsync();
+        Assert.ThrowsExceptionAsync<ArgumentException>(testSubject.RunAsync);
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentException))]
-    public async Task SbomRedactionWorkflow_FailsOnMatchingInputOutputDirs()
+    public void SbomRedactionWorkflow_FailsOnMatchingInputOutputDirs()
     {
         configurationMock.SetupGet(c => c.SbomDir).Returns(new ConfigurationSetting<string> { Value = SbomDirStub });
         configurationMock.SetupGet(c => c.OutputPath).Returns(new ConfigurationSetting<string> { Value = SbomDirStub });
         fileSystemUtilsMock.Setup(m => m.DirectoryExists(SbomDirStub)).Returns(true).Verifiable();
         fileSystemUtilsMock.Setup(m => m.GetFullPath(SbomDirStub)).Returns(SbomDirStub).Verifiable();
-        var result = await testSubject.RunAsync();
+        Assert.ThrowsExceptionAsync<ArgumentException>(testSubject.RunAsync);
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentException))]
-    public async Task SbomRedactionWorkflow_FailsOnExistingOutputSbom()
+    public void SbomRedactionWorkflow_FailsOnExistingOutputSbom()
     {
         configurationMock.SetupGet(c => c.SbomPath).Returns(new ConfigurationSetting<string> { Value = SbomPathStub });
         configurationMock.SetupGet(c => c.OutputPath).Returns(new ConfigurationSetting<string> { Value = OutDirStub });
@@ -101,12 +98,11 @@ public class SbomRedactionWorkflowTests
         // Output already file exists
         fileSystemUtilsMock.Setup(m => m.FileExists(OutPathStub)).Returns(true).Verifiable();
 
-        var result = await testSubject.RunAsync();
+        Assert.ThrowsExceptionAsync<ArgumentException>(testSubject.RunAsync);
     }
 
     [TestMethod]
-    [ExpectedException(typeof(InvalidDataException))]
-    public async Task SbomRedactionWorkflow_FailsOnInvalidSboms()
+    public void SbomRedactionWorkflow_FailsOnInvalidSboms()
     {
         SetUpDirStructure();
 
@@ -118,7 +114,7 @@ public class SbomRedactionWorkflowTests
         validatedSbomMock.Setup(m => m.GetValidationResults()).ReturnsAsync(validationRes).Verifiable();
         validatedSbomMock.Setup(m => m.Dispose()).Verifiable();
 
-        var result = await testSubject.RunAsync();
+        Assert.ThrowsExceptionAsync<InvalidDataException>(testSubject.RunAsync);
     }
 
     [TestMethod]

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/SbomRedactionWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/SbomRedactionWorkflowTests.cs
@@ -65,23 +65,23 @@ public class SbomRedactionWorkflowTests
     }
 
     [TestMethod]
-    public void SbomRedactionWorkflow_FailsOnNoSbomsProvided()
+    public async Task SbomRedactionWorkflow_FailsOnNoSbomsProvided()
     {
-        Assert.ThrowsExceptionAsync<ArgumentException>(testSubject.RunAsync);
+        await Assert.ThrowsExceptionAsync<ArgumentException>(testSubject.RunAsync);
     }
 
     [TestMethod]
-    public void SbomRedactionWorkflow_FailsOnMatchingInputOutputDirs()
+    public async Task SbomRedactionWorkflow_FailsOnMatchingInputOutputDirs()
     {
         configurationMock.SetupGet(c => c.SbomDir).Returns(new ConfigurationSetting<string> { Value = SbomDirStub });
         configurationMock.SetupGet(c => c.OutputPath).Returns(new ConfigurationSetting<string> { Value = SbomDirStub });
         fileSystemUtilsMock.Setup(m => m.DirectoryExists(SbomDirStub)).Returns(true).Verifiable();
         fileSystemUtilsMock.Setup(m => m.GetFullPath(SbomDirStub)).Returns(SbomDirStub).Verifiable();
-        Assert.ThrowsExceptionAsync<ArgumentException>(testSubject.RunAsync);
+        await Assert.ThrowsExceptionAsync<ArgumentException>(testSubject.RunAsync);
     }
 
     [TestMethod]
-    public void SbomRedactionWorkflow_FailsOnExistingOutputSbom()
+    public async Task SbomRedactionWorkflow_FailsOnExistingOutputSbom()
     {
         configurationMock.SetupGet(c => c.SbomPath).Returns(new ConfigurationSetting<string> { Value = SbomPathStub });
         configurationMock.SetupGet(c => c.OutputPath).Returns(new ConfigurationSetting<string> { Value = OutDirStub });
@@ -98,11 +98,11 @@ public class SbomRedactionWorkflowTests
         // Output already file exists
         fileSystemUtilsMock.Setup(m => m.FileExists(OutPathStub)).Returns(true).Verifiable();
 
-        Assert.ThrowsExceptionAsync<ArgumentException>(testSubject.RunAsync);
+        await Assert.ThrowsExceptionAsync<ArgumentException>(testSubject.RunAsync);
     }
 
     [TestMethod]
-    public void SbomRedactionWorkflow_FailsOnInvalidSboms()
+    public async Task SbomRedactionWorkflow_FailsOnInvalidSboms()
     {
         SetUpDirStructure();
 
@@ -114,7 +114,7 @@ public class SbomRedactionWorkflowTests
         validatedSbomMock.Setup(m => m.GetValidationResults()).ReturnsAsync(validationRes).Verifiable();
         validatedSbomMock.Setup(m => m.Dispose()).Verifiable();
 
-        Assert.ThrowsExceptionAsync<InvalidDataException>(testSubject.RunAsync);
+        await Assert.ThrowsExceptionAsync<InvalidDataException>(testSubject.RunAsync);
     }
 
     [TestMethod]

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomFileParserTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomFileParserTests.cs
@@ -163,13 +163,11 @@ public class SbomFileParserTests : SbomParserTestsBase
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentException))]
     public void NullOrEmptyBuffer_Throws()
     {
         var bytes = Encoding.UTF8.GetBytes(SbomFileJsonStrings.MalformedJson);
         using var stream = new MemoryStream(bytes);
 
-        var parser = new SPDXParser(stream, bufferSize: 0);
-        Assert.ThrowsException<ArgumentException>(() => this.Parse(parser));
+        Assert.ThrowsException<ArgumentException>(() => new SPDXParser(stream, bufferSize: 0));
     }
 }

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomPackageParserTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomPackageParserTests.cs
@@ -39,16 +39,13 @@ public class SbomPackageParserTests : SbomParserTestsBase
     }
 
     [TestMethod]
-    [ExpectedException(typeof(EndOfStreamException))]
-    public void StreamEmptyTestReturnsNull()
+    public void StreamEmptyTestThrowsException()
     {
         using var stream = new MemoryStream();
         stream.Read(new byte[Constants.ReadBufferSize]);
         var buffer = new byte[Constants.ReadBufferSize];
 
-        var parser = new SPDXParser(stream);
-
-        var result = this.Parse(parser);
+        Assert.ThrowsException<EndOfStreamException>(() => new SPDXParser(stream));
     }
 
     [DataTestMethod]
@@ -76,7 +73,6 @@ public class SbomPackageParserTests : SbomParserTestsBase
     [DataRow(SbomPackageStrings.PackageJsonWith1PackageMissingReferenceLocator)]
     [DataRow(SbomPackageStrings.PackageJsonWith1PackageMissingPackageVerificationCode)]
     [DataRow(SbomPackageStrings.PackageJsonWith1PackageFilesAnalyzedTrueAndMissingLicenseInfoFromFiles)]
-    [ExpectedException(typeof(ParserException))]
     public void MissingPropertiesTest_Throws(string json)
     {
         var bytes = Encoding.UTF8.GetBytes(json);
@@ -84,7 +80,7 @@ public class SbomPackageParserTests : SbomParserTestsBase
 
         var parser = new SPDXParser(stream);
 
-        var result = this.Parse(parser);
+        Assert.ThrowsException<ParserException>(() => this.Parse(parser));
     }
 
     [DataTestMethod]
@@ -107,7 +103,6 @@ public class SbomPackageParserTests : SbomParserTestsBase
     [DataRow(SbomPackageStrings.MalformedJsonEmptyObject)]
     [DataRow(SbomPackageStrings.MalformedJsonEmptyObjectNoArrayEnd)]
     [TestMethod]
-    [ExpectedException(typeof(ParserException))]
     public void MalformedJsonTest_Throws(string json)
     {
         var bytes = Encoding.UTF8.GetBytes(json);
@@ -115,7 +110,7 @@ public class SbomPackageParserTests : SbomParserTestsBase
 
         var parser = new SPDXParser(stream);
 
-        var result = this.Parse(parser);
+        Assert.ThrowsException<ParserException>(() => this.Parse(parser));
     }
 
     [TestMethod]
@@ -130,14 +125,11 @@ public class SbomPackageParserTests : SbomParserTestsBase
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentException))]
     public void NullOrEmptyBuffer_Throws()
     {
         var bytes = Encoding.UTF8.GetBytes(SbomFileJsonStrings.MalformedJson);
         using var stream = new MemoryStream(bytes);
 
-        var parser = new SPDXParser(stream, bufferSize: 0);
-
-        var result = this.Parse(parser);
+        Assert.ThrowsException<ArgumentException>(() => new SPDXParser(stream, bufferSize: 0));
     }
 }

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomParserTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomParserTests.cs
@@ -55,12 +55,11 @@ public class SbomParserTests : SbomParserTestsBase
     [DataRow(SbomParserStrings.JsonWithMissingFiles)]
     [DataRow(SbomParserStrings.JsonWithMissingPackages)]
     [DataRow(SbomParserStrings.JsonWithMissingRelationships)]
-    [ExpectedException(typeof(ParserException))]
     public void MissingPropertyThrows(string json)
     {
         var bytes = Encoding.UTF8.GetBytes(json);
         using var stream = new MemoryStream(bytes);
-        this.IterateAllPropertiesAsync(stream);
+        Assert.ThrowsException<ParserException>(() => this.IterateAllPropertiesAsync(stream));
     }
 
     [DataTestMethod]

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomRelationshipParserTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/SbomRelationshipParserTests.cs
@@ -28,16 +28,13 @@ public class SbomRelationshipParserTests : SbomParserTestsBase
     }
 
     [TestMethod]
-    [ExpectedException(typeof(EndOfStreamException))]
     public void StreamEmptyTestReturnsNull()
     {
         using var stream = new MemoryStream();
         stream.Read(new byte[SbomConstants.ReadBufferSize]);
         var buffer = new byte[SbomConstants.ReadBufferSize];
 
-        var parser = new SPDXParser(stream);
-
-        var result = this.Parse(parser);
+        Assert.ThrowsException<EndOfStreamException>(() => new SPDXParser(stream));
     }
 
     [DataTestMethod]
@@ -99,14 +96,11 @@ public class SbomRelationshipParserTests : SbomParserTestsBase
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentException))]
     public void NullOrEmptyBuffer_Throws()
     {
         var bytes = Encoding.UTF8.GetBytes(SbomFileJsonStrings.MalformedJson);
         using var stream = new MemoryStream(bytes);
 
-        var parser = new SPDXParser(stream, bufferSize: 0);
-
-        var result = this.Parse(parser);
+        Assert.ThrowsException<ArgumentException>(() => new SPDXParser(stream, bufferSize: 0));
     }
 }

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Utils/SPDXExtensionsTest.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Utils/SPDXExtensionsTest.cs
@@ -99,11 +99,10 @@ public class SPDXExtensionsTest
     }
 
     [TestMethod]
-    [ExpectedException(typeof(ArgumentNullException))]
     public void AddPackageUrlsTest_WithNullSPDXPackage_Failure()
     {
         spdxPackage = null;
-        spdxPackage.AddPackageUrls(packageInfo);
+        Assert.ThrowsException<ArgumentNullException>(() => spdxPackage.AddPackageUrls(packageInfo));
     }
 
     [TestMethod]

--- a/test/Microsoft.Sbom.Parsers.Spdx30SbomParser.Tests/Parser/GeneratorTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx30SbomParser.Tests/Parser/GeneratorTests.cs
@@ -82,7 +82,7 @@ public class GeneratorTests
         expectedJsonContentAsString = NormalizeString(expectedJsonContentAsString);
 
         Assert.IsFalse(generatedJsonString.Contains("null"));
-        Assert.AreEqual(generatedJsonString, expectedJsonContentAsString);
+        Assert.AreEqual(expectedJsonContentAsString, generatedJsonString);
     }
 
     [TestMethod]
@@ -105,7 +105,7 @@ public class GeneratorTests
         expectedJsonContentAsString = NormalizeString(expectedJsonContentAsString);
 
         Assert.IsFalse(generatedJsonString.Contains("null"));
-        Assert.AreEqual(generatedJsonString, expectedJsonContentAsString);
+        Assert.AreEqual(expectedJsonContentAsString, generatedJsonString);
     }
 
     [TestMethod]
@@ -126,7 +126,7 @@ public class GeneratorTests
         expectedJsonContentAsString = NormalizeString(expectedJsonContentAsString);
 
         Assert.IsFalse(generatedJsonString.Contains("null"));
-        Assert.AreEqual(generatedJsonString, expectedJsonContentAsString);
+        Assert.AreEqual(expectedJsonContentAsString, generatedJsonString);
     }
 
     [TestMethod]
@@ -147,7 +147,7 @@ public class GeneratorTests
         expectedJsonContentAsString = NormalizeString(expectedJsonContentAsString);
 
         Assert.IsFalse(generatedJsonString.Contains("null"));
-        Assert.AreEqual(generatedJsonString, expectedJsonContentAsString);
+        Assert.AreEqual(expectedJsonContentAsString, generatedJsonString);
     }
 
     [TestCleanup]

--- a/test/Microsoft.Sbom.Tool.Tests/IntegrationTests.cs
+++ b/test/Microsoft.Sbom.Tool.Tests/IntegrationTests.cs
@@ -28,7 +28,7 @@ public class IntegrationTests
         testRunDirectory = context.TestRunDirectory;
     }
 
-    [ClassCleanup]
+    [ClassCleanup(ClassCleanupBehavior.EndOfClass)]
     public static void TearDown()
     {
         // Clean up test directories


### PR DESCRIPTION
Dependabot tried to update `MSTest.TestFramework` from 3.6.4 to 3.7.0 in #839, and `MSTest.TestAdapter` in #841. These PR's both failed, as the 2 pieces need to move together for the tests to work correctly. In addition, the newer version of `MSTest.TestFramework` adds several new warnings, and since our builds treat warnings as errors, the build breaks.

This PR touches a lot of files, but since these packages are all test-specific, so are the code changes. It was done as a series of commits, and reviewing each commit in sequence will probably simplify the review process. Commits are as follows:

Commit | Description/Coment
--- | ---
[1](https://github.com/microsoft/sbom-tool/commit/5512a2f23685422003ae188c73d15f8698e0ea46) | Unchanged from #839 
[2](https://github.com/microsoft/sbom-tool/commit/03b9a4ac629c71c400214be30cf45ee02de5c522) | Suppress new warnings
[3](https://github.com/microsoft/sbom-tool/commit/353b0db5a98e1d3549d8f0698d2ada42c9be81e5) | Unchanged from #841 -- this allowed the tests to run
[4](https://github.com/microsoft/sbom-tool/commit/1ea8e90a4305e53a9f011b4b85b2dfc4e7d2297d) | Added a suppression that was flagged once both packages were updated
[5](https://github.com/microsoft/sbom-tool/commit/b8fcf1f66315877814413285deb3480243e39abf) | [MSTEST0005](https://learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0005) We were using TestContext improperly, fix it
[6](https://github.com/microsoft/sbom-tool/commit/7275b724652228305f268c5a5e910dd0ce45b9f7) | [MSTEST0006](https://learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0006) `ExpectedException` is no longer considered a best practice, so I changed them to `ThrowsException` or `ThrowsExceptionAsync`. Most of these changes were tool-driven, but some were manual and exposed some dead code in the unit tests
[7](https://github.com/microsoft/sbom-tool/commit/22517b288625ecc2864bee1241c0c5a221d85703) | [MSTEST0017](https://learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0017) `Assert.AreEqual` wants the expected parameter first--there were many places in the code where we had the test parameter first. These changes were largely tool-driven
[8](https://github.com/microsoft/sbom-tool/commit/f794cc42fdfa1e1fe92857a18eaa17835bcaace8) | [MSTEST0024](https://learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0024) was fixed by [5](https://github.com/microsoft/sbom-tool/commit/b8fcf1f66315877814413285deb3480243e39abf), so the suppression can go away
[9](https://github.com/microsoft/sbom-tool/commit/99f1757a67b5995c5748629137281fa89723ee26) | [MSTEST0034](https://learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0034) This just adds a parameter to an attribute decoration
[10](https://github.com/microsoft/sbom-tool/commit/764c30a0d27ce4b95d49cb1fc759f8f51d2f9f2d) | [MSTEST0037](https://learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0037) `Assert.AreEqual`, `Assert.IsNull`, and `Assert.IsNotNull` are all preferred over `Assert.IsTrue` becuase they are more descriptive. These changes were largely tool-driven.
[11](https://github.com/microsoft/sbom-tool/commit/ff3f4b0d8d178ac323750e794059f5f2edda5f04) | I noticed a few more places where the parameters of `Assert.AreEqual` were in the wrong order, but the analyzer failed to catch the error. These changes were manual.
[12](https://github.com/microsoft/sbom-tool/commit/8c9248b6bb81fa7e289f0ce0c58a9fb1bf6e16bc) | [MSTEST0026](https://learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0026) Null propagation in asserts is discouraged
[13](https://github.com/microsoft/sbom-tool/commit/e8b2539e1cb4dea649900c0cc2254ce840e5e1d9) | [MSTEST0032](https://learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0032) Non-nullable types don't need to be asserted as non-null. Note that this undoes some of the changes from [12](https://github.com/microsoft/sbom-tool/commit/8c9248b6bb81fa7e289f0ce0c58a9fb1bf6e16bc)
[14](https://github.com/microsoft/sbom-tool/commit/ded35baee9f4da3957836ada6fe19754ecfd849b) | [JSON002](https://learn.microsoft.com/en-us/visualstudio/ide/reference/json002?view=vs-2022) is no longer showing up as an error, so I removed the suppression
[15](https://github.com/microsoft/sbom-tool/commit/ad24014ac372ae2d06af2aa6934857778f4af61b) | Remove a couple of using blocks that were accidentally added along the way
[16](https://github.com/microsoft/sbom-tool/commit/dca3b38fd953672fe537af341929742ff1b6c389) | Restore a check was dropped in [6](https://github.com/microsoft/sbom-tool/commit/7275b724652228305f268c5a5e910dd0ce45b9f7)
[17](https://github.com/microsoft/sbom-tool/pull/848/commits/2d93c2d6bea31d14f17773c5d41be63c5b6a1b60) | Fix broken tests on macOS, add local JSON002 (only seems to impact Visual Studio, not command line)

Note: When running from inside Visual Studio, the net472 projects get skipped. They run correctly from the command line, so any potential regressions should get caught in the pipelines. The net80 versions of the tests work as expected in both Visual Studio and from the command line. I opened https://github.com/microsoft/testfx/issues/4487 to report that issue. It was resolved as a dupe of https://github.com/microsoft/testfx/issues/4426