### PR TITLE
Fix SPDX 3.0 manifest missing files bug

### DIFF
--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Constants.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Constants.cs
@@ -15,6 +15,7 @@ internal static class Constants
     internal const string DataLicenceValue = "CC0-1.0";
     internal const string SPDXDocumentIdValue = "SPDXRef-DOCUMENT";
     internal const string RootPackageIdValue = "SPDXRef-RootPackage";
+    internal const string SPDXRefFile = "SPDXRef-File";
     internal const string SPDXDocumentNameFormatString = "{0} {1}";
     internal const string PackageSupplierFormatString = "Organization: {0}";
     internal const string SPDXContextHeaderName = "@context";

--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Utils/SPDXExtensions.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Utils/SPDXExtensions.cs
@@ -31,7 +31,11 @@ public static class SPDXExtensions
     /// </summary>
     public static string GenerateSpdxId(Element element, string id) => $"SPDXRef-{element.Type}-{GetStringHash(id)}";
 
-    public static string GetSpdxId(Element element, string id) => $"SPDXRef{element.Type}-{element.Name}-{id}";
+    public static string GetSpdxId(Element element, string id)
+    {
+        var spdxFileId = $"{Constants.SPDXRefFile}-{element.Name}-{id}";
+        return SpdxIdAllowedCharsRegex.Replace(spdxFileId, "-");
+    }
 
     /// <summary>
     /// Returns the SPDX-compliant external document ID.

--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Utils/SPDXExtensions.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Utils/SPDXExtensions.cs
@@ -31,6 +31,8 @@ public static class SPDXExtensions
     /// </summary>
     public static string GenerateSpdxId(Element element, string id) => $"SPDXRef-{element.Type}-{GetStringHash(id)}";
 
+    public static string GetSpdxId(Element element, string id) => $"SPDXRef{element.Type}-{element.Name}-{id}";
+
     /// <summary>
     /// Returns the SPDX-compliant external document ID.
     /// </summary>
@@ -64,8 +66,7 @@ public static class SPDXExtensions
     }
 
     /// <summary>
-    /// Adds a SPDXID property to the given file. The id of the file should be the same
-    /// for any build as long as the contents of the file haven't changed.
+    /// Gets the SHA1 checksum value for a file.
     /// </summary>
     /// <param name="fileName"></param>
     /// <param name="checksums"></param>
@@ -146,7 +147,12 @@ public static class SPDXExtensions
         packageVerificationCode.SpdxId = GenerateSpdxId(packageVerificationCode, packageVerificationCode.Algorithm.ToString());
     }
 
-    public static void AddSpdxId(this Element element, string id)
+    public static void AddSpdxId(this File element, string id)
+    {
+        element.SpdxId = GetSpdxId(element, id);
+    }
+
+    public static void AddSpdxId(this Package element, string id)
     {
         element.SpdxId = GenerateSpdxId(element, id);
     }

--- a/test/Microsoft.Sbom.Parsers.Spdx30SbomParser.Tests/Parser/GeneratorTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx30SbomParser.Tests/Parser/GeneratorTests.cs
@@ -109,6 +109,37 @@ public class GeneratorTests
     }
 
     [TestMethod]
+    public void GenerateJsonDocumentTest_FilesWithDifferingChecksums_CreatesDifferentSpdxFiles()
+    {
+        var fileInfo1 = new InternalSbomFileInfo
+        {
+            Checksum = GetSampleChecksums(),
+            FileCopyrightText = "sampleCopyright",
+            LicenseConcluded = "sampleLicense1",
+            LicenseInfoInFiles = new List<string> { "sampleLicense1" },
+            Path = "/sample/path",
+        };
+
+        var fileInfo2 = new InternalSbomFileInfo
+        {
+            Checksum = GetDifferentSampleChecksums(),
+            FileCopyrightText = "sampleCopyright",
+            LicenseConcluded = "sampleLicense1",
+            LicenseInfoInFiles = new List<string> { "sampleLicense1" },
+            Path = "/sample/path",
+        };
+
+        var generatorResultFile1 = generator.GenerateJsonDocument(fileInfo1);
+        var generatorResultFile2 = generator.GenerateJsonDocument(fileInfo2);
+
+        // Compare entity IDs which is the same as the SPDX ID for each file.
+        Assert.AreNotEqual(generatorResultFile1.ResultMetadata.EntityId, generatorResultFile2.ResultMetadata.EntityId);
+        Assert.IsTrue(generatorResultFile1.ResultMetadata.EntityId.Contains("sha1Value"));
+        Assert.IsTrue(generatorResultFile2.ResultMetadata.EntityId.Contains("DIFFsha1Value"));
+        Assert.AreNotEqual(generatorResultFile1, generatorResultFile2);
+    }
+
+    [TestMethod]
     public void GenerateJsonDocumentTest_ExternalMap()
     {
         var externalDocInfo = new ExternalDocumentReferenceInfo
@@ -187,6 +218,22 @@ public class GeneratorTests
           {
             Algorithm = AlgorithmName.SHA256,
             ChecksumValue = "sha256Value"
+          },
+        };
+    }
+
+    private List<Checksum> GetDifferentSampleChecksums()
+    {
+        return new List<Checksum>
+        {
+          new Checksum
+          {
+            Algorithm = AlgorithmName.SHA1,
+            ChecksumValue = "DIFFsha1Value"
+          },  new Checksum
+          {
+            Algorithm = AlgorithmName.SHA256,
+            ChecksumValue = "DIFFsha256Value"
           },
         };
     }

--- a/test/Microsoft.Sbom.Parsers.Spdx30SbomParser.Tests/Parser/JsonStrings/SbomFileJsonStrings.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx30SbomParser.Tests/Parser/JsonStrings/SbomFileJsonStrings.cs
@@ -12,7 +12,7 @@ public static class SbomFileJsonStrings
             ""name"": ""./sample/path"",
             ""software_copyrightText"": ""sampleCopyright"",
             ""creationInfo"": ""_:creationinfo"",
-            ""spdxId"": ""SPDXRef-software_File-B4A9F99A3A03B9273AE34753D96564CB4F2B0FAD885BBD36B0DD619E9E8AC967"",
+            ""spdxId"": ""SPDXRef-File-.-sample-path-sha1Value"",
             ""verifiedUsing"": [
               {
                 ""algorithm"": ""sha1"",
@@ -38,7 +38,7 @@ public static class SbomFileJsonStrings
             ""type"": ""AnyLicenseInfo""
           },
           {
-            ""from"": ""SPDXRef-software_File-B4A9F99A3A03B9273AE34753D96564CB4F2B0FAD885BBD36B0DD619E9E8AC967"",
+            ""from"": ""SPDXRef-File-.-sample-path-sha1Value"",
             ""relationshipType"": ""HAS_CONCLUDED_LICENSE"",
             ""to"": [
               ""SPDXRef-AnyLicenseInfo-3BA3FA6D3D66FE2BA75992BB0850D080F1223256368A76C77BEF8E0F6AC71896""
@@ -48,7 +48,7 @@ public static class SbomFileJsonStrings
             ""type"": ""Relationship""
           },
           {
-            ""from"": ""SPDXRef-software_File-B4A9F99A3A03B9273AE34753D96564CB4F2B0FAD885BBD36B0DD619E9E8AC967"",
+            ""from"": ""SPDXRef-File-.-sample-path-sha1Value"",
             ""relationshipType"": ""HAS_DECLARED_LICENSE"",
             ""to"": [
               ""SPDXRef-AnyLicenseInfo-3BA3FA6D3D66FE2BA75992BB0850D080F1223256368A76C77BEF8E0F6AC71896""

--- a/test/Microsoft.Sbom.Tool.Tests/IntegrationTests.cs
+++ b/test/Microsoft.Sbom.Tool.Tests/IntegrationTests.cs
@@ -92,7 +92,7 @@ public class IntegrationTests
     }
 
     [TestMethod]
-    public void E2E_GenerateAndValidateManifest_ValidationSucceeds_ReturnsZeroExitCode()
+    public void E2E_GenerateAndValidateSPDX22Manifest_ValidationSucceeds_ReturnsZeroExitCode()
     {
         if (!IsWindows)
         {
@@ -104,6 +104,28 @@ public class IntegrationTests
         GenerateManifestAndValidateSuccess(testFolderPath);
 
         var (arguments, outputFile) = GetValidateManifestArguments(testFolderPath);
+
+        var (stdout, stderr, exitCode) = LaunchAndCaptureOutput(arguments);
+
+        Assert.AreEqual(stderr, string.Empty);
+        Assert.AreEqual(0, exitCode.Value, $"Unexpected failure: stdout = {stdout}");
+        Assert.IsTrue(File.Exists(outputFile), $"{outputFile} should have been created during validation");
+        Assert.IsTrue(File.ReadAllText(outputFile).Contains("\"Result\":\"Success\"", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [TestMethod]
+    public void E2E_GenerateAndValidateSPDX30Manifest_ValidationSucceeds_ReturnsZeroExitCode()
+    {
+        if (!IsWindows)
+        {
+            Assert.Inconclusive("This test is not (yet) supported on non-Windows platforms.");
+            return;
+        }
+
+        var testFolderPath = CreateTestFolder();
+        GenerateManifestAndValidateSuccess(testFolderPath, manifestInfoSpdxVersion: "3.0");
+
+        var (arguments, outputFile) = GetValidateManifestArguments(testFolderPath, manifestInfoValue: "SPDX:3.0");
 
         var (stdout, stderr, exitCode) = LaunchAndCaptureOutput(arguments);
 
@@ -152,7 +174,7 @@ public class IntegrationTests
         }
 
         var testFolderPath = CreateTestFolder();
-        GenerateManifestAndValidateSuccess(testFolderPath, manifestInfoValue: "3.0");
+        GenerateManifestAndValidateSuccess(testFolderPath, manifestInfoSpdxVersion: "3.0");
 
         var outputFolder = Path.Combine(TestContext.TestRunDirectory, TestContext.TestName, "redacted");
         var originalManifestFolderPath = AppendFullManifestFolderPath(testFolderPath, spdxVersion: "3.0");
@@ -226,18 +248,15 @@ public class IntegrationTests
         Assert.AreNotEqual(0, exitCode.Value);
     }
 
-    private void GenerateManifestAndValidateSuccess(string testFolderPath, string manifestInfoValue = null)
+    private void GenerateManifestAndValidateSuccess(string testFolderPath, string manifestInfoSpdxVersion = null)
     {
         var arguments = $"generate -ps IntegrationTests -pn IntegrationTests -pv 1.2.3 -m \"{testFolderPath}\"  -b \"{testDropDirectory}\" -bc \"{GetSolutionFolderPath()}\"";
-        if (!string.IsNullOrEmpty(manifestInfoValue))
-        {
-            arguments += $" -mi SPDX:{manifestInfoValue}";
-        }
+        arguments += !string.IsNullOrEmpty(manifestInfoSpdxVersion) ? $" -mi SPDX:{manifestInfoSpdxVersion}" : string.Empty;
 
         var (stdout, stderr, exitCode) = LaunchAndCaptureOutput(arguments);
 
         Assert.AreEqual(stderr, string.Empty);
-        var manifestFolderPath = AppendFullManifestFolderPath(testFolderPath, spdxVersion: manifestInfoValue);
+        var manifestFolderPath = AppendFullManifestFolderPath(testFolderPath, spdxVersion: manifestInfoSpdxVersion);
         var jsonFilePath = Path.Combine(manifestFolderPath, ManifestFileName);
         var shaFilePath = Path.Combine(manifestFolderPath, "manifest.spdx.json.sha256");
         Assert.IsTrue(File.Exists(jsonFilePath));

--- a/test/Microsoft.Sbom.Tool.Tests/IntegrationTests.cs
+++ b/test/Microsoft.Sbom.Tool.Tests/IntegrationTests.cs
@@ -250,8 +250,8 @@ public class IntegrationTests
 
     private void GenerateManifestAndValidateSuccess(string testFolderPath, string manifestInfoSpdxVersion = null)
     {
-        var arguments = $"generate -ps IntegrationTests -pn IntegrationTests -pv 1.2.3 -m \"{testFolderPath}\"  -b \"{testDropDirectory}\" -bc \"{GetSolutionFolderPath()}\"";
-        arguments += !string.IsNullOrEmpty(manifestInfoSpdxVersion) ? $" -mi SPDX:{manifestInfoSpdxVersion}" : string.Empty;
+        var manifestInfoArg = string.IsNullOrEmpty(manifestInfoSpdxVersion) ? string.Empty : $"-mi SPDX:{manifestInfoSpdxVersion}";
+        var arguments = $"generate -ps IntegrationTests -pn IntegrationTests -pv 1.2.3 -m \"{testFolderPath}\" -b \"{testDropDirectory}\" -bc \"{GetSolutionFolderPath()}\" {manifestInfoArg}";
 
         var (stdout, stderr, exitCode) = LaunchAndCaptureOutput(arguments);
 


### PR DESCRIPTION
This PR is the fix for issue https://github.com/microsoft/sbom-tool/issues/962. The root cause was that during the generation of SPDX file elements, the SPDX id was not generated using the file hash. This meant that the SPDX id was not unique for each file, which meant that certain files were incorrectly identified as duplicates. Then during deduplication these incorrectly identified "duplicates" were not added to the manifest file. 

This PR fixes the logic for adding SPDX id's to SPDX 3.0 file elements and validates the fix with unit tests and E2E tests. 