### PR TITLE
Revert bump to Microsoft.Extensions.DependencyModel (Revert part of #847)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="8.0.2" />
     <PackageVersion Include="Microsoft.ComponentDetection.Common" Version="$(ComponentDetectionPackageVersion)" />
     <PackageVersion Include="Microsoft.ComponentDetection.Contracts" Version="$(ComponentDetectionPackageVersion)" />
     <PackageVersion Include="Microsoft.ComponentDetection.Detectors" Version="$(ComponentDetectionPackageVersion)" />


### PR DESCRIPTION
PR #847 bumped both `Microsoft.Extensions.DependencyModel` and `System.Text.Json`. It passed all local tests and successfully passed the PR checks, but after it merged, it was causing test failures in the CI pipeline. I ran 2 iterations of the CI pipeline, one reverting both version bumps, and one reverting just `Microsoft.Extensions.DependencyModel`. They both passed. Bumping `System.Text.Json` is a good thing, so this PR backs out just the bump to `Microsoft.Extensions.DependencyModel`