### PR TITLE
Refactor external doc refs generation

### DIFF
--- a/src/Microsoft.Sbom.Api/Executors/GenerationResult.cs
+++ b/src/Microsoft.Sbom.Api/Executors/GenerationResult.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Text.Json;
 using Microsoft.Sbom.Api.Entities;
-using Microsoft.Sbom.Api.Providers;
 using Microsoft.Sbom.Extensions;
 
 namespace Microsoft.Sbom.Api.Workflows.Helpers;
@@ -19,18 +17,17 @@ public class GenerationResult
 
     public Dictionary<IManifestToolJsonSerializer, List<JsonDocument>> SerializerToJsonDocuments { get; set; }
 
-    public IEnumerable<ISourcesProvider> SourcesProviders { get; set; }
+    public bool JsonArrayStarted { get; set; }
 
     /// <summary>
     /// Result from generators. This result is used to write to the SBOM manifest file.
     /// </summary>
     /// <param name="errors">List of FileValidationResult errors.</param>
     /// <param name="serializerToJsonDocuments">Dictionary to map serializer to the JSON document that should be written to it.</param>
-    /// <param name="sourcesProviders">Only used for the external document reference generator in SPDX 2.2.</param>
-    public GenerationResult(List<FileValidationResult> errors, Dictionary<IManifestToolJsonSerializer, List<JsonDocument>> serializerToJsonDocuments, IEnumerable<ISourcesProvider> sourcesProviders = null)
+    public GenerationResult(List<FileValidationResult> errors, Dictionary<IManifestToolJsonSerializer, List<JsonDocument>> serializerToJsonDocuments, bool jsonArrayStarted = false)
     {
         Errors = errors;
         SerializerToJsonDocuments = serializerToJsonDocuments;
-        SourcesProviders = sourcesProviders ?? Enumerable.Empty<ISourcesProvider>();
+        JsonArrayStarted = jsonArrayStarted;
     }
 }

--- a/src/Microsoft.Sbom.Api/Executors/GenerationResult.cs
+++ b/src/Microsoft.Sbom.Api/Executors/GenerationResult.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 using Microsoft.Sbom.Api.Entities;
 using Microsoft.Sbom.Api.Providers;
@@ -30,5 +31,6 @@ public class GenerationResult
     {
         Errors = errors;
         SerializerToJsonDocuments = serializerToJsonDocuments;
+        SourcesProviders = sourcesProviders ?? Enumerable.Empty<ISourcesProvider>();
     }
 }

--- a/src/Microsoft.Sbom.Api/Executors/GenerationResult.cs
+++ b/src/Microsoft.Sbom.Api/Executors/GenerationResult.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Text.Json;
 using Microsoft.Sbom.Api.Entities;
 using Microsoft.Sbom.Api.Providers;

--- a/src/Microsoft.Sbom.Api/Executors/GenerationResult.cs
+++ b/src/Microsoft.Sbom.Api/Executors/GenerationResult.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 using Microsoft.Sbom.Api.Entities;
 using Microsoft.Sbom.Api.Providers;
@@ -20,10 +21,15 @@ public class GenerationResult
 
     public IEnumerable<ISourcesProvider> SourcesProviders { get; set; }
 
+    /// <summary>
+    /// Result from generators. This result is used to write to the SBOM manifest file.
+    /// </summary>
+    /// <param name="errors">List of FileValidationResult errors.</param>
+    /// <param name="serializerToJsonDocuments">Dictionary to map serializer to the JSON document that should be written to it.</param>
+    /// <param name="sourcesProviders">Only used for the external document reference generator in SPDX 2.2.</param>
     public GenerationResult(List<FileValidationResult> errors, Dictionary<IManifestToolJsonSerializer, List<JsonDocument>> serializerToJsonDocuments, IEnumerable<ISourcesProvider> sourcesProviders = null)
     {
         Errors = errors;
         SerializerToJsonDocuments = serializerToJsonDocuments;
-        this.SourcesProviders = sourcesProviders;
     }
 }

--- a/src/Microsoft.Sbom.Api/Executors/IJsonSerializationStrategy.cs
+++ b/src/Microsoft.Sbom.Api/Executors/IJsonSerializationStrategy.cs
@@ -10,13 +10,13 @@ namespace Microsoft.Sbom.Api.Workflows.Helpers;
 
 internal interface IJsonSerializationStrategy
 {
-    public void AddToFilesSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config);
+    public bool AddToFilesSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config);
 
-    public void AddToPackagesSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config);
+    public bool AddToPackagesSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config);
 
     public bool AddToRelationshipsSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config);
 
-    public void AddToExternalDocRefsSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config);
+    public bool AddToExternalDocRefsSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config);
 
     public void AddHeadersToSbom(ISbomConfigProvider sbomConfigs, ISbomConfig config)
     {

--- a/src/Microsoft.Sbom.Api/Executors/Spdx22SerializationStrategy.cs
+++ b/src/Microsoft.Sbom.Api/Executors/Spdx22SerializationStrategy.cs
@@ -123,7 +123,7 @@ internal class Spdx22SerializationStrategy : IJsonSerializationStrategy
     {
         var externalDocumentReferenceGenerationResult = await externalDocumentReferenceGenerator.GenerateAsync();
         errors.AddRange(externalDocumentReferenceGenerationResult.Errors);
-        WriteJsonObjectsFromGenerationResult(externalDocumentReferenceGenerationResult, externalDocumentReferenceGenerator.SbomConfig, externalDocumentReferenceGenerationResult.SourcesProviders);
+        WriteJsonObjectsFromGenerationResultForExternalDocRefs(externalDocumentReferenceGenerationResult, externalDocumentReferenceGenerator.SbomConfig, externalDocumentReferenceGenerationResult.SourcesProviders);
     }
 
     /// <summary>
@@ -152,6 +152,26 @@ internal class Spdx22SerializationStrategy : IJsonSerializationStrategy
             }
 
             serializer.EndJsonArray();
+        }
+
+        if (sourcesProviders is not null)
+        {
+            sbomConfig.JsonSerializer.EndJsonArray();
+        }
+    }
+
+    private void WriteJsonObjectsFromGenerationResultForExternalDocRefs(GenerationResult generationResult, ISbomConfig sbomConfig, IEnumerable<ISourcesProvider> sourcesProviders)
+    {
+        foreach (var serializer in generationResult.SerializerToJsonDocuments.Keys)
+        {
+            var jsonDocuments = generationResult.SerializerToJsonDocuments[serializer];
+            if (jsonDocuments.Count > 0)
+            {
+                foreach (var jsonDocument in jsonDocuments)
+                {
+                    serializer.Write(jsonDocument);
+                }
+            }
         }
 
         if (sourcesProviders is not null)

--- a/src/Microsoft.Sbom.Api/Executors/Spdx22SerializationStrategy.cs
+++ b/src/Microsoft.Sbom.Api/Executors/Spdx22SerializationStrategy.cs
@@ -158,14 +158,7 @@ internal class Spdx22SerializationStrategy : IJsonSerializationStrategy
 
     private void WriteJsonObjectsFromGenerationResultForExternalDocRefs(GenerationResult generationResult, ISbomConfig sbomConfig, IEnumerable<ISourcesProvider> sourcesProviders)
     {
-        if (sourcesProviders is null)
-        {
-            WriteJsonObjectsFromGenerationResult(generationResult, sbomConfig);
-        }
-        else
-        {
-            WriteJsonObjectsFromGenerationResult(generationResult, sbomConfig, false);
-            sbomConfig.JsonSerializer.EndJsonArray();
-        }
+        WriteJsonObjectsFromGenerationResult(generationResult, sbomConfig, false);
+        sbomConfig.JsonSerializer.EndJsonArray();
     }
 }

--- a/src/Microsoft.Sbom.Api/Executors/Spdx22SerializationStrategy.cs
+++ b/src/Microsoft.Sbom.Api/Executors/Spdx22SerializationStrategy.cs
@@ -159,6 +159,9 @@ internal class Spdx22SerializationStrategy : IJsonSerializationStrategy
     private void WriteJsonObjectsFromGenerationResultForExternalDocRefs(GenerationResult generationResult, ISbomConfig sbomConfig, IEnumerable<ISourcesProvider> sourcesProviders)
     {
         WriteJsonObjectsFromGenerationResult(generationResult, sbomConfig, false);
-        sbomConfig.JsonSerializer.EndJsonArray();
+        if (generationResult.SerializerToJsonDocuments.Count != 0)
+        {
+            sbomConfig.JsonSerializer.EndJsonArray();
+        }
     }
 }

--- a/src/Microsoft.Sbom.Api/Executors/Spdx22SerializationStrategy.cs
+++ b/src/Microsoft.Sbom.Api/Executors/Spdx22SerializationStrategy.cs
@@ -136,7 +136,7 @@ internal class Spdx22SerializationStrategy : IJsonSerializationStrategy
         WriteJsonObjectsFromGenerationResult(relationshipGenerationResult, relationshipsArrayGenerator.SbomConfig);
    }
 
-    private void WriteJsonObjectsFromGenerationResult(GenerationResult generationResult, ISbomConfig sbomConfig, IEnumerable<ISourcesProvider> sourcesProviders = null)
+    private void WriteJsonObjectsFromGenerationResult(GenerationResult generationResult, ISbomConfig sbomConfig, bool endArrayForEachSerializer = true)
     {
         foreach (var serializer in generationResult.SerializerToJsonDocuments.Keys)
         {
@@ -149,31 +149,22 @@ internal class Spdx22SerializationStrategy : IJsonSerializationStrategy
                 }
             }
 
-            serializer.EndJsonArray();
-        }
-
-        if (sourcesProviders is not null)
-        {
-            sbomConfig.JsonSerializer.EndJsonArray();
+            if (endArrayForEachSerializer)
+            {
+                serializer.EndJsonArray();
+            }
         }
     }
 
     private void WriteJsonObjectsFromGenerationResultForExternalDocRefs(GenerationResult generationResult, ISbomConfig sbomConfig, IEnumerable<ISourcesProvider> sourcesProviders)
     {
-        foreach (var serializer in generationResult.SerializerToJsonDocuments.Keys)
+        if (sourcesProviders is null)
         {
-            var jsonDocuments = generationResult.SerializerToJsonDocuments[serializer];
-            if (jsonDocuments.Count > 0)
-            {
-                foreach (var jsonDocument in jsonDocuments)
-                {
-                    serializer.Write(jsonDocument);
-                }
-            }
+            WriteJsonObjectsFromGenerationResult(generationResult, sbomConfig);
         }
-
-        if (sourcesProviders is not null)
+        else
         {
+            WriteJsonObjectsFromGenerationResult(generationResult, sbomConfig, false);
             sbomConfig.JsonSerializer.EndJsonArray();
         }
     }

--- a/src/Microsoft.Sbom.Api/Executors/Spdx30SerializationStrategy.cs
+++ b/src/Microsoft.Sbom.Api/Executors/Spdx30SerializationStrategy.cs
@@ -15,14 +15,16 @@ namespace Microsoft.Sbom.Api.Workflows.Helpers;
 /// </summary>
 internal class Spdx30SerializationStrategy : IJsonSerializationStrategy
 {
-    public void AddToFilesSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
+    public bool AddToFilesSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
     {
         elementsSupportingConfigs.Add(config);
+        return true;
     }
 
-    public void AddToPackagesSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
+    public bool AddToPackagesSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
     {
         elementsSupportingConfigs.Add(config);
+        return true;
     }
 
     public bool AddToRelationshipsSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
@@ -30,9 +32,10 @@ internal class Spdx30SerializationStrategy : IJsonSerializationStrategy
         return true;
     }
 
-    public void AddToExternalDocRefsSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
+    public bool AddToExternalDocRefsSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
     {
         elementsSupportingConfigs.Add(config);
+        return true;
     }
 
     public async Task<List<FileValidationResult>> WriteJsonObjectsToSbomAsync(

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/ExternalDocumentReferenceGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/ExternalDocumentReferenceGenerator.cs
@@ -51,7 +51,7 @@ public class ExternalDocumentReferenceGenerator : IJsonArrayGenerator<ExternalDo
             if (!sourcesProviders.Any())
             {
                 log.Debug($"No source providers found for {ProviderType.ExternalDocumentReference}");
-                return new GenerationResult(totalErrors, jsonDocumentCollection.SerializersToJson);
+                return new GenerationResult(totalErrors, jsonDocumentCollection.SerializersToJson, sourcesProviders);
             }
 
             // Write the start of the array, if supported.

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/ExternalDocumentReferenceGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/ExternalDocumentReferenceGenerator.cs
@@ -51,13 +51,13 @@ public class ExternalDocumentReferenceGenerator : IJsonArrayGenerator<ExternalDo
             if (!sourcesProviders.Any())
             {
                 log.Debug($"No source providers found for {ProviderType.ExternalDocumentReference}");
-                return new GenerationResult(totalErrors, jsonDocumentCollection.SerializersToJson, sourcesProviders);
+                return new GenerationResult(totalErrors, jsonDocumentCollection.SerializersToJson, jsonArrayStarted: false);
             }
 
             // Write the start of the array, if supported.
             IList<ISbomConfig> externalRefArraySupportingConfigs = new List<ISbomConfig>();
             var serializationStrategy = JsonSerializationStrategyFactory.GetStrategy(SpdxManifestVersion);
-            serializationStrategy.AddToExternalDocRefsSupportingConfig(externalRefArraySupportingConfigs, this.SbomConfig);
+            var jsonArrayStarted = serializationStrategy.AddToExternalDocRefsSupportingConfig(externalRefArraySupportingConfigs, this.SbomConfig);
 
             foreach (var sourcesProvider in sourcesProviders)
             {
@@ -80,7 +80,7 @@ public class ExternalDocumentReferenceGenerator : IJsonArrayGenerator<ExternalDo
                 }
             }
 
-            return new GenerationResult(totalErrors, jsonDocumentCollection.SerializersToJson, sourcesProviders);
+            return new GenerationResult(totalErrors, jsonDocumentCollection.SerializersToJson, jsonArrayStarted);
         }
     }
 }

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/FileArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/FileArrayGenerator.cs
@@ -59,7 +59,7 @@ public class FileArrayGenerator : IJsonArrayGenerator<FileArrayGenerator>
             // Write the start of the array, if supported.
             IList<ISbomConfig> filesArraySupportingSboms = new List<ISbomConfig>();
             var serializationStrategy = JsonSerializationStrategyFactory.GetStrategy(SpdxManifestVersion);
-            serializationStrategy.AddToFilesSupportingConfig(filesArraySupportingSboms, this.SbomConfig);
+            var jsonArrayStarted = serializationStrategy.AddToFilesSupportingConfig(filesArraySupportingSboms, this.SbomConfig);
 
             this.logger.Verbose("Started writing files array for {configFile}.", this.SbomConfig.ManifestJsonFilePath);
 
@@ -83,7 +83,7 @@ public class FileArrayGenerator : IJsonArrayGenerator<FileArrayGenerator>
                 }
             }
 
-            return new GenerationResult(totalErrors, jsonDocumentCollection.SerializersToJson);
+            return new GenerationResult(totalErrors, jsonDocumentCollection.SerializersToJson, jsonArrayStarted);
         }
     }
 }

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/PackageArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/PackageArrayGenerator.cs
@@ -55,7 +55,7 @@ public class PackageArrayGenerator : IJsonArrayGenerator<PackageArrayGenerator>
             // Write the start of the array, if supported.
             IList<ISbomConfig> packagesArraySupportingConfigs = new List<ISbomConfig>();
             var serializationStrategy = JsonSerializationStrategyFactory.GetStrategy(SpdxManifestVersion);
-            serializationStrategy.AddToPackagesSupportingConfig(packagesArraySupportingConfigs, this.SbomConfig);
+            var jsonArrayStarted = serializationStrategy.AddToPackagesSupportingConfig(packagesArraySupportingConfigs, this.SbomConfig);
 
             var (jsonDocResults, errors) = sourcesProvider.Get(packagesArraySupportingConfigs);
 
@@ -100,7 +100,7 @@ public class PackageArrayGenerator : IJsonArrayGenerator<PackageArrayGenerator>
                 }
             }
 
-            return new GenerationResult(totalErrors, jsonDocumentCollection.SerializersToJson);
+            return new GenerationResult(totalErrors, jsonDocumentCollection.SerializersToJson, jsonArrayStarted);
         }
     }
 }

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/RelationshipsArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/RelationshipsArrayGenerator.cs
@@ -55,7 +55,8 @@ public class RelationshipsArrayGenerator : IJsonArrayGenerator<RelationshipsArra
             var serializationStrategy = JsonSerializationStrategyFactory.GetStrategy(SpdxManifestVersion);
 
             // Write the relationship array only if supported
-            if (serializationStrategy.AddToRelationshipsSupportingConfig(relationshipsArraySupportingConfigs, SbomConfig))
+            var jsonArrayStarted = serializationStrategy.AddToRelationshipsSupportingConfig(relationshipsArraySupportingConfigs, SbomConfig);
+            if (jsonArrayStarted)
             {
                 var generationData = SbomConfig?.Recorder.GetGenerationData();
 
@@ -105,7 +106,7 @@ public class RelationshipsArrayGenerator : IJsonArrayGenerator<RelationshipsArra
                 log.Debug($"Wrote {count} relationship elements in the SBOM.");
             }
 
-            return new GenerationResult(totalErrors, jsonDocumentCollection.SerializersToJson);
+            return new GenerationResult(totalErrors, jsonDocumentCollection.SerializersToJson, jsonArrayStarted);
         }
     }
 

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -11,7 +11,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.13.1" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="1.5.3" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="1.6.2" />
     <PackageVersion Include="MSTest" Version="3.7.3" />
     <PackageVersion Include="Moq" Version="4.20.72" />
   </ItemGroup>


### PR DESCRIPTION
SPDX 2.2 relies on `sourcesProviders` to generate `ExternalDocRefs`. Other sections in SPDX 2.2 (files, packages, relationships) do not rely on this. This PR simply refactors the differing behavior for `ExternalDocRefs` in a separate method.