### PR TITLE
Add skipBuildTagsForGitHubPullRequests setting to PR pipeline

### DIFF
--- a/pipelines/sbom-tool-pr-build.yaml
+++ b/pipelines/sbom-tool-pr-build.yaml
@@ -19,6 +19,8 @@ extends:
       sourceAnalysisPool:
         name: sbom-windows-build-pool
         os: windows
+    settings:
+      skipBuildTagsForGitHubPullRequests: true
     stages:
       - stage: stage1
         jobs:


### PR DESCRIPTION
Adding setting recommended in [enghub docs](https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/sdlanalysis/sourceanalysisstage#i-use-a-github-repo-and-my-pipeline-is-failing-in-step-tag-build-and-log-custom-issues-1es-pt-with-access-denied-error-how-should-i-resolve)