### PR TITLE
Address a targeted set of analyzer warnings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -461,7 +461,7 @@ stylecop.documentation.xmlHeader = false
 
 # SA1623: Property summary documentation must match accessors
 # Justification: It's noise to start a summary with "Gets" or "Sets"
-# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1200.md
+# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1623.md
 dotnet_diagnostic.SA1623.severity = none
 
 # CA1859: Use concrete types when possible

--- a/.editorconfig
+++ b/.editorconfig
@@ -619,7 +619,7 @@ dotnet_diagnostic.SA1625.severity = suggestion
 
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1626.md
 # SA1626: Single-line comments should not use documentation style slashes
-dotnet_diagnostic.SA1626.severity = suggestion
+dotnet_diagnostic.SA1626.severity = error
 
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1627.md
 # SA1627: Documentation text should not be empty

--- a/.editorconfig
+++ b/.editorconfig
@@ -952,7 +952,7 @@ dotnet_diagnostic.CS8632.severity = suggestion
 
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0005
 # IDE0005: Using directive is unnecessary
-dotnet_diagnostic.IDE0005.severity = suggestion
+dotnet_diagnostic.IDE0005.severity = error
 
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0009
 # IDE0009: Add 'this' or 'Me' qualification

--- a/.editorconfig
+++ b/.editorconfig
@@ -752,7 +752,7 @@ dotnet_diagnostic.CA1311.severity = suggestion
 
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1508
 # CA1508: Avoid dead conditional code
-dotnet_diagnostic.CA1508.severity = suggestion
+dotnet_diagnostic.CA1508.severity = error
 
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1510
 # CA1510: Use '...' instead of explicitly throwing a new exception instance

--- a/.editorconfig
+++ b/.editorconfig
@@ -676,7 +676,7 @@ dotnet_diagnostic.CA1032.severity = suggestion
 
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1040
 # CA1040: Avoid empty interfaces
-dotnet_diagnostic.CA1040.severity = suggestion
+dotnet_diagnostic.CA1040.severity = error
 
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1041
 # CA1041: Provide ObsoleteAttribute message

--- a/.editorconfig
+++ b/.editorconfig
@@ -615,7 +615,7 @@ dotnet_diagnostic.SA1622.severity = suggestion
 
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1625.md
 # SA1625: Element documentation should not be copied and pasted
-dotnet_diagnostic.SA1625.severity = suggestion
+dotnet_diagnostic.SA1625.severity = error
 
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1626.md
 # SA1626: Single-line comments should not use documentation style slashes

--- a/.editorconfig
+++ b/.editorconfig
@@ -631,7 +631,7 @@ dotnet_diagnostic.SA1629.severity = suggestion
 
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1633.md
 # SA1633: File should have header
-dotnet_diagnostic.SA1633.severity = suggestion
+dotnet_diagnostic.SA1633.severity = error
 
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1642.md
 # SA1642: Constructor summary documentation should begin with standard text

--- a/.editorconfig
+++ b/.editorconfig
@@ -543,7 +543,7 @@ dotnet_diagnostic.SA1204.severity = suggestion
 
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1207.md
 # SA1207: Member attributes should follow the order
-dotnet_diagnostic.SA1207.severity = suggestion
+dotnet_diagnostic.SA1207.severity = error
 
 # https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1214.md
 # SA1214: Readonly fields must appear before non-readonly fields

--- a/src/Microsoft.Sbom.Api/Config/ApiConfigurationBuilder.cs
+++ b/src/Microsoft.Sbom.Api/Config/ApiConfigurationBuilder.cs
@@ -25,8 +25,8 @@ public static class ApiConfigurationBuilder
     /// </summary>
     /// <param name="rootPath">Path where package exists. If scanning start here.</param>
     /// <param name="manifestDirPath">Output path to where manifest is generated.</param>
-    /// <param name="files">Use null to scan.</param>
-    /// <param name="packages">Use null to scan.</param>
+    /// <param name="files">Use null to scan all files.</param>
+    /// <param name="packages">Use null to scan all packages.</param>
     /// <param name="metadata"></param>
     /// <param name="specifications"></param>
     /// <param name="runtimeConfiguration"></param>

--- a/src/Microsoft.Sbom.Api/Config/Args/FormatValidationArgs.cs
+++ b/src/Microsoft.Sbom.Api/Config/Args/FormatValidationArgs.cs
@@ -1,10 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using Microsoft.Sbom.Api.Utils;
-using Microsoft.Sbom.Extensions.Entities;
 using PowerArgs;
 
 namespace Microsoft.Sbom.Api.Config.Args;

--- a/src/Microsoft.Sbom.Api/Config/Args/GenerationAndValidationCommonArgs.cs
+++ b/src/Microsoft.Sbom.Api/Config/Args/GenerationAndValidationCommonArgs.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using Microsoft.Sbom.Common.Config;
 using Microsoft.Sbom.Extensions.Entities;
 using PowerArgs;
-using Serilog.Events;
 
 namespace Microsoft.Sbom.Api.Config.Args;
 

--- a/src/Microsoft.Sbom.Api/Config/ConfigFileParser.cs
+++ b/src/Microsoft.Sbom.Api/Config/ConfigFileParser.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.Sbom.Common;

--- a/src/Microsoft.Sbom.Api/Config/ConfigPostProcessor.cs
+++ b/src/Microsoft.Sbom.Api/Config/ConfigPostProcessor.cs
@@ -4,13 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.IO;
-using System.Linq;
 using AutoMapper;
 using Microsoft.Sbom.Api.Output.Telemetry;
 using Microsoft.Sbom.Common;
 using Microsoft.Sbom.Common.Config;
-using Microsoft.Sbom.Common.Config.Attributes;
 using Microsoft.Sbom.Common.Config.Validators;
 using Microsoft.Sbom.Common.Utils;
 using PowerArgs;

--- a/src/Microsoft.Sbom.Api/Config/ConfigSanitizer.cs
+++ b/src/Microsoft.Sbom.Api/Config/ConfigSanitizer.cs
@@ -3,15 +3,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Reflection;
-using Microsoft.Sbom.Api.Executors;
 using Microsoft.Sbom.Api.Hashing;
 using Microsoft.Sbom.Api.Utils;
 using Microsoft.Sbom.Common;
 using Microsoft.Sbom.Common.Config;
-using Microsoft.Sbom.Common.Config.Attributes;
 using Microsoft.Sbom.Common.Utils;
 using Microsoft.Sbom.Contracts.Enums;
 using Microsoft.Sbom.Extensions.Entities;

--- a/src/Microsoft.Sbom.Api/Config/ISbomService.cs
+++ b/src/Microsoft.Sbom.Api/Config/ISbomService.cs
@@ -9,7 +9,9 @@ namespace Microsoft.Sbom.Api.Config;
 /// Marker interface for an SBOM service.
 /// </summary>
 /// <typeparam name="T">The type of arguments against which this service is run.</typeparam>
+#pragma warning disable CA1040 // Avoid empty interfaces
 public interface ISbomService<T>
+#pragma warning restore CA1040 // Avoid empty interfaces
     where T : CommonArgs
 {
 }

--- a/src/Microsoft.Sbom.Api/Config/ValueConverters/NullableBoolConfigurationSettingAddingConverter.cs
+++ b/src/Microsoft.Sbom.Api/Config/ValueConverters/NullableBoolConfigurationSettingAddingConverter.cs
@@ -28,7 +28,7 @@ internal class NullableBoolConfigurationSettingAddingConverter : IValueConverter
         return new ConfigurationSetting<bool>
         {
             Source = settingSource,
-            Value = sourceMember ?? false
+            Value = sourceMember.Value
         };
     }
 }

--- a/src/Microsoft.Sbom.Api/Executors/EnumeratorChannel.cs
+++ b/src/Microsoft.Sbom.Api/Executors/EnumeratorChannel.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using Microsoft.Sbom.Api.Entities;
-using Microsoft.Sbom.Api.Output.Telemetry;
 using Microsoft.Sbom.JsonAsynchronousNodeKit.Exceptions;
 using Serilog;
 

--- a/src/Microsoft.Sbom.Api/Executors/FileHasher.cs
+++ b/src/Microsoft.Sbom.Api/Executors/FileHasher.cs
@@ -12,7 +12,6 @@ using Microsoft.Sbom.Api.Hashing;
 using Microsoft.Sbom.Api.Manifest;
 using Microsoft.Sbom.Api.Utils;
 using Microsoft.Sbom.Common.Config;
-using Microsoft.Sbom.Contracts;
 using Microsoft.Sbom.Contracts.Enums;
 using Microsoft.Sbom.Entities;
 using Microsoft.Sbom.Extensions;

--- a/src/Microsoft.Sbom.Api/Executors/FileHasher.cs
+++ b/src/Microsoft.Sbom.Api/Executors/FileHasher.cs
@@ -72,16 +72,6 @@ public class FileHasher
         ManifestGeneratorProvider manifestGeneratorProvider,
         IFileTypeUtils fileTypeUtils)
     {
-        if (configuration is null)
-        {
-            throw new ArgumentNullException(nameof(configuration));
-        }
-
-        if (manifestGeneratorProvider is null)
-        {
-            throw new ArgumentNullException(nameof(manifestGeneratorProvider));
-        }
-
         this.hashCodeGenerator = hashCodeGenerator ?? throw new ArgumentNullException(nameof(hashCodeGenerator));
         this.manifestPathConverter = manifestPathConverter ?? throw new ArgumentNullException(nameof(manifestPathConverter));
         this.log = log ?? throw new ArgumentNullException(nameof(log));

--- a/src/Microsoft.Sbom.Api/Executors/FileListEnumerator.cs
+++ b/src/Microsoft.Sbom.Api/Executors/FileListEnumerator.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Channels;
 using System.Threading.Tasks;

--- a/src/Microsoft.Sbom.Api/Executors/HashValidator.cs
+++ b/src/Microsoft.Sbom.Api/Executors/HashValidator.cs
@@ -6,7 +6,6 @@ using System.Threading.Channels;
 using System.Threading.Tasks;
 using Microsoft.Sbom.Api.Entities;
 using Microsoft.Sbom.Common.Config;
-using Microsoft.Sbom.Contracts;
 using Microsoft.Sbom.Extensions.Entities;
 
 namespace Microsoft.Sbom.Api.Executors;

--- a/src/Microsoft.Sbom.Api/Executors/ILicenseInformationFetcher2.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ILicenseInformationFetcher2.cs
@@ -1,10 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.ComponentDetection.Contracts.BcdeModels;
 
 namespace Microsoft.Sbom.Api.Executors;
 

--- a/src/Microsoft.Sbom.Api/Executors/RelationshipGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Executors/RelationshipGenerator.cs
@@ -7,7 +7,6 @@ using System.Text.Json;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using Microsoft.Sbom.Api.Manifest;
-using Microsoft.Sbom.Extensions;
 using Microsoft.Sbom.Extensions.Entities;
 
 namespace Microsoft.Sbom.Api.Executors;

--- a/src/Microsoft.Sbom.Api/FormatValidator/ValidatedSBOM.cs
+++ b/src/Microsoft.Sbom.Api/FormatValidator/ValidatedSBOM.cs
@@ -115,14 +115,14 @@ public class ValidatedSBOM: IValidatedSBOM
             return ValidationDetails;
         }
 
-        if (SPDXVersionParser.VersionMatchesRequiredVersion(sbom?.Version, requiredSpdxMajorVersion))
+        if (SPDXVersionParser.VersionMatchesRequiredVersion(sbom.Version, requiredSpdxMajorVersion))
         {
             ValidationDetails.AggregateValidationStatus(FormatValidationStatus.Valid);
             return ValidationDetails;
         }
 
         ValidationDetails.AggregateValidationStatus(FormatValidationStatus.NotValid);
-        ValidationDetails.Errors.Add($"SBOM version {sbom?.Version} is not recognized as SPDX major version 2.");
+        ValidationDetails.Errors.Add($"SBOM version {sbom.Version} is not recognized as SPDX major version 2.");
         return ValidationDetails;
     }
 

--- a/src/Microsoft.Sbom.Api/PackageDetails/ComponentDetailsUtils/RubyGemsUtils.cs
+++ b/src/Microsoft.Sbom.Api/PackageDetails/ComponentDetailsUtils/RubyGemsUtils.cs
@@ -12,7 +12,6 @@ using Microsoft.Sbom.Api.Exceptions;
 using Microsoft.Sbom.Api.Output.Telemetry;
 using Microsoft.Sbom.Common;
 using Serilog;
-using File = System.IO.File;
 
 namespace Microsoft.Sbom.Api.PackageDetails;
 

--- a/src/Microsoft.Sbom.Api/Providers/ExternalDocumentReferenceProviders/CGExternalDocumentReferenceProvider.cs
+++ b/src/Microsoft.Sbom.Api/Providers/ExternalDocumentReferenceProviders/CGExternalDocumentReferenceProvider.cs
@@ -8,7 +8,6 @@ using System.Threading.Channels;
 using Microsoft.ComponentDetection.Contracts.BcdeModels;
 using Microsoft.Sbom.Api.Converters;
 using Microsoft.Sbom.Api.Entities;
-using Microsoft.Sbom.Api.Exceptions;
 using Microsoft.Sbom.Api.Executors;
 using Microsoft.Sbom.Api.Utils;
 using Microsoft.Sbom.Common.Config;

--- a/src/Microsoft.Sbom.Api/Providers/FilesProviders/CGScannedExternalDocumentReferenceFileProvider.cs
+++ b/src/Microsoft.Sbom.Api/Providers/FilesProviders/CGScannedExternalDocumentReferenceFileProvider.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Threading.Channels;
 using Microsoft.Sbom.Api.Converters;
 using Microsoft.Sbom.Api.Entities;
-using Microsoft.Sbom.Api.Exceptions;
 using Microsoft.Sbom.Api.Executors;
 using Microsoft.Sbom.Api.Utils;
 using Microsoft.Sbom.Common.Config;

--- a/src/Microsoft.Sbom.Api/Utils/ComponentDetectorCachedExecutor.cs
+++ b/src/Microsoft.Sbom.Api/Utils/ComponentDetectorCachedExecutor.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Contracts.BcdeModels;
 using Microsoft.ComponentDetection.Orchestrator.Commands;
 using Serilog;
-using Spectre.Console.Cli;
 
 namespace Microsoft.Sbom.Api.Utils;
 

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/PackageArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/PackageArrayGenerator.cs
@@ -10,7 +10,6 @@ using Microsoft.Sbom.Api.Output.Telemetry;
 using Microsoft.Sbom.Api.Providers;
 using Microsoft.Sbom.Api.Utils;
 using Microsoft.Sbom.Extensions;
-using Microsoft.Sbom.Extensions.Entities;
 using Serilog;
 
 namespace Microsoft.Sbom.Api.Workflows.Helpers;

--- a/src/Microsoft.Sbom.Api/Workflows/SBOMRedactionWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SBOMRedactionWorkflow.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.Sbom.Api.FormatValidator;

--- a/src/Microsoft.Sbom.Common/Config/IConfiguration.cs
+++ b/src/Microsoft.Sbom.Common/Config/IConfiguration.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.Sbom.Common.Config.Attributes;
 using Microsoft.Sbom.Contracts;
 using Microsoft.Sbom.Contracts.Enums;

--- a/src/Microsoft.Sbom.Common/FileSystemUtils.cs
+++ b/src/Microsoft.Sbom.Common/FileSystemUtils.cs
@@ -49,7 +49,6 @@ public abstract class FileSystemUtils : IFileSystemUtils
         Path.Join(root, relativePath, secondRelativePath);
 
     /// <inheritdoc />
-    /// <inheritdoc />
     public string GetRelativePath(string relativeTo, string path) => Path.GetRelativePath(relativeTo, path);
 
     /// <inheritdoc />

--- a/src/Microsoft.Sbom.Common/GeneratorUtils.cs
+++ b/src/Microsoft.Sbom.Common/GeneratorUtils.cs
@@ -4,8 +4,6 @@
 namespace Microsoft.Sbom.Common;
 
 using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using Microsoft.Sbom.Contracts;
 using Microsoft.Sbom.Contracts.Enums;

--- a/src/Microsoft.Sbom.Common/InternalMetadataProviderIdentityExtensions.cs
+++ b/src/Microsoft.Sbom.Common/InternalMetadataProviderIdentityExtensions.cs
@@ -4,11 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Security.Cryptography;
-using System.Text;
 using Microsoft.Sbom.Extensions;
 using Microsoft.Sbom.Extensions.Entities;
-using HashAlgorithmName = Microsoft.Sbom.Contracts.Enums.AlgorithmName;
 
 namespace Microsoft.Sbom.Common;
 

--- a/src/Microsoft.Sbom.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Sbom.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -5,7 +5,6 @@ using System.Collections.Concurrent;
 using Microsoft.ComponentDetection.Orchestrator;
 using Microsoft.ComponentDetection.Orchestrator.Extensions;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Sbom.Api;
 using Microsoft.Sbom.Api.Config;
@@ -41,7 +40,6 @@ using Serilog.Events;
 using Serilog.Extensions.Logging;
 using Serilog.Filters;
 using Constants = Microsoft.Sbom.Api.Utils.Constants;
-using IComponentDetector = Microsoft.ComponentDetection.Contracts.IComponentDetector;
 using ILogger = Serilog.ILogger;
 
 namespace Microsoft.Sbom.Extensions.DependencyInjection;

--- a/src/Microsoft.Sbom.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Sbom.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -103,7 +103,7 @@ public static class ServiceCollectionExtensions
             .AddTransient<RelationshipGenerator>()
             .AddTransient<ConfigSanitizer>()
             .AddTransient<IProcessExecutor, ProcessExecutor>()
-            .AddTransient<Api.Utils.IComponentDetector, ComponentDetector>()
+            .AddTransient<IComponentDetector, ComponentDetector>()
             .AddTransient<IMetadataBuilderFactory, MetadataBuilderFactory>()
             .AddTransient<FileInfoWriter>()
             .AddTransient<ComponentToExternalReferenceInfoConverter>()

--- a/src/Microsoft.Sbom.Extensions/Entities/ManifestInfo.cs
+++ b/src/Microsoft.Sbom.Extensions/Entities/ManifestInfo.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Sbom.Extensions.Entities;
 

--- a/src/Microsoft.Sbom.Extensions/Exceptions/MissingHashValueException.cs
+++ b/src/Microsoft.Sbom.Extensions/Exceptions/MissingHashValueException.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Runtime.Serialization;
 
 namespace Microsoft.Sbom.Extensions.Exceptions;
 

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SPDXRelationship.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/SPDXRelationship.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Text.Json.Serialization;
-using Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities.Enums;
 
 namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
 

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Snippet.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Entities/Snippet.cs
@@ -3,7 +3,6 @@
 
 namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
 
-using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Exceptions/MissingHashValueException.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Exceptions/MissingHashValueException.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Runtime.Serialization;
 
 namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Exceptions;
 

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/SPDXExtensions.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/SPDXExtensions.cs
@@ -186,6 +186,7 @@ public static class SPDXExtensions
         return referenceCategory.ToString().Replace('_', '-');
     }
 
+    /// <summary>
     /// Compute the SHA256 string representation (omitting dashes) of a given string
     /// </summary>
     /// <remarks>

--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/AnyLicenseInfo.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/AnyLicenseInfo.cs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Microsoft.Sbom.Parsers.Spdx30SbomParser.Entities;
 
 /// <summary>

--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/ContentIdentifier.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/ContentIdentifier.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.Sbom.Parsers.Spdx30SbomParser.Entities;

--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/Element.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/Element.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 

--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/Enums/ComplianceStandard.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/Enums/ComplianceStandard.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.Sbom.Parsers.Spdx30SbomParser.Entities.Enums;

--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/ExternalIdentifier.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/ExternalIdentifier.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 

--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/File.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/File.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections;
-using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.Sbom.Parsers.Spdx30SbomParser.Entities;

--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/NTIAFile.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/NTIAFile.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 

--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/NTIASpdxDocument.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/NTIASpdxDocument.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
 using System.Text.Json.Serialization;
-using Microsoft.Sbom.Parsers.Spdx30SbomParser.Entities.Enums;
 
 namespace Microsoft.Sbom.Parsers.Spdx30SbomParser.Entities;
 

--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/NoAssertionElement.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/NoAssertionElement.cs
@@ -1,10 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections;
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Microsoft.Sbom.Parsers.Spdx30SbomParser.Entities;
 
 public class NoAssertionElement : Element

--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/NoneElement.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/NoneElement.cs
@@ -1,10 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections;
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 namespace Microsoft.Sbom.Parsers.Spdx30SbomParser.Entities;
 
 public class NoneElement : Element

--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/Organization.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/Organization.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.Sbom.Parsers.Spdx30SbomParser.Entities;
 
-using System.Text.Json.Serialization;
-
 /// <summary>
 /// https://spdx.github.io/spdx-spec/v3.0.1/model/Core/Classes/Organization/
 /// </summary>

--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/Package.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/Package.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.Sbom.Parsers.Spdx30SbomParser.Entities;

--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/Person.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/Person.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.Sbom.Parsers.Spdx30SbomParser.Entities;
 
-using System.Text.Json.Serialization;
-
 /// <summary>
 /// https://spdx.github.io/spdx-spec/v3.0.1/model/Core/Classes/Person/
 /// </summary>

--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/Relationship.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/Relationship.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
-using Microsoft.Sbom.Extensions.Entities;
 using RelationshipType = Microsoft.Sbom.Parsers.Spdx30SbomParser.Entities.Enums.RelationshipType;
 
 namespace Microsoft.Sbom.Parsers.Spdx30SbomParser.Entities;

--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/Snippet.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/Snippet.cs
@@ -3,10 +3,6 @@
 
 namespace Microsoft.Sbom.Parsers.Spdx30SbomParser.Entities;
 
-using System;
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-
 /// <summary>
 /// https://spdx.github.io/spdx-spec/v3.0.1/model/Software/Classes/Snippet/
 /// </summary>

--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/Software.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/Software.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using Microsoft.Sbom.Parsers.Spdx30SbomParser.Entities;
 

--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/Tool.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Entities/Tool.cs
@@ -3,8 +3,6 @@
 
 namespace Microsoft.Sbom.Parsers.Spdx30SbomParser.Entities;
 
-using System.Text.Json.Serialization;
-
 /// <summary>
 /// A tool is an element of hardware and/or software utilized to carry out a particular function.
 /// https://spdx.github.io/spdx-spec/v3.0.1/model/Core/Classes/Tool/

--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Exceptions/MissingHashValueException.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Exceptions/MissingHashValueException.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Runtime.Serialization;
 
 namespace Microsoft.Sbom.Parsers.Spdx30SbomParser.Exceptions;
 

--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Parser/ContextsResult.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Parser/ContextsResult.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Sbom.JsonAsynchronousNodeKit;
-using Microsoft.Sbom.Parsers.Spdx30SbomParser.Entities;
 
 namespace Microsoft.Sbom.Parser;
 

--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Parser/ParserResults.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Parser/ParserResults.cs
@@ -3,7 +3,6 @@
 
 namespace Microsoft.Sbom.Parser;
 
-using System.Collections.Generic;
 using Microsoft.Sbom.Parsers.Spdx30SbomParser.Entities;
 
 public class ParserResults

--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Parser/SPDX30Parser.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Parser/SPDX30Parser.cs
@@ -4,15 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.Sbom.Contracts;
 using Microsoft.Sbom.Extensions.Entities;
 using Microsoft.Sbom.JsonAsynchronousNodeKit;
 using Microsoft.Sbom.JsonAsynchronousNodeKit.Exceptions;
-using Microsoft.Sbom.Parsers.Spdx30SbomParser.Entities;
 using Microsoft.Sbom.Parsers.Spdx30SbomParser.Entities.Enums;
 using SPDXConstants = Microsoft.Sbom.Parsers.Spdx30SbomParser.Constants;
 

--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Utils/SPDXExtensions.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Utils/SPDXExtensions.cs
@@ -8,12 +8,9 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.Sbom.Contracts;
-using Microsoft.Sbom.Contracts.Entities;
 using Microsoft.Sbom.Contracts.Enums;
-using Microsoft.Sbom.Extensions.Entities;
 using Microsoft.Sbom.Extensions.Exceptions;
 using Microsoft.Sbom.Parsers.Spdx30SbomParser.Entities;
-using Microsoft.Sbom.Parsers.Spdx30SbomParser.Entities.Enums;
 
 namespace Microsoft.Sbom.Parsers.Spdx30SbomParser.Utils;
 

--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Utils/SPDXExtensions.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Utils/SPDXExtensions.cs
@@ -151,6 +151,7 @@ public static class SPDXExtensions
         element.SpdxId = GenerateSpdxId(element, id);
     }
 
+    /// <summary>
     /// Compute the SHA256 string representation (omitting dashes) of a given string
     /// </summary>
     /// <remarks>

--- a/src/Microsoft.Sbom.Targets/GenerateSbom.cs
+++ b/src/Microsoft.Sbom.Targets/GenerateSbom.cs
@@ -3,9 +3,6 @@
 
 namespace Microsoft.Sbom.Targets;
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics.Tracing;
 using Microsoft.Build.Framework;
 
 /// <summary>

--- a/src/Microsoft.Sbom.Targets/GenerateSbomTask.cs
+++ b/src/Microsoft.Sbom.Targets/GenerateSbomTask.cs
@@ -5,9 +5,6 @@ namespace Microsoft.Sbom.Targets;
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.Tracing;
-using System.IO;
-using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/src/Microsoft.Sbom.Targets/SbomCLIToolTask.cs
+++ b/src/Microsoft.Sbom.Targets/SbomCLIToolTask.cs
@@ -3,7 +3,6 @@
 
 namespace Microsoft.Sbom.Targets;
 
-using System;
 using System.IO;
 using Microsoft.Build.Utilities;
 

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -2,6 +2,10 @@
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>
 
+  <PropertyGroup Label="Build">
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>  <!-- Required for IDE0005 rule -->
+  </PropertyGroup>
+  
   <ItemGroup Label="Package References">
     <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigSanitizerTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigSanitizerTests.cs
@@ -9,7 +9,6 @@ using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using Microsoft.Sbom.Api.Config;
 using Microsoft.Sbom.Api.Exceptions;
-using Microsoft.Sbom.Api.Executors;
 using Microsoft.Sbom.Api.Hashing;
 using Microsoft.Sbom.Api.Utils;
 using Microsoft.Sbom.Common;

--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsBase.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsBase.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Sbom.Api.Config.Tests;
 public class ConfigurationBuilderTestsBase
 {
     protected Mock<IFileSystemUtils> fileSystemUtilsMock;
-    protected private IMapper mapper;
+    private protected IMapper mapper;
     protected ConfigValidator[] configValidators;
     protected Mock<IAssemblyConfig> mockAssemblyConfig;
 

--- a/test/Microsoft.Sbom.Api.Tests/ConsoleCapture.cs
+++ b/test/Microsoft.Sbom.Api.Tests/ConsoleCapture.cs
@@ -43,17 +43,17 @@ internal class ConsoleCapture
     {
         if (stdOutWriter is not null)
         {
-            CapturedStdOut = stdOutWriter?.ToString() ?? string.Empty;
+            CapturedStdOut = stdOutWriter.ToString() ?? string.Empty;
             Console.SetOut(oldStdOut);
-            stdOutWriter?.Dispose();
+            stdOutWriter.Dispose();
             stdOutWriter = null;
         }
 
         if (stdErrWriter is not null)
         {
-            CapturedStdError = stdErrWriter?.ToString() ?? string.Empty;
+            CapturedStdError = stdErrWriter.ToString() ?? string.Empty;
             Console.SetError(oldStdError);
-            stdErrWriter?.Dispose();
+            stdErrWriter.Dispose();
             stdErrWriter = null;
         }
     }

--- a/test/Microsoft.Sbom.Api.Tests/Converters/ComponentToExternalReferenceInfoConverterTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Converters/ComponentToExternalReferenceInfoConverterTests.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Microsoft.ComponentDetection.Contracts.BcdeModels;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.Sbom.Api.Converters;
-using Microsoft.Sbom.Api.Entities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Serilog;

--- a/test/Microsoft.Sbom.Api.Tests/Converters/ExternalReferenceInfoToPathConverterTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Converters/ExternalReferenceInfoToPathConverterTest.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using Microsoft.Sbom.Api.Converters;
-using Microsoft.Sbom.Api.Entities;
 using Microsoft.Sbom.Extensions.Entities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;

--- a/test/Microsoft.Sbom.Api.Tests/Converters/SbomToolManifestPathConverterTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Converters/SbomToolManifestPathConverterTests.cs
@@ -8,7 +8,6 @@ using Microsoft.Sbom.Common;
 using Microsoft.Sbom.Common.Config;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using PowerArgs;
 
 namespace Microsoft.Sbom.Api.Convertors.Tests;
 

--- a/test/Microsoft.Sbom.Api.Tests/Executors/ExternalDocumentReferenceWriterTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/ExternalDocumentReferenceWriterTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.Text.Json;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using Microsoft.Sbom.Api.Executors;

--- a/test/Microsoft.Sbom.Api.Tests/Executors/RelationshipGeneratorTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/RelationshipGeneratorTest.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading;
-using System.Threading.Channels;
 using System.Threading.Tasks;
 using Microsoft.Sbom.Api.Manifest;
 using Microsoft.Sbom.Extensions;

--- a/test/Microsoft.Sbom.Api.Tests/FormatValidator/SpdxExemplars.cs
+++ b/test/Microsoft.Sbom.Api.Tests/FormatValidator/SpdxExemplars.cs
@@ -3,12 +3,6 @@
 
 namespace Microsoft.Sbom.Api.Tests.FormatValidator;
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 internal readonly struct SpdxExemplars
 {
     public const string JsonSpdx23Exemplar = /*lang=json,strict*/ @"{

--- a/test/Microsoft.Sbom.Api.Tests/Hashing/HashCodeGeneratorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Hashing/HashCodeGeneratorTests.cs
@@ -9,7 +9,6 @@ using Microsoft.Sbom.Contracts;
 using Microsoft.Sbom.Contracts.Enums;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using PowerArgs;
 
 namespace Microsoft.Sbom.Api.Hashing.Tests;
 

--- a/test/Microsoft.Sbom.Api.Tests/Utils/ComponentDetectionCliArgumentBuilderTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Utils/ComponentDetectionCliArgumentBuilderTests.cs
@@ -4,11 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using Microsoft.ComponentDetection.Orchestrator.Commands;
 using Microsoft.Sbom.Api.Utils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using PowerArgs;
 using static Microsoft.Sbom.Api.Tests.Utils.ComponentDetectionCliArgumentBuilderTestsExtensions;
 
 namespace Microsoft.Sbom.Api.Tests.Utils;

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/ManifestGenerationWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/ManifestGenerationWorkflowTests.cs
@@ -39,7 +39,6 @@ using Microsoft.Sbom.Extensions.Entities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Newtonsoft.Json.Linq;
-using Serilog.Events;
 using Checksum = Microsoft.Sbom.Contracts.Checksum;
 using Constants = Microsoft.Sbom.Api.Utils.Constants;
 using IComponentDetector = Microsoft.Sbom.Api.Utils.IComponentDetector;

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/SbomRedactionWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/SbomRedactionWorkflowTests.cs
@@ -15,7 +15,6 @@ using Microsoft.Sbom.Common.Config;
 using Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using PowerArgs;
 using Serilog;
 
 namespace Microsoft.Sbom.Workflows;

--- a/test/Microsoft.Sbom.Parsers.Spdx30SbomParser.Tests/Parser/SbomParserTestsBase.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx30SbomParser.Tests/Parser/SbomParserTestsBase.cs
@@ -207,7 +207,7 @@ public abstract class SbomParserTestsBase
 
             var fileHasSha256Hash = fileElement.VerifiedUsing.
                 Any(packageVerificationCode => packageVerificationCode.Algorithm ==
-                Parsers.Spdx30SbomParser.Entities.Enums.HashAlgorithm.sha256);
+                HashAlgorithm.sha256);
 
             if (!fileHasSha256Hash)
             {
@@ -230,7 +230,7 @@ public abstract class SbomParserTestsBase
 
             var packageHasSha256Hash = packageElement.VerifiedUsing.
                 Any(packageVerificationCode => packageVerificationCode.Algorithm ==
-                Parsers.Spdx30SbomParser.Entities.Enums.HashAlgorithm.sha256);
+                HashAlgorithm.sha256);
 
             if (!packageHasSha256Hash)
             {

--- a/test/Microsoft.Sbom.Targets.E2E.Tests/ProjectSamples/ProjectSample1/SampleLibrary.cs
+++ b/test/Microsoft.Sbom.Targets.E2E.Tests/ProjectSamples/ProjectSample1/SampleLibrary.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-using System;
 
 public class SampleLibrary
 {

--- a/test/Microsoft.Sbom.Targets.Tests/AbstractGenerateSbomTaskInputTests.cs
+++ b/test/Microsoft.Sbom.Targets.Tests/AbstractGenerateSbomTaskInputTests.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+#if NET472
 using System.Linq;
+#endif
 using System.Reflection;
 using System.Text.RegularExpressions;
 using Microsoft.Build.Framework;

--- a/test/Microsoft.Sbom.Targets.Tests/GenerateSbomTaskSPDX_2_2Tests.cs
+++ b/test/Microsoft.Sbom.Targets.Tests/GenerateSbomTaskSPDX_2_2Tests.cs
@@ -3,11 +3,6 @@
 
 namespace Microsoft.Sbom.Targets.Tests;
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 /// <summary>


### PR DESCRIPTION
Issue #340 provides a long list of analyzer warnings that were added to prevent a build break. The vast majority of the warnings on this list are extraordinarily pedantic, and some of them actually go against what I would consider best practices. I grabbed a few of the rules that seemed worthwhile and didn't represent a huge impact, and made the appropriate changes. At some point, we may want to officially ignore analyzer warnings that we actively don't want. This PR adds enforcement of the following analyzer warnings:

ID/Link | Description | Comment
--- | --- | ---
[IDE0005](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0005) | Using directive is unnecessary | Cleaned up the using blocks that the compiler says it's not using. I had to tell the test code to generate XML comments to enable this--that seems odd but not-problematic
[CA1040](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1040) | Avoid empty interfaces | We only had one, and it exists for a reason, so I suppressed the warning on that one
[CA1508](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1508) | Avoid dead conditional code | Nobody wants dead code
[SA1207](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1207.md) | Member attributes should follow the order | OK, this is pedantic but it only changed 1 line of code
[SA1633](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1633.md) | File should have header | This was probably fixed by #347 but the flag was never enforced
[SA1626](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1626.md) | Single-line comments should not use documentation style slashes | Another pedantic one, but Visual Studio was whining and the fix was trivial
[SA1625](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1625.md) | Element documentation should not be copied and pasted | Another pedantic one, but Visual Studio was whining and the fix was trivial

**Note**: This will probably best be reviewed on a per-commit basis. It will flag the banner about changing the API, but it can be ignored because we're not actually changing any of the API surfaces.