### PR TITLE
Target E2E tests with net472 only on Windows

### DIFF
--- a/test/Microsoft.Sbom.Targets.E2E.Tests/Microsoft.Sbom.Targets.E2E.Tests.csproj
+++ b/test/Microsoft.Sbom.Targets.E2E.Tests/Microsoft.Sbom.Targets.E2E.Tests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net8.0;net472</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net8.0</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <IsPackable>false</IsPackable>
     <SignAssembly>True</SignAssembly>


### PR DESCRIPTION
While helping with #881, I noticed that the `Microsoft.Sbom.Targets.E2E.Tests` project was targeting `net472` on non-windows platforms, but that none of them were actually running. Tests for `Linux`, `macOS`, and `macOS-arm64` all produced the error message, with minor variation in the root path (line breaks added to make it simpler to read):

```
No test is available in <root>/s/test/Microsoft.Sbom.Targets.E2E.Tests/bin/Debug/net472/Microsoft.Sbom.Targets.E2E.Tests.dll.
Make sure that test discoverer & executors are registered and platform & framework version settings are appropriate and try again.
```

The `Microsoft.Sbom.Targets.Tests` [project](https://github.com/microsoft/sbom-tool/blob/main/test/Microsoft.Sbom.Targets.Tests/Microsoft.Sbom.Targets.Tests.csproj#L4-L5) already restricts net472 targeting to Windows. This PR simply brings the same pattern to the E2E tests. It doesn't actually change what tests are running, but explicitly identifies the effective state of the tests. This change is needed for #881 to proceed successfully.