### PR TITLE
Specify correct image for running on osx-arm64

### DIFF
--- a/pipelines/sbom-tool-main-build.yaml
+++ b/pipelines/sbom-tool-main-build.yaml
@@ -276,7 +276,7 @@ extends:
               artifactName: '$(OutputArtifactName)-macOS-arm64'
           pool:
             name: Azure Pipelines
-            image: macos-latest
+            image: macos-14-arm64
             os: macOS
           steps:
           - template: pipelines/build-test-tool-template.yaml@self

--- a/pipelines/sbom-tool-pr-build.yaml
+++ b/pipelines/sbom-tool-pr-build.yaml
@@ -53,7 +53,7 @@ extends:
           displayName: 'Build (macOS-arm64)'
           pool:
             name: Azure Pipelines
-            image: macos-latest
+            image: macos-14-arm64
             os: macOS
           steps:
           - template: pipelines/build-test-tool-template.yaml@self


### PR DESCRIPTION
As called out in #912, we're not currently running our CI or PR builds on osx-arm64. This was a typo in #756 for the CI build, and that got repeated for the PR build in #875. This PR corrects the image to use `macos-14-arm64` for both the CI and PR builds, which is the image that we use in our internal validation pipeline. This image is an internal-only resource, but it leverages the runner configuration described at https://github.com/actions/runner-images/blob/macos-14-arm64/20250127.794/images/macos/macos-14-arm64-Readme.md.