### PR TITLE
Switch DataTestMethod to DataTestMethod (part 2)

### DIFF
--- a/test/Microsoft.Sbom.Parsers.Spdx30SbomParser.Tests/Parser/SbomFileParserTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx30SbomParser.Tests/Parser/SbomFileParserTests.cs
@@ -12,10 +12,9 @@ namespace Microsoft.Sbom.Parser;
 [TestClass]
 public class SbomFileParserTests : SbomParserTestsBase
 {
-    [DataTestMethod]
+    [TestMethod]
     [DataRow(SbomFullDocWithFilesStrings.SbomFileWithMissingNameJsonString)]
     [DataRow(SbomFullDocWithFilesStrings.SbomFileWithMissingSpdxIdJsonString)]
-    [TestMethod]
     public void MissingPropertiesTest_Throws(string json)
     {
         var bytes = Encoding.UTF8.GetBytes(json);

--- a/test/Microsoft.Sbom.Parsers.Spdx30SbomParser.Tests/Parser/SbomMetadataParserTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx30SbomParser.Tests/Parser/SbomMetadataParserTests.cs
@@ -120,10 +120,9 @@ public class SbomMetadataParserTests : SbomParserTestsBase
         Assert.ThrowsException<EndOfStreamException>(() => new SPDXParser(stream));
     }
 
-    [DataTestMethod]
+    [TestMethod]
     [DataRow(SbomFullDocWithMetadataJsonStrings.MalformedJsonEmptyObject)]
     [DataRow(SbomFullDocWithMetadataJsonStrings.MalformedJsonEmptyArray)]
-    [TestMethod]
     public void MalformedJsonTest_Throws(string json)
     {
         var bytes = Encoding.UTF8.GetBytes(json);


### PR DESCRIPTION
PR #849 converted the `[DataTestMethod]` attributes to `[TestMethod]` because they're interchangeable but `[DataTestMethod]` may not be supported in the future. After #849 was authored, 2 additional unit tests were added using the `[DataTestMethod]` attribute. This PR simply makes the same changes in the 2 recently added unit tests. It converts the `[DataTestMethod]` to `[TestMethod]`, then deletes the duplicate `[TestMethod]` since the tests had both attributes.