### PR TITLE
Pin Microsoft.IO.Redist in net472 tests

### DIFF
--- a/test/Microsoft.Sbom.Targets.E2E.Tests/Microsoft.Sbom.Targets.E2E.Tests.csproj
+++ b/test/Microsoft.Sbom.Targets.E2E.Tests/Microsoft.Sbom.Targets.E2E.Tests.csproj
@@ -43,6 +43,11 @@
     <None Include="ProjectSamples\ProjectSample1\ProjectSample1.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Pinned assemblies for transitive dependencies -->
+    <PackageReference Condition="'$(TargetFramework)'=='net472'" Include="Microsoft.IO.Redist" /> <!-- Used by Microsoft.Build -->
+  </ItemGroup>
+
   <!--Build and copy the sbom-tool to the output directory-->
   <Target Name="AddSbomToolToPackage" AfterTargets="Build" Condition="$(TargetFramework) == 'net472'">
     <Message Importance="high" Text="Building $(SBOMCLIToolProjectDir)bin\$(Configuration)\$(SbomCLIToolTargetFramework)" />

--- a/test/Microsoft.Sbom.Targets.Tests/Microsoft.Sbom.Targets.Tests.csproj
+++ b/test/Microsoft.Sbom.Targets.Tests/Microsoft.Sbom.Targets.Tests.csproj
@@ -22,6 +22,11 @@
     <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Pinned assemblies for transitive dependencies -->
+    <PackageReference Condition="'$(TargetFramework)'=='net472'" Include="Microsoft.IO.Redist" /> <!-- Used by Microsoft.Build -->
+  </ItemGroup>
+
   <Target Name="AddSbomToolToPackage" AfterTargets="Build" Condition="$(TargetFramework) == 'net472'">
     <Message Importance="high" Text="Building $(SBOMCLIToolProjectDir)bin\$(Configuration)\$(SbomCLIToolTargetFramework)" />
     <MSBuild Projects="$(SBOMCLIToolProjectDir)Microsoft.Sbom.Tool.csproj" Properties="TargetFramework=$(SbomCLIToolTargetFramework)" Targets="Publish" />


### PR DESCRIPTION
CVE-2024-38081 calls out a vulnerability in `Microsoft.IO.Redist` 6.0.0, which is fixed in 6.0.1. We already use 6.1.0 in our shipping bits, but the net472 tests are stuck on an older version of `Microsoft.Build`, which still uses version 6.0.0 of `Microsoft.IO.Redist`. This adds `net472`-specific pins to the test projects, so that CG will no longer complain about this package.