### PR TITLE
Add a workflow to comment on API changes

### DIFF
--- a/.github/workflows/pr-comment-api-change.md
+++ b/.github/workflows/pr-comment-api-change.md
@@ -8,7 +8,7 @@ Because any of these changes can potentially break a downstream consumer with cu
 ## Option 1 - Publish this as a breaking change
 1. Update the documentation to show the new functionality
 2. Bump the major version in the next release
-3. Be sure to highlight of the breaking changes in the release notes
+3. Be sure to highlight the breaking changes in the release notes
 
 ## Option 2 - Refactor the changes to be non-breaking
 1. Review [this commit](https://github.com/microsoft/sbom-tool/commit/4d0ce83e194ed6feace53666aeb6280f5b8b8769), which adds a new interface in a backward-compatible way

--- a/.github/workflows/pr-comment-api-change.md
+++ b/.github/workflows/pr-comment-api-change.md
@@ -1,4 +1,15 @@
-You touched the API project. Did you change _any_ of the API interfaces in _any way_? If so, this is an API-breaking change. Please be sure you do the following:
+This PR changes files in the API project. Does it change _any_ of the API interfaces in _any way_? Please note that this includes the following types of changes:
+- Changing the signature of an existing interface method
+- Adding a new method to an existing interface
+- Adding a required data member to a class that an existing interface method consumes
 
-1. Bump the major version in the next release
-2. Update the documentation to show the new functionality
+Because any of these changes can potentially break a downstream consumer with customized interface implementations, these changes need to be treated as breaking changes. Please do one of the following:
+
+## Option 1 - Publish this as a breaking change
+1. Update the documentation to show the new functionality and/or explain the change
+2. Bump the major version in the next release
+
+## Option 2 - Refactor the changes to be non-breaking
+1. Review [this commit](https://github.com/microsoft/sbom-tool/commit/4d0ce83e194ed6feace53666aeb6280f5b8b8769), which adds a new interface in a backward-compatible way
+2. Refactor the change to follow this pattern so that existing interfaces are left completely intact
+3. Bump the minor version in the next release

--- a/.github/workflows/pr-comment-api-change.md
+++ b/.github/workflows/pr-comment-api-change.md
@@ -6,8 +6,9 @@ This PR changes files in the API project. Does it change _any_ of the API interf
 Because any of these changes can potentially break a downstream consumer with customized interface implementations, these changes need to be treated as breaking changes. Please do one of the following:
 
 ## Option 1 - Publish this as a breaking change
-1. Update the documentation to show the new functionality and/or explain the change
+1. Update the documentation to show the new functionality
 2. Bump the major version in the next release
+3. Be sure to highlight of the breaking changes in the release notes
 
 ## Option 2 - Refactor the changes to be non-breaking
 1. Review [this commit](https://github.com/microsoft/sbom-tool/commit/4d0ce83e194ed6feace53666aeb6280f5b8b8769), which adds a new interface in a backward-compatible way

--- a/.github/workflows/pr-comment-api-change.md
+++ b/.github/workflows/pr-comment-api-change.md
@@ -1,0 +1,4 @@
+You touched the API project. Did you change _any_ of the API interfaces in _any way_? If so, this is an API-breaking change. Please be sure you do the following:
+
+1. Bump the major version in the next release
+2. Update the documentation to show the new functionality

--- a/.github/workflows/pr-comment-api-change.yml
+++ b/.github/workflows/pr-comment-api-change.yml
@@ -1,0 +1,22 @@
+name: Check for API changes
+
+on:
+  pull_request:
+    paths:
+      - 'src/Microsoft.Sbom.Api/**/*.cs'
+      
+jobs:
+  auto-comment:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: PR Comment
+        run:
+          gh pr comment $PRNUM --body-file .github/workflows/pr-comment-api-change.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PRNUM: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Last year, we introduced a breaking change into the API without taking the versioning into account. In order to prevent that sort of change in the future, this PR adds a workflow that inserts a PR comment to encourage people to think through the versioning before merging the PR. This was developed and iterated in #884, and you can view the PR comment on [this PR comment](https://github.com/microsoft/sbom-tool/pull/884#issuecomment-2607835094).

The PR comment itself lives in a markdown file, so extending the comment itself is straightforward.

This workflow is targeted by changes to `.cs` files in the `src\Microsoft.Sbom.Api` path, so this workflow will not run on PR's that do not satisfy the targeting requirement. It will also run after each push to the PR--we may want to scale that down eventually, but for now, it's a good way to ensure that we're catching all the changes.