### PR TITLE
Clean apt cache in Dockerfile to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM mcr.microsoft.com/dotnet/runtime-deps:7.0.20-bullseye-slim-amd64
 WORKDIR /app/src/Microsoft.Sbom.Tool
 COPY --from=build-env /app/src/Microsoft.Sbom.Tool/output .
 
-RUN apt update -y && apt install -y python golang nuget npm cargo ruby maven
+RUN apt update -y && apt install -y python golang nuget npm cargo ruby maven && rm -rf /var/lib/apt/lists/*
 RUN useradd -ms /bin/bash sbom
 USER sbom
 ENTRYPOINT ["./Microsoft.Sbom.Tool"]


### PR DESCRIPTION
This is the exact same change as #553, which we can't merge directly because it's stale and the fork owner hasn't responded to requests for a refresh. The change applies a docker best practice as illustrated at https://docs.docker.com/build/building/best-practices