### PR TITLE
Collect code coverage

### DIFF
--- a/pipelines/build-test-tool-template.yaml
+++ b/pipelines/build-test-tool-template.yaml
@@ -24,6 +24,7 @@ steps:
       arguments: '--collect:"XPlat Code Coverage;Format=Cobertura"'
 
   - task: PublishCodeCoverageResults@2
-    displayName: "Publish code coverage"
+    displayName: "Publish code coverage (Windows only)"
+    condition: eq(variables['Agent.OS'], 'Windows_NT')
     inputs:
       summaryFileLocation: '$(Agent.TempDirectory)/**/coverage.cobertura.xml'

--- a/pipelines/build-test-tool-template.yaml
+++ b/pipelines/build-test-tool-template.yaml
@@ -20,4 +20,10 @@ steps:
   - task: DotNetCoreCLI@2
     displayName: Run tests
     inputs:
-      command: test --collect:"XPlat Code Coverage"
+      command: test
+      arguments: '--collect:"XPlat Code Coverage;Format=Cobertura"'
+
+  - task: PublishCodeCoverageResults@2
+    displayName: "Publish code coverage"
+    inputs:
+      summaryFileLocation: '$(Agent.TempDirectory)/**/coverage.cobertura.xml'

--- a/pipelines/build-test-tool-template.yaml
+++ b/pipelines/build-test-tool-template.yaml
@@ -20,4 +20,10 @@ steps:
   - task: DotNetCoreCLI@2
     displayName: Run tests
     inputs:
-      command: 'test'
+      command: 'test --collect:"XPlat Code Coverage"'
+
+  - task: PublishCodeCoverageResults@1
+    inputs:
+      codecoverageTool: 'Cobertura'
+      summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.cobertura.xml'
+      reportDirectory: '$(System.DefaultWorkingDirectory)/**/site/cobertura'

--- a/pipelines/build-test-tool-template.yaml
+++ b/pipelines/build-test-tool-template.yaml
@@ -20,10 +20,4 @@ steps:
   - task: DotNetCoreCLI@2
     displayName: Run tests
     inputs:
-      command: 'test --collect:"XPlat Code Coverage"'
-
-  - task: PublishCodeCoverageResults@1
-    inputs:
-      codecoverageTool: 'Cobertura'
-      summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.cobertura.xml'
-      reportDirectory: '$(System.DefaultWorkingDirectory)/**/site/cobertura'
+      command: test --collect:"XPlat Code Coverage"

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -3,10 +3,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="coverlet.collector">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="MSTest.TestAdapter"/>
     <PackageReference Include="MSTest.TestFramework"/>


### PR DESCRIPTION
We currently produce no code coverage in our build pipelines. Clicking on the "Code Coverage" tab (sample [link](https://dev.azure.com/mseng/AzureDevOps/_build/results?buildId=29532738&view=codecoverage-tab) produces a blank page. This PR collects code coverage data during tests and publishes it to the "Code Coverage" tab.

Some observations:
1. The Code Coverage tab organizes data by path. The paths are different on Windows, Linux, and macOS, and that gets confusing. To keep the tab simple, only the Windows results are published there
2. Full coverage results are published in HTML format as a build artifact
3. So far, coverage data is only available at the file level--ideally we'd be able to get method and line level information. Perhaps that's a future improvement.
4. Collecting and organizing the code coverage data makes the PR builds slower by a minute or so