### PR TITLE
Manifest info name should be case insensitive

### DIFF
--- a/src/Microsoft.Sbom.Api/Config/Validators/ManifestInfoValidator.cs
+++ b/src/Microsoft.Sbom.Api/Config/Validators/ManifestInfoValidator.cs
@@ -27,7 +27,7 @@ public class ManifestInfoValidator : ConfigValidator
         if (paramValue is not null && paramValue is List<ManifestInfo> listOfManifestInfos && !Constants.SupportedSpdxManifests.Any(listOfManifestInfos.Contains))
         {
             var supportedManifests = string.Join(", ", Constants.SupportedSpdxManifests.Select(m => m.ToString()));
-            throw new ValidationArgException($"Please provide a valid value for the ManifestInfo (-mi) parameter. Supported values include: {supportedManifests}");
+            throw new ValidationArgException($"Please provide a valid value for the ManifestInfo (-mi) parameter. Supported values include: {supportedManifests}. The values are case-insensitive.");
         }
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/Config/Validators/ManifestInfoValidatorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/Validators/ManifestInfoValidatorTests.cs
@@ -19,7 +19,6 @@ public class ManifestInfoValidatorTests
     [DataRow("randomName", "2.2")]
     [DataRow("randomName", "3.0")]
     [DataRow("SPDX", "randomVersion")]
-    [DataRow("spdx", "randomVersion")]
     [DataRow("asodijf", "randomVersion")]
     [TestMethod]
     public void InvalidManifestInfoThrows(string name, string version)
@@ -36,14 +35,16 @@ public class ManifestInfoValidatorTests
         Assert.ThrowsException<ValidationArgException>(() => validator.ValidateInternal("property", listOfManifestInfos, null));
     }
 
-    [DataRow("2.2")]
-    [DataRow("3.0")]
+    [DataRow("SPDX", "2.2")]
+    [DataRow("SPDX", "3.0")]
+    [DataRow("spdx", "2.2")]
+    [DataRow("spdx", "3.0")]
     [TestMethod]
-    public void ValidManifestInfoPasses(string spdxVersion)
+    public void ValidManifestInfoPasses(string name, string spdxVersion)
     {
         var validManifestInfo = new ManifestInfo
         {
-            Name = "SPDX",
+            Name = name,
             Version = spdxVersion
         };
 

--- a/test/Microsoft.Sbom.Tool.Tests/IntegrationTests.cs
+++ b/test/Microsoft.Sbom.Tool.Tests/IntegrationTests.cs
@@ -162,7 +162,7 @@ public class IntegrationTests
         arguments += " -mi randomName:randomVersion";
 
         var (stdout, stderr, exitCode) = LaunchAndCaptureOutput(arguments);
-        Assert.AreEqual("Please provide a valid value for the ManifestInfo (-mi) parameter. Supported values include: SPDX:2.2, SPDX:3.0\r\n", stderr);
+        Assert.AreEqual("Please provide a valid value for the ManifestInfo (-mi) parameter. Supported values include: SPDX:2.2, SPDX:3.0. The values are case-insensitive.\r\n", stderr);
         Assert.AreNotEqual(0, exitCode.Value);
     }
 

--- a/test/Microsoft.Sbom.Tool.Tests/IntegrationTests.cs
+++ b/test/Microsoft.Sbom.Tool.Tests/IntegrationTests.cs
@@ -142,7 +142,7 @@ public class IntegrationTests
         var testFolderPath = CreateTestFolder();
         var arguments = $"generate -ps IntegrationTests -pn IntegrationTests -pv 1.2.3 -m \"{testFolderPath}\" -b . -bc \"{GetSolutionFolderPath()}\" -mi randomName:randomVersion";
         var (stdout, stderr, exitCode) = LaunchAndCaptureOutput(arguments);
-        Assert.AreEqual("Please provide a valid value for the ManifestInfo (-mi) parameter. Supported values include: SPDX:2.2, SPDX:3.0\r\n", stderr);
+        Assert.AreEqual("Please provide a valid value for the ManifestInfo (-mi) parameter. Supported values include: SPDX:2.2, SPDX:3.0. The values are case-insensitive.\r\n", stderr);
         Assert.AreNotEqual(0, exitCode.Value);
     }
 


### PR DESCRIPTION
Existing code has an overriden `Equals()` method that returns true even if the manifestInfo has differing cases. This PR updates the manifestInfoValidator error message to indicate that and also adds unit tests to validate the behavior.