### PR TITLE
Pin ubuntu runner to 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os:
           - windows-latest
-          - ubuntu-latest
+          - ubuntu-22.04
           - macos-latest
           - macos-latest-large
 


### PR DESCRIPTION
This is the PR called out in #855 to unblock PR builds. It pins the GitHub runner environment at `ubuntu-22.04`, which still has the `mono` package that we need for some tests.