### PR TITLE
Fix NugetPackagesPath

### DIFF
--- a/src/Microsoft.Sbom.Api/PackageDetails/ComponentDetailsUtils/NugetUtils.cs
+++ b/src/Microsoft.Sbom.Api/PackageDetails/ComponentDetailsUtils/NugetUtils.cs
@@ -23,7 +23,7 @@ public class NugetUtils : IPackageManagerUtils<NugetUtils>
     private readonly ILogger log;
     private readonly IRecorder recorder;
 
-    private static readonly string NugetPackagesPath = SettingsUtility.GetGlobalPackagesFolder(new NullSettings());
+    private static readonly string NugetPackagesPath = SettingsUtility.GetGlobalPackagesFolder(Settings.LoadDefaultSettings(null, null, null));
 
     public NugetUtils(IFileSystemUtils fileSystemUtils, ILogger log, IRecorder recorder)
     {


### PR DESCRIPTION
`globalPackagesFolder` can be redefined by `nuget.config`.

`NullSettings` does not use `nuget.config`.

We should use `DefaultSettings` instead of `NullSettings`.