### PR TITLE
Revert extra dependency that we added in #758

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,6 @@
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.7.8" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.4" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="8.0.2" />
     <PackageVersion Include="Microsoft.ComponentDetection.Common" Version="$(ComponentDetectionPackageVersion)" />
     <PackageVersion Include="Microsoft.ComponentDetection.Contracts" Version="$(ComponentDetectionPackageVersion)" />

--- a/src/Microsoft.Sbom.Api/Microsoft.Sbom.Api.csproj
+++ b/src/Microsoft.Sbom.Api/Microsoft.Sbom.Api.csproj
@@ -32,7 +32,6 @@
 
     <ItemGroup>
         <!-- Pinned assemblies for transitive dependencies -->
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" /> <!-- Used by ComponentDetection -->
         <PackageReference Include="System.Net.Http" />                     <!-- Used by ComponentDetection -->
     </ItemGroup>
 


### PR DESCRIPTION
This PR reverts #758, which was needed until we consumed a component-detection version of 5.1.6 or newer. #894 recently moved us to version 5.2.1, so we can now make this change. The original intent was to add a direct dependency on `Microsoft.Extensions.Caching.Memory` of version 8.0.1, so that we would override the transitive dependency on version 8.0.0 that we were inheriting from component-detection.

Here are redacted before and after of `dotnet nuget why Microsoft.Sbom.sln Microsoft.Extensions.Caching.Memory`:

Before (using 8.0.1 via a direct dependency from `Microsoft.Sbom.Api`)
```
Project 'Microsoft.Sbom.Tool' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   ├─ Microsoft.Sbom.Api (v1.0.0)
   │  ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
   │  │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   │  ├─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
   │  │  └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
   │  │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   └─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
      └─ Microsoft.Sbom.Api (v1.0.0)
         ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
         │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
         ├─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
         │  └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
         │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
         └─ Microsoft.Extensions.Caching.Memory (v8.0.1)

Project 'Microsoft.Sbom.Api' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
   │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   ├─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
   │  └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
   │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   └─ Microsoft.Extensions.Caching.Memory (v8.0.1)

Project 'Microsoft.Sbom.Api.Tests' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   └─ Microsoft.Sbom.Api (v1.0.0)
      ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
      │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      ├─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
      │  └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
      │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      └─ Microsoft.Extensions.Caching.Memory (v8.0.1)

Project 'Microsoft.Sbom.DotNetTool' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   ├─ Microsoft.Sbom.Api (v1.0.0)
   │  ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
   │  │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   │  ├─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
   │  │  └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
   │  │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   └─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
      └─ Microsoft.Sbom.Api (v1.0.0)
         ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
         │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
         ├─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
         │  └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
         │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
         └─ Microsoft.Extensions.Caching.Memory (v8.0.1)

Project 'Microsoft.Sbom.Extensions.DependencyInjection' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   └─ Microsoft.Sbom.Api (v1.0.0)
      ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
      │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      ├─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
      │  └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
      │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
Project 'Microsoft.Sbom.Extensions.DependencyInjection.Tests' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':

  [net8.0]
   │  
   └─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
      └─ Microsoft.Sbom.Api (v1.0.0)
         ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
         │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
         ├─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
         │  └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
         │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
         └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
Project 'Microsoft.Sbom.Targets' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':

  [net8.0]
   │  
   ├─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
   │  └─ Microsoft.Sbom.Api (v1.0.0)
   │     ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
   │     │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   │     ├─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
   │     │  └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
   │     │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   └─ Microsoft.Sbom.Tool (v1.0.0)
      ├─ Microsoft.Sbom.Api (v1.0.0)
      │  ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
      │  │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      │  ├─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
      │  │  └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
      │  │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      └─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
         └─ Microsoft.Sbom.Api (v1.0.0)
            ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
            │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
            ├─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
            │  └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
            │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
            └─ Microsoft.Extensions.Caching.Memory (v8.0.1)

Project 'Microsoft.Sbom.Targets.Tests' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   ├─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
   │  └─ Microsoft.Sbom.Api (v1.0.0)
   │     ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
   │     │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   │     ├─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
   │     │  └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
   │     │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   └─ Microsoft.Sbom.Tool (v1.0.0)
      ├─ Microsoft.Sbom.Api (v1.0.0)
      │  ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
      │  │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      │  ├─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
      │  │  └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
      │  │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      └─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
         └─ Microsoft.Sbom.Api (v1.0.0)
            ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
            │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
            ├─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
            │  └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
            │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
            └─ Microsoft.Extensions.Caching.Memory (v8.0.1)

Project 'Microsoft.Sbom.Tool.Tests' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   └─ Microsoft.Sbom.Tool (v1.0.0)
      ├─ Microsoft.Sbom.Api (v1.0.0)
      │  ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
      │  │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      │  ├─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
      │  │  └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
      │  │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      └─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
         └─ Microsoft.Sbom.Api (v1.0.0)
            ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
            │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
            ├─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
            │  └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
            │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
            └─ Microsoft.Extensions.Caching.Memory (v8.0.1)

Project 'Microsoft.Sbom.Targets.E2E.Tests' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   └─ Microsoft.Sbom.Tool (v1.0.0)
      ├─ Microsoft.Sbom.Api (v1.0.0)
      │  ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
      │  │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      │  ├─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
      │  │  └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
      │  │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      └─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
         └─ Microsoft.Sbom.Api (v1.0.0)
            ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
            │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
            ├─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
            │  └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
            │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
            └─ Microsoft.Extensions.Caching.Memory (v8.0.1)

Project 'Microsoft.Sbom.Parsers.Spdx30SbomParser.Tests' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':

  [net8.0]
   │  
   ├─ Microsoft.Sbom.Api (v1.0.0)
   │  ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
   │  │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   │  ├─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
   │  │  └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
   │  │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   └─ Microsoft.Sbom.Api.Tests (v1.0.0)
      └─ Microsoft.Sbom.Api (v1.0.0)
         ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
         │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
         ├─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
         │  └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
         │     └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
         └─ Microsoft.Extensions.Caching.Memory (v8.0.1)

```

After (still using version 8.0.1, but via the transitive dependency from `Microsoft.ComponentDetection.Detectors`):
```
Project 'Microsoft.Sbom.Tool' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   ├─ Microsoft.Sbom.Api (v1.0.0)
   │  ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
   │  │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   │  └─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
   │     └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
   │        └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   └─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
      └─ Microsoft.Sbom.Api (v1.0.0)
         ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
         │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
         └─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
            └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
               └─ Microsoft.Extensions.Caching.Memory (v8.0.1)

Project 'Microsoft.Sbom.Api' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
   │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   └─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
      └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
         └─ Microsoft.Extensions.Caching.Memory (v8.0.1)

Project 'Microsoft.Sbom.Api.Tests' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   └─ Microsoft.Sbom.Api (v1.0.0)
      ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
      │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      └─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
         └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
            └─ Microsoft.Extensions.Caching.Memory (v8.0.1)

Project 'Microsoft.Sbom.DotNetTool' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   ├─ Microsoft.Sbom.Api (v1.0.0)
   │  ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
   │  │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   │  └─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
   │     └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
   │        └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   └─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
      └─ Microsoft.Sbom.Api (v1.0.0)
         ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
         │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
         └─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
            └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
               └─ Microsoft.Extensions.Caching.Memory (v8.0.1)

Project 'Microsoft.Sbom.Extensions.DependencyInjection' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   └─ Microsoft.Sbom.Api (v1.0.0)
      ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
      │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      └─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
         └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
            └─ Microsoft.Extensions.Caching.Memory (v8.0.1)

Project 'Microsoft.Sbom.Extensions.DependencyInjection.Tests' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   └─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
      └─ Microsoft.Sbom.Api (v1.0.0)
         ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
         │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
         └─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
            └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
               └─ Microsoft.Extensions.Caching.Memory (v8.0.1)

Project 'Microsoft.Sbom.Targets' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   ├─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
   │  └─ Microsoft.Sbom.Api (v1.0.0)
   │     ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
   │     │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   │     └─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
   │        └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
   │           └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   └─ Microsoft.Sbom.Tool (v1.0.0)
      ├─ Microsoft.Sbom.Api (v1.0.0)
      │  ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
      │  │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      │  └─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
      │     └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
      │        └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      └─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
         └─ Microsoft.Sbom.Api (v1.0.0)
            ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
            │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
            └─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
               └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
                  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)

Project 'Microsoft.Sbom.Targets.Tests' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   ├─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
   │  └─ Microsoft.Sbom.Api (v1.0.0)
   │     ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
   │     │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   │     └─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
   │        └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
   │           └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   └─ Microsoft.Sbom.Tool (v1.0.0)
      ├─ Microsoft.Sbom.Api (v1.0.0)
      │  ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
      │  │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      │  └─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
      │     └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
      │        └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      └─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
         └─ Microsoft.Sbom.Api (v1.0.0)
            ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
            │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
            └─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
               └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
                  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)

Project 'Microsoft.Sbom.Tool.Tests' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   └─ Microsoft.Sbom.Tool (v1.0.0)
      ├─ Microsoft.Sbom.Api (v1.0.0)
      │  ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
      │  │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      │  └─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
      │     └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
      │        └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      └─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
         └─ Microsoft.Sbom.Api (v1.0.0)
            ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
            │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
            └─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
               └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
                  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)

Project 'Microsoft.Sbom.Targets.E2E.Tests' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   └─ Microsoft.Sbom.Tool (v1.0.0)
      ├─ Microsoft.Sbom.Api (v1.0.0)
      │  ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
      │  │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      │  └─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
      │     └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
      │        └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
      └─ Microsoft.Sbom.Extensions.DependencyInjection (v1.0.0)
         └─ Microsoft.Sbom.Api (v1.0.0)
            ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
            │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
            └─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
               └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
                  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)

Project 'Microsoft.Sbom.Parsers.Spdx30SbomParser.Tests' has the following dependency graph(s) for 'Microsoft.Extensions.Caching.Memory':
  [net8.0]
   │  
   ├─ Microsoft.Sbom.Api (v1.0.0)
   │  ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
   │  │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   │  └─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
   │     └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
   │        └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
   └─ Microsoft.Sbom.Api.Tests (v1.0.0)
      └─ Microsoft.Sbom.Api (v1.0.0)
         ├─ Microsoft.ComponentDetection.Detectors (v5.2.1)
         │  └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
         └─ Microsoft.ComponentDetection.Orchestrator (v5.2.1)
            └─ Microsoft.ComponentDetection.Detectors (v5.2.1)
               └─ Microsoft.Extensions.Caching.Memory (v8.0.1)
```