### PR TITLE
Disable CodeQL until they fix the osx-arm64 problem

### DIFF
--- a/pipelines/sbom-tool-main-build.yaml
+++ b/pipelines/sbom-tool-main-build.yaml
@@ -35,6 +35,10 @@ extends:
       sourceAnalysisPool:
         name: sbom-windows-build-pool
         os: windows
+      codeql:
+        compiled:
+          enabled: false
+          justificationForDisabling: 'Temporarily disable CodeQL until .NET 8/osx-arm64 problem is addressed'        
     stages:
       - stage: stage1
         jobs:


### PR DESCRIPTION
CodeQL has a problem running with .NET 8 on osx-arm64 systems, which is breaking our CI build. We're temporarily disabling CodeQL to unblock the CI build while still retaining full support for osx-arm64.

We've filed an issue with the CodeQL team and will be able to revert this change once a fixed version is released.