### PR TITLE
Check for invalid manifestInfo's during the redaction workflow

### DIFF
--- a/src/Microsoft.Sbom.Api/Utils/Constants.cs
+++ b/src/Microsoft.Sbom.Api/Utils/Constants.cs
@@ -47,6 +47,11 @@ public static class Constants
         SPDX30ManifestInfo
     };
 
+    public static Collection<ManifestInfo> SupportedSpdxManifestsForRedaction = new()
+    {
+        SPDX22ManifestInfo
+    };
+
     public static List<Entities.ErrorType> SkipFailureReportingForErrors = new()
     {
         Entities.ErrorType.ManifestFolder,

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/SbomRedactionWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/SbomRedactionWorkflowTests.cs
@@ -163,6 +163,12 @@ public class SbomRedactionWorkflowTests
     {
         configurationMock.SetupGet(c => c.SbomDir).Returns(new ConfigurationSetting<string> { Value = SbomDirStub });
         configurationMock.SetupGet(c => c.OutputPath).Returns(new ConfigurationSetting<string> { Value = OutDirStub });
+        var validManifestInfo = new ConfigurationSetting<IList<ManifestInfo>>
+        {
+            Value = new List<ManifestInfo> { new ManifestInfo { Name = "SPDX", Version = "2.2" } }
+        };
+
+        configurationMock.SetupGet(c => c.ManifestInfo).Returns(validManifestInfo);
         fileSystemUtilsMock.Setup(m => m.DirectoryExists(SbomDirStub)).Returns(true).Verifiable();
         fileSystemUtilsMock.Setup(m => m.DirectoryExists(OutDirStub)).Returns(true).Verifiable();
         fileSystemUtilsMock.Setup(m => m.GetFullPath(SbomDirStub)).Returns(SbomDirStub).Verifiable();


### PR DESCRIPTION
Redaction for SBOM's is only supported for SPDX 2.2 manifests. Any other manifestInfo should not be supported when the customer uses the -redact CLI command on the SBOM tool.