### PR TITLE
Bump component-detection from 5.1.6 to 5.2.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     </PackageVersion>
   </ItemDefinitionGroup>
   <PropertyGroup>
-    <ComponentDetectionPackageVersion>5.1.6</ComponentDetectionPackageVersion>
+    <ComponentDetectionPackageVersion>5.2.1</ComponentDetectionPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AutoMapper" Version="10.1.1" />


### PR DESCRIPTION
We're several versions behind on component-detection. This moves us to the most current version