### PR TITLE
Add runsettings file to avoid local UT failures

### DIFF
--- a/.runsettings
+++ b/.runsettings
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RunSettings>
     <RunConfiguration>
-        <ResultsDirectory>C:\Users\ppandrate\source\repos\sbom-tool\test\.\%temp%\sbom-tool-test-results</ResultsDirectory>
+        <ResultsDirectory>$(SolutionDir)test\.\%temp%\sbom-tool-test-results</ResultsDirectory>
     </RunConfiguration>
 </RunSettings>

--- a/.runsettings
+++ b/.runsettings
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+    <RunConfiguration>
+        <ResultsDirectory>C:\Users\ppandrate\source\repos\sbom-tool\test\.\%temp%\sbom-tool-test-results</ResultsDirectory>
+    </RunConfiguration>
+</RunSettings>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -41,4 +41,8 @@
     <StrongNameSigningPublicKey>0024000004800000940000000602000000240000525341310004000001000100c1f8987b4994a7ec30c5ba8253a8a6322b40642ef9d5dbc96828bda61a5a8bf1fa1667ee6fdda72fc29b00686a2e8d37984c37ef90b2d51a5c8767c5e6fb35ff9d4516a77929626db1d06297f90c2950e87e1fcd335bd82d73e1c37d1da42afb1e41397be50aac74895b873a8bad90c2caee9d7c9e34b94ff255cb040630ad94</StrongNameSigningPublicKey>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <RunSettingsFilePath>$(SolutionDir).runsettings</RunSettingsFilePath>
+  </PropertyGroup>
+
 </Project>

--- a/Microsoft.Sbom.sln
+++ b/Microsoft.Sbom.sln
@@ -15,6 +15,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		Directory.Build.props = Directory.Build.props
+		.runsettings = .runsettings
 		Directory.Build.targets = Directory.Build.targets
 		Directory.Packages.props = Directory.Packages.props
 		global.json = global.json


### PR DESCRIPTION
This issue https://github.com/microsoft/sbom-tool/issues/930 documents local unit test failures caused by locked files. By adding a runsettings file we create a temp directory for local unit test results which avoids locked file issues. 