### PR TITLE
Remove FluentAssertions from tests

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -11,7 +11,6 @@
     <PackageReference Include="MSTest.TestAdapter"/>
     <PackageReference Include="MSTest.TestFramework"/>
     <PackageReference Include="Moq"/>
-    <PackageReference Include="FluentAssertions"/>
   </ItemGroup>
 
 </Project>

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -11,7 +11,6 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="FluentAssertions" Version="7.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="MSTest.TestAdapter" Version="3.7.2" />
     <PackageVersion Include="MSTest.TestFramework" Version="3.7.2" />


### PR DESCRIPTION
The current build references `FluentAssertions` in `test/Directory.Build.props` and `test/Directory.Packages.props`, but they are never referenced in the test code.