### PR TITLE
Address new warnings from .NET 9

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
     <AnalysisLevel>latest</AnalysisLevel>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>$(NoWarn);CA1014;CS8002;CA1416;CA1515;CA1872;CA2263;IDE0040;IDE0120;IDE0052;IDE0306</NoWarn>
+    <NoWarn>$(NoWarn);CA1014;CS8002;CA1416;CA1515;CA1872;CA2263;IDE0040;IDE0120;IDE0052</NoWarn>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
   </PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
     <AnalysisLevel>latest</AnalysisLevel>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>$(NoWarn);CA1014;CS8002;CA1416;CA1515;CA1872;CA2263;IDE0040;IDE0120;IDE0052</NoWarn>
+    <NoWarn>$(NoWarn);CA1014;CS8002;CA1416;CA1515;CA1872;CA2263;IDE0040;IDE0120</NoWarn>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
   </PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
     <AnalysisLevel>latest</AnalysisLevel>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>$(NoWarn);CA1014;CS8002;CA1416;CA1515;CA1872;CA2263;IDE0040;IDE0120</NoWarn>
+    <NoWarn>$(NoWarn);CA1014;CS8002;CA1416;CA1515;CA1872;CA2263;IDE0040</NoWarn>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
   </PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
     <AnalysisLevel>latest</AnalysisLevel>
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>$(NoWarn);CA1014;CS8002;CA1416;CA1515;CA1872;CA2263</NoWarn>
+    <NoWarn>$(NoWarn);CA1014;CS8002;CA1416;CA1515;CA1872;CA2263;IDE0040;IDE0120;IDE0052;IDE0306</NoWarn>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
   </PropertyGroup>
 

--- a/src/Microsoft.Sbom.Api/Entities/output/ValidationResultGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Entities/output/ValidationResultGenerator.cs
@@ -96,7 +96,7 @@ public class ValidationResultGenerator
                 {
                     FilesSuccessfulCount = successCount,
                     FilesValidatedCount = NodeValidationResults.Count + successCount,
-                    FilesFailedCount = validationErrors.Where(r => r.ErrorType != ErrorType.NoPackagesFound).Count(),
+                    FilesFailedCount = validationErrors.Count(r => r.ErrorType != ErrorType.NoPackagesFound),
                     FilesSkippedCount = skippedErrors.Count,
                     TotalFilesInManifest = totalFiles,
                     TotalPackagesInManifest = totalPackages

--- a/src/Microsoft.Sbom.Api/Executors/ManifestFileFilterer.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ManifestFileFilterer.cs
@@ -47,7 +47,7 @@ public class ManifestFileFilterer
         Task.Run(async () =>
         {
             var manifestKeys = manifestData.HashesMap != null
-                ? new List<string>(manifestData.HashesMap.Keys)
+                ? [.. manifestData.HashesMap.Keys]
                 : new List<string>();
 
             foreach (var manifestFile in manifestKeys)

--- a/src/Microsoft.Sbom.Api/Providers/PackagesProviders/CGScannedPackagesProvider.cs
+++ b/src/Microsoft.Sbom.Api/Providers/PackagesProviders/CGScannedPackagesProvider.cs
@@ -24,8 +24,6 @@ public class CGScannedPackagesProvider : CommonPackagesProvider<ScannedComponent
 
     private readonly PackagesWalker packagesWalker;
 
-    private ILicenseInformationFetcher licenseInformationFetcher;
-
     public CGScannedPackagesProvider(
         IConfiguration configuration,
         ChannelUtils channelUtils,
@@ -40,7 +38,6 @@ public class CGScannedPackagesProvider : CommonPackagesProvider<ScannedComponent
     {
         this.packageInfoConverter = packageInfoConverter ?? throw new ArgumentNullException(nameof(packageInfoConverter));
         this.packagesWalker = packagesWalker ?? throw new ArgumentNullException(nameof(packagesWalker));
-        this.licenseInformationFetcher = licenseInformationFetcher ?? throw new ArgumentNullException(nameof(licenseInformationFetcher));
     }
 
     public override bool IsSupported(ProviderType providerType)


### PR DESCRIPTION
The latest version of Visual Studio uses .NET 9 by default, which triggered 4 new warnings:

- [IDE0040](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0040) requires network modifiers on all interface methods. This PR adds a suppression for this warning to the `Directory.Build.props` file to prevent it from being triggered.
- [IDE0052](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0052) flags unused private fields. We only had one, so it was an easy fix to remove it
- [IDE0120](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0120) flags a potential Linq simplification. We only had one, so it was an easy fix to address it
- IDE0306 (no functional link) flags ways to improve collection initialization. We only had 1 instance, so it was an easy fix to address it