### PR TITLE
Add CI action for publishing package to WinGet

### DIFF
--- a/.github/workflows/submit-winget.yml
+++ b/.github/workflows/submit-winget.yml
@@ -1,0 +1,29 @@
+name: Submit published release to WinGet community repository
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-winget:
+    name: Submit to WinGet repository
+    runs-on: windows-latest
+    # Only submit stable releases
+    if: ${{ !github.event.release.prerelease }}
+    steps:
+      # Sometimes wingetcreate may fail to sync fork automatically, so we do it manually here.
+      # Ref: https://github.com/microsoft/winget-create/issues/502
+      - name: Sync winget-pkgs fork
+        run: gh repo sync DaveTryon/winget-pkgs -b master
+        env:
+          GH_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
+      - name: Submit package using wingetcreate
+        run: |
+          # Get installer info from release event
+          $assets = '${{ toJSON(github.event.release.assets) }}' | ConvertFrom-Json
+          $installerUrl = $assets | Where-Object -Property name -eq 'sbom-tool-win-x64.exe' | Select-Object -ExpandProperty browser_download_url
+          $packageVersion = (${{ toJSON(github.event.release.tag_name) }}).Trim('v')
+
+          # Update package using wingetcreate
+          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          .\wingetcreate.exe update Microsoft.SBOMTool --version $packageVersion --urls $installerUrl --submit --token "${{ secrets.WINGET_GITHUB_TOKEN }}"


### PR DESCRIPTION
- Related to #196


This PR proposes to add a GitHub action for submitting the latest stable release to WinGet as it gets published. [microsoft/winget-create](https://github.com/microsoft/winget-create) is used as the tool for submitting the latest package.

## Steps needed from maintainers

If the maintainers approve of these changes, they will need to do the following before merging this PR:

1. Fork [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) under a personal or bot account. I see a fork already created https://github.com/DaveTryon/winget-pkgs so I'm assuming that would be the one used here
2. Create a [public access token (classic)](https://github.com/microsoft/winget-create?tab=readme-ov-file#github-personal-access-token-classic-permissions) with [`public_repo`](https://raw.githubusercontent.com/microsoft/winget-create/main/doc/images/tokenscope-publicrepo.png) scope from the user account where the fork exists.
3. Store the created token in a repository secret here with the name `WINGET_GITHUB_TOKEN`


For reference, maintainers may see similar implemented actions in the following repos:
[Terminal](https://github.com/microsoft/terminal/blob/main/.github/workflows/winget.yml), [DevHome](https://github.com/microsoft/devhome/blob/main/.github/workflows/winget-submission.yml), [PowerToys](https://github.com/microsoft/PowerToys/blob/main/.github/workflows/package-submissions.yml), [Oh-my-posh](https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/.github/workflows/winget.yml)