### PR TITLE
Add DotNet Component Adapter

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     </PackageVersion>
   </ItemDefinitionGroup>
   <PropertyGroup>
-    <ComponentDetectionPackageVersion>5.2.1</ComponentDetectionPackageVersion>
+    <ComponentDetectionPackageVersion>5.2.13</ComponentDetectionPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AutoMapper" Version="10.1.1" />

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/DotNetComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/DotNetComponentExtensions.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Sbom.Adapters.ComponentDetection;
+
+using System;
+using Microsoft.ComponentDetection.Contracts.TypedComponent;
+using Microsoft.Sbom.Contracts;
+
+internal static class DotNetComponentExtensions
+{
+    private const string NotApplicablePropertyValue = "-";
+    private const string ComponentUnknownPropertyValue = "unknown";
+
+    public static SbomPackage ToSbomPackage(this DotNetComponent dotnetComponent, ExtendedScannedComponent component)
+    {
+        var sdkVersion = SanitizeString(dotnetComponent.SdkVersion);
+        var targetFramework = SanitizeString(dotnetComponent.TargetFramework);
+        var projectType = SanitizeString(dotnetComponent.ProjectType);
+
+        string packageName;
+        if (string.IsNullOrWhiteSpace(targetFramework) && string.IsNullOrWhiteSpace(projectType))
+        {
+            packageName = sdkVersion ?? string.Empty;
+        }
+        else
+        {
+            packageName = $"{targetFramework} {projectType}".Trim();
+        }
+
+        return new()
+        {
+            Id = dotnetComponent.Id,
+            PackageUrl = dotnetComponent.PackageUrl?.ToString(),
+            PackageName = packageName,
+            PackageVersion = sdkVersion,
+            FilesAnalyzed = false,
+            Type = "dotnet"
+        };
+    }
+
+    private static string? SanitizeString(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value)
+            || string.Equals(value.Trim(), ComponentUnknownPropertyValue, StringComparison.CurrentCultureIgnoreCase)
+            || string.Equals(value.Trim(), NotApplicablePropertyValue, StringComparison.CurrentCultureIgnoreCase))
+        {
+            return null;
+        }
+
+        return value.Trim();
+    }
+}

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/ExtendedScannedComponent.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/ExtendedScannedComponent.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Sbom.Adapters.ComponentDetection;
 
 using Microsoft.ComponentDetection.Contracts.BcdeModels;
 using Microsoft.Sbom.Adapters.Report;
+using Microsoft.Sbom.Common;
 using Microsoft.Sbom.Contracts;
 
 /// <summary>
@@ -54,6 +55,7 @@ public class ExtendedScannedComponent : ScannedComponent
     /// Converts a <see cref="ExtendedScannedComponent" /> to an <see cref="SbomPackage" />.
     /// </summary>
     /// <param name="report">The <see cref="AdapterReport" /> to use.</param>
+    /// <param name="osUtils">The <see cref="IOSUtils" /> to use. Optionally turns on component adapters. Example: EnableSBOM_DotNetComponent=true</param>
     /// <returns>The converted <see cref="SbomPackage" />.</returns>
-    public SbomPackage? ToSbomPackage(AdapterReport report) => ScannedComponentExtensions.ToSbomPackage(this, report);
+    public SbomPackage? ToSbomPackage(AdapterReport report, IOSUtils osUtils) => ScannedComponentExtensions.ToSbomPackage(this, report, osUtils);
 }

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/ScannedComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/ScannedComponentExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
 using Microsoft.Sbom.Adapters.ComponentDetection.Logging;
 using Microsoft.Sbom.Adapters.Report;
+using Microsoft.Sbom.Common;
 using Microsoft.Sbom.Contracts;
 
 namespace Microsoft.Sbom.Adapters.ComponentDetection;
@@ -17,7 +18,7 @@ public static class ScannedComponentExtensions
     /// <summary>
     /// Converts a <see cref="ExtendedScannedComponent"/> to an <see cref="SbomPackage"/>.
     /// </summary>
-    public static SbomPackage? ToSbomPackage(this ExtendedScannedComponent component, AdapterReport report)
+    public static SbomPackage? ToSbomPackage(this ExtendedScannedComponent component, AdapterReport report, IOSUtils oSUtils)
     {
         return component.Component switch
         {
@@ -35,10 +36,17 @@ public static class ScannedComponentExtensions
             PipComponent pipComponent => pipComponent.ToSbomPackage(component),
             PodComponent podComponent => podComponent.ToSbomPackage(component),
             RubyGemsComponent rubyGemsComponent => rubyGemsComponent.ToSbomPackage(component),
-            DotNetComponent dotNetComponent => dotNetComponent.ToSbomPackage(component),
+            DotNetComponent dotNetComponent => IsEnabled(component.Component, oSUtils) ? dotNetComponent.ToSbomPackage(component) : null,
             null => Error(report => report.LogNullComponent(nameof(ToSbomPackage))),
             _ => Error(report => report.LogNoConversionFound(component.Component.GetType(), component.Component))
         };
+
+        static bool IsEnabled(TypedComponent typedComponent, IOSUtils oSUtils)
+        {
+            // Example Build Variable: EnableSBOM_DotNetComponent=true
+            var buildVariableName = $"EnableSBOM_{typedComponent.GetType().Name}";
+            return bool.TryParse(oSUtils.GetEnvironmentVariable(buildVariableName), out var parsedVariable) && parsedVariable;
+        }
 
         // Logs an error prior to returning null.
         SbomPackage? Error(Action<AdapterReport> log)

--- a/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/ScannedComponentExtensions.cs
+++ b/src/Microsoft.Sbom.Adapters/Adapters/ComponentDetection/ScannedComponentExtensions.cs
@@ -35,6 +35,7 @@ public static class ScannedComponentExtensions
             PipComponent pipComponent => pipComponent.ToSbomPackage(component),
             PodComponent podComponent => podComponent.ToSbomPackage(component),
             RubyGemsComponent rubyGemsComponent => rubyGemsComponent.ToSbomPackage(component),
+            DotNetComponent dotNetComponent => dotNetComponent.ToSbomPackage(component),
             null => Error(report => report.LogNullComponent(nameof(ToSbomPackage))),
             _ => Error(report => report.LogNoConversionFound(component.Component.GetType(), component.Component))
         };

--- a/src/Microsoft.Sbom.Adapters/ComponentDetectionToSbomPackageAdapter.cs
+++ b/src/Microsoft.Sbom.Adapters/ComponentDetectionToSbomPackageAdapter.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.Sbom.Adapters.ComponentDetection;
 using Microsoft.Sbom.Adapters.Report;
+using Microsoft.Sbom.Common;
 using Microsoft.Sbom.Contracts;
 using Newtonsoft.Json;
 
@@ -14,6 +15,13 @@ namespace Microsoft.Sbom.Adapters;
 
 public class ComponentDetectionToSbomPackageAdapter
 {
+    private readonly IOSUtils osUtils;
+
+    public ComponentDetectionToSbomPackageAdapter(IOSUtils osUtils)
+    {
+        this.osUtils = osUtils ?? throw new ArgumentNullException(nameof(osUtils));
+    }
+
     /// <summary>
     /// Parses the output from Component Detection and converts it into a list of <see cref="SbomPackage"/> objects.
     /// The report returned by this function will also indicate any errors encountered by the adapter, and on successful
@@ -43,7 +51,7 @@ public class ComponentDetectionToSbomPackageAdapter
             else if (componentDetectionScanResult.ComponentsFound != null)
             {
                 packages = componentDetectionScanResult.ComponentsFound
-                    .Select(component => component.ToSbomPackage(report))
+                    .Select(component => component.ToSbomPackage(report, this.osUtils))
                     .Where(package => package != null) // It is acceptable to return a partial list of values with null filtered out since they should be reported as failures already
                     .Select(package => package!);
 

--- a/src/Microsoft.Sbom.Adapters/Microsoft.Sbom.Adapters.csproj
+++ b/src/Microsoft.Sbom.Adapters/Microsoft.Sbom.Adapters.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Microsoft.Sbom.Common\Microsoft.Sbom.Common.csproj" />
     <ProjectReference Include="..\Microsoft.Sbom.Contracts\Microsoft.Sbom.Contracts.csproj" />
   </ItemGroup>
 

--- a/src/Microsoft.Sbom.Api/Executors/ComponentToPackageInfoConverter.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ComponentToPackageInfoConverter.cs
@@ -14,6 +14,7 @@ using Serilog;
 namespace Microsoft.Sbom.Api.Executors;
 
 using Microsoft.Sbom.Adapters.ComponentDetection;
+using Microsoft.Sbom.Common;
 
 /// <summary>
 /// Takes a <see cref="ScannedComponent"/> object and converts it to a <see cref="PackageInfo"/>
@@ -22,14 +23,16 @@ using Microsoft.Sbom.Adapters.ComponentDetection;
 public class ComponentToPackageInfoConverter
 {
     private readonly ILogger log;
+    private readonly IOSUtils osUtils;
 
     // TODO: Remove and use interface
     // For unit testing only
     public ComponentToPackageInfoConverter() { }
 
-    public ComponentToPackageInfoConverter(ILogger log)
+    public ComponentToPackageInfoConverter(ILogger log, IOSUtils oSUtils)
     {
         this.log = log ?? throw new ArgumentNullException(nameof(log));
+        this.osUtils = oSUtils ?? throw new ArgumentNullException(nameof(oSUtils));
     }
 
     public virtual (ChannelReader<SbomPackage> output, ChannelReader<FileValidationResult> errors) Convert(ChannelReader<ScannedComponent> componentReader)
@@ -52,7 +55,7 @@ public class ComponentToPackageInfoConverter
             {
                 try
                 {
-                    var sbom = scannedComponent.ToSbomPackage(report);
+                    var sbom = scannedComponent.ToSbomPackage(report, this.osUtils);
 
                     if (sbom == null)
                     {

--- a/test/Microsoft.Sbom.Adapters.Tests/ComponentDetectionToSbomPackageAdapterTests.cs
+++ b/test/Microsoft.Sbom.Adapters.Tests/ComponentDetectionToSbomPackageAdapterTests.cs
@@ -271,6 +271,58 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         AssertPackageUrlIsCorrect(gitComponent.PackageUrl, sbomPackage.PackageUrl);
     }
 
+    [TestMethod]
+    public void DotNetComponent_ToSbomPackage()
+    {
+        var dotnetComponent = new DotNetComponent("6.0.102", "net6.0", "application");
+        var scannedComponent = new ExtendedScannedComponent() { Component = dotnetComponent };
+        var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
+
+        Assert.AreEqual(dotnetComponent.Id, sbomPackage.Id);
+        Assert.AreEqual(dotnetComponent.SdkVersion, sbomPackage.PackageVersion);
+        Assert.IsNotNull(sbomPackage.PackageName);
+
+        var nameSegments = sbomPackage.PackageName.Split(' ');
+        Assert.AreEqual(2, nameSegments.Length);
+
+        Assert.AreEqual(dotnetComponent.TargetFramework, nameSegments[0], $"{nameof(dotnetComponent.TargetFramework)} should be part of package name");
+        Assert.AreEqual(dotnetComponent.ProjectType, nameSegments[1], $"{nameof(dotnetComponent.ProjectType)} should be part of package name");
+
+        dotnetComponent = new DotNetComponent("6.0.102", "net6.0");
+        scannedComponent = new ExtendedScannedComponent() { Component = dotnetComponent };
+        sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
+
+        Assert.AreEqual(dotnetComponent.Id, sbomPackage.Id);
+        Assert.AreEqual(dotnetComponent.SdkVersion, sbomPackage.PackageVersion);
+        Assert.IsNotNull(sbomPackage.PackageName);
+
+        nameSegments = sbomPackage.PackageName.Split(' ');
+        Assert.AreEqual(1, nameSegments.Length);
+
+        Assert.AreEqual(dotnetComponent.TargetFramework, nameSegments[0], $"{nameof(dotnetComponent.TargetFramework)} should be part of package name");
+
+        dotnetComponent = new DotNetComponent("6.0.102");
+        scannedComponent = new ExtendedScannedComponent() { Component = dotnetComponent };
+        sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
+
+        Assert.AreEqual(dotnetComponent.Id, sbomPackage.Id);
+        Assert.IsNotNull(sbomPackage.PackageName);
+        Assert.AreEqual(dotnetComponent.SdkVersion, sbomPackage.PackageVersion);
+        Assert.AreEqual(dotnetComponent.SdkVersion, sbomPackage.PackageName);
+
+        dotnetComponent = new DotNetComponent(sdkVersion: null, targetFramework: "net6.0");
+        scannedComponent = new ExtendedScannedComponent() { Component = dotnetComponent };
+        sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
+
+        Assert.AreEqual(dotnetComponent.Id, sbomPackage.Id);
+        Assert.IsNull(sbomPackage.PackageVersion);
+        Assert.IsNotNull(sbomPackage.PackageName);
+
+        nameSegments = sbomPackage.PackageName.Split(' ');
+        Assert.AreEqual(1, nameSegments.Length);
+        Assert.AreEqual(dotnetComponent.TargetFramework, nameSegments[0], $"{nameof(dotnetComponent.TargetFramework)} should be part of package name");
+    }
+
     private void AssertPackageUrlIsCorrect(PackageUrl.PackageURL expectedPackageUrl, string actualPackageUrl)
     {
         if (expectedPackageUrl is null)

--- a/test/Microsoft.Sbom.Adapters.Tests/ComponentDetectionToSbomPackageAdapterTests.cs
+++ b/test/Microsoft.Sbom.Adapters.Tests/ComponentDetectionToSbomPackageAdapterTests.cs
@@ -15,11 +15,21 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.Sbom.Adapters.Tests;
 
 using Microsoft.Sbom.Adapters.ComponentDetection;
+using Microsoft.Sbom.Common;
+using Moq;
 
 [TestClass]
 public class ComponentDetectionToSBOMPackageAdapterTests
 {
+    private Mock<IOSUtils> osUtils;
+
     public TestContext TestContext { get; set; }
+
+    [TestInitialize]
+    public void Setup()
+    {
+        this.osUtils = new Mock<IOSUtils>();
+    }
 
     [TestMethod]
     public void BasicAdapterTest_Succeeds()
@@ -109,7 +119,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
     {
         Assert.ThrowsException<ArgumentNullException>(() =>
         {
-            var adapter = new ComponentDetectionToSbomPackageAdapter();
+            var adapter = new ComponentDetectionToSbomPackageAdapter(this.osUtils.Object);
             adapter.TryConvert("not/a/real/path");
         });
     }
@@ -120,7 +130,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         var cargoComponent = new CargoComponent("name", "version");
         var scannedComponent = new ExtendedScannedComponent() { Component = cargoComponent };
 
-        var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
+        var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport(), this.osUtils.Object);
 
         Assert.IsNotNull(sbomPackage.Id);
         Assert.IsNotNull(sbomPackage.PackageUrl);
@@ -137,7 +147,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         var conanComponent = new ConanComponent("name", "version", md5, sha1Hash);
         var scannedComponent = new ExtendedScannedComponent() { Component = conanComponent };
 
-        var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
+        var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport(), this.osUtils.Object);
 
         Assert.IsNotNull(sbomPackage.Id);
         Assert.IsNotNull(sbomPackage.PackageUrl);
@@ -154,7 +164,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         var condaComponent = new CondaComponent("name", "version", "build", "channel", "subdir", "namespace", "http://microsoft.com", "md5");
         var scannedComponent = new ExtendedScannedComponent() { Component = condaComponent };
 
-        var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
+        var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport(), this.osUtils.Object);
 
         Assert.AreEqual(condaComponent.Id, sbomPackage.Id);
         AssertPackageUrlIsCorrect(condaComponent.PackageUrl, sbomPackage.PackageUrl);
@@ -170,7 +180,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         var dockerImageComponent = new DockerImageComponent("name", "version", "tag") { Digest = "digest" };
         var scannedComponent = new ExtendedScannedComponent() { Component = dockerImageComponent };
 
-        var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
+        var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport(), this.osUtils.Object);
 
         Assert.AreEqual(dockerImageComponent.Id, sbomPackage.Id);
         AssertPackageUrlIsCorrect(dockerImageComponent.PackageUrl, sbomPackage.PackageUrl);
@@ -185,7 +195,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         var npmComponent = new NpmComponent("name", "verison", author: new NpmAuthor("name", "email@contoso.com"));
         var scannedComponent = new ExtendedScannedComponent() { Component = npmComponent };
 
-        var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
+        var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport(), this.osUtils.Object);
 
         Assert.AreEqual(npmComponent.Id, sbomPackage.Id);
         Assert.IsNotNull(npmComponent.PackageUrl);
@@ -201,7 +211,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         var npmComponent = new NpmComponent("name", "verison");
         var scannedComponent = new ExtendedScannedComponent() { Component = npmComponent };
 
-        var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
+        var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport(), this.osUtils.Object);
 
         Assert.AreEqual(npmComponent.Id, sbomPackage.Id);
         Assert.IsNotNull(npmComponent.PackageUrl);
@@ -217,7 +227,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         var nuGetComponent = new NuGetComponent("name", "version", new string[] { "Author Name1, Another Author" });
         var scannedComponent = new ExtendedScannedComponent() { Component = nuGetComponent };
 
-        var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
+        var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport(), this.osUtils.Object);
 
         Assert.AreEqual(nuGetComponent.Id, sbomPackage.Id);
         AssertPackageUrlIsCorrect(nuGetComponent.PackageUrl, sbomPackage.PackageUrl);
@@ -233,7 +243,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         var nuGetComponent = new NuGetComponent("name", "version");
         var scannedComponent = new ExtendedScannedComponent() { Component = nuGetComponent };
 
-        var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
+        var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport(), this.osUtils.Object);
 
         Assert.AreEqual(nuGetComponent.Id, sbomPackage.Id);
         Assert.IsNotNull(nuGetComponent.PackageUrl);
@@ -249,7 +259,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         var pipComponent = new PipComponent("name", "version");
         var scannedComponent = new ExtendedScannedComponent() { Component = pipComponent };
 
-        var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
+        var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport(), this.osUtils.Object);
 
         Assert.AreEqual(pipComponent.Id, sbomPackage.Id);
         Assert.IsNotNull(pipComponent.PackageUrl);
@@ -265,7 +275,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         var gitComponent = new GitComponent(uri, "version");
         var scannedComponent = new ExtendedScannedComponent() { Component = gitComponent };
 
-        var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
+        var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport(), this.osUtils.Object);
 
         Assert.AreEqual(gitComponent.Id, sbomPackage.Id);
         AssertPackageUrlIsCorrect(gitComponent.PackageUrl, sbomPackage.PackageUrl);
@@ -274,9 +284,11 @@ public class ComponentDetectionToSBOMPackageAdapterTests
     [TestMethod]
     public void DotNetComponent_ToSbomPackage()
     {
+        this.osUtils.Setup(x => x.GetEnvironmentVariable("EnableSBOM_DotNetComponent")).Returns("true");
+
         var dotnetComponent = new DotNetComponent("6.0.102", "net6.0", "application");
         var scannedComponent = new ExtendedScannedComponent() { Component = dotnetComponent };
-        var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
+        var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport(), this.osUtils.Object);
 
         Assert.AreEqual(dotnetComponent.Id, sbomPackage.Id);
         Assert.AreEqual(dotnetComponent.SdkVersion, sbomPackage.PackageVersion);
@@ -290,7 +302,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
 
         dotnetComponent = new DotNetComponent("6.0.102", "net6.0");
         scannedComponent = new ExtendedScannedComponent() { Component = dotnetComponent };
-        sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
+        sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport(), this.osUtils.Object);
 
         Assert.AreEqual(dotnetComponent.Id, sbomPackage.Id);
         Assert.AreEqual(dotnetComponent.SdkVersion, sbomPackage.PackageVersion);
@@ -303,7 +315,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
 
         dotnetComponent = new DotNetComponent("6.0.102");
         scannedComponent = new ExtendedScannedComponent() { Component = dotnetComponent };
-        sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
+        sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport(), this.osUtils.Object);
 
         Assert.AreEqual(dotnetComponent.Id, sbomPackage.Id);
         Assert.IsNotNull(sbomPackage.PackageName);
@@ -312,7 +324,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
 
         dotnetComponent = new DotNetComponent(sdkVersion: null, targetFramework: "net6.0");
         scannedComponent = new ExtendedScannedComponent() { Component = dotnetComponent };
-        sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport());
+        sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport(), this.osUtils.Object);
 
         Assert.AreEqual(dotnetComponent.Id, sbomPackage.Id);
         Assert.IsNull(sbomPackage.PackageVersion);
@@ -321,6 +333,17 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         nameSegments = sbomPackage.PackageName.Split(' ');
         Assert.AreEqual(1, nameSegments.Length);
         Assert.AreEqual(dotnetComponent.TargetFramework, nameSegments[0], $"{nameof(dotnetComponent.TargetFramework)} should be part of package name");
+    }
+
+    [TestMethod]
+    public void DotNetComponentDisabled_ToSbomPackage()
+    {
+        this.osUtils.Setup(x => x.GetEnvironmentVariable("EnableSBOM_DotNetComponent")).Returns("false");
+
+        var dotnetComponent = new DotNetComponent("6.0.102", "net6.0", "application");
+        var scannedComponent = new ExtendedScannedComponent() { Component = dotnetComponent };
+        var sbomPackage = scannedComponent.ToSbomPackage(new AdapterReport(), this.osUtils.Object);
+        Assert.IsNull(sbomPackage);
     }
 
     private void AssertPackageUrlIsCorrect(PackageUrl.PackageURL expectedPackageUrl, string actualPackageUrl)
@@ -342,7 +365,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         Directory.CreateDirectory(baseDirectory);
         File.WriteAllText(bcdeOutputPath, json);
 
-        var adapter = new ComponentDetectionToSbomPackageAdapter();
+        var adapter = new ComponentDetectionToSbomPackageAdapter(this.osUtils.Object);
         var (errors, packages) = adapter.TryConvert(bcdeOutputPath);
         var output = packages.ToList();
 

--- a/test/Microsoft.Sbom.Api.Tests/Executors/ComponentToPackageInfoConverterTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/ComponentToPackageInfoConverterTests.cs
@@ -19,6 +19,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using HashAlgorithmName = Microsoft.Sbom.Contracts.Enums.AlgorithmName;
 using ILogger = Serilog.ILogger;
+using IOSUtils = Microsoft.Sbom.Common.IOSUtils;
 using PackageInfo = Microsoft.Sbom.Contracts.SbomPackage;
 
 namespace Microsoft.Sbom.Api.Executors.Tests;
@@ -30,6 +31,7 @@ public class ComponentToPackageInfoConverterTests
 {
     private readonly Mock<ILogger> mockLogger = new Mock<ILogger>();
     private readonly Mock<IConfiguration> mockConfiguration = new Mock<IConfiguration>();
+    private readonly Mock<IOSUtils> mockOSUtils = new Mock<IOSUtils>();
     private readonly ManifestGeneratorProvider manifestGeneratorProvider;
 
     [TestInitialize]
@@ -267,7 +269,7 @@ public class ComponentToPackageInfoConverterTests
         var componentsChannel = Channel.CreateUnbounded<ScannedComponent>();
         await componentsChannel.Writer.WriteAsync(scannedComponent);
         componentsChannel.Writer.Complete();
-        var packageInfoConverter = new ComponentToPackageInfoConverter(mockLogger.Object);
+        var packageInfoConverter = new ComponentToPackageInfoConverter(mockLogger.Object, mockOSUtils.Object);
         var (output, _) = packageInfoConverter.Convert(componentsChannel);
         var packageInfo = await output.ReadAsync();
         return packageInfo;
@@ -282,7 +284,7 @@ public class ComponentToPackageInfoConverterTests
         }
 
         componentsChannel.Writer.Complete();
-        var packageInfoConverter = new ComponentToPackageInfoConverter(mockLogger.Object);
+        var packageInfoConverter = new ComponentToPackageInfoConverter(mockLogger.Object, mockOSUtils.Object);
         var (output, errors) = packageInfoConverter.Convert(componentsChannel);
         return (await output.ReadAllAsync().ToListAsync(), await errors.ReadAllAsync().ToListAsync());
     }


### PR DESCRIPTION
## Context
New DotNet component contract was added upstream in component detection. The detector is still in experimental phase, but we want to be able to deserialize the contract successfully and generate SBOM when ready.

## ⚙️ Changes
Some other updates were included in the version upgrade
- Mariner 2.0 Syft Tweak Ignore Logic
- Remove incomplete ELF Syft results for Mariner 2.0
- Fix link version parsing in pnpm9
- Register VS Code built-in packages as skipped
- Fix broken links in Go detector doc
- Update syft image and doc - use docker commands
- Add Swift Package Manager component detection (detector disabled by default)

