### PR TITLE
Bump MSTest.Test* from 3.7.0 to 3.7.2

### DIFF
--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -13,8 +13,8 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.3" />
     <PackageVersion Include="FluentAssertions" Version="7.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="3.7.0" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.7.0" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.7.2" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.7.2" />
     <PackageVersion Include="Moq" Version="4.20.72" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Dependabot opened #887 and #889 to update (respectively) MSTest.TestFramework and MSTest.TestAdapter from 3.7.0 to 3.7.2. Both of those PR's failed when running the tests, which I was able to repro locally. Updating them simultaneously allowed the tests to run locally. This PR simply combines the changes from the dependabot PR's into a single PR.