### PR TITLE
Introduce functionality to validate signatures on non-Windows machines

### DIFF
--- a/src/Microsoft.Sbom.Api/Output/Telemetry/Entities/SbomTelemetry.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/Entities/SbomTelemetry.cs
@@ -75,4 +75,9 @@ public class SbomTelemetry
     /// Gets or sets the total number of PackageDetails entries created during the execution of the tool.
     /// </summary>
     public int PackageDetailsEntries { get; set; }
+
+    /// <summary>
+    /// Gets or sets the SBOM validation results from the signtool.exe implementation and the non-signtool.exe implementation.
+    /// </summary>
+    public IDictionary<string, bool> SbomValidationResults { get; set; }
 }

--- a/src/Microsoft.Sbom.Api/Output/Telemetry/Entities/SbomTelemetry.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/Entities/SbomTelemetry.cs
@@ -79,5 +79,5 @@ public class SbomTelemetry
     /// <summary>
     /// Gets or sets the SBOM validation results from the signtool.exe implementation and the non-signtool.exe implementation.
     /// </summary>
-    public IDictionary<string, bool> SbomValidationResults { get; set; }
+    public IDictionary<string, bool?> SbomValidationResults { get; set; }
 }

--- a/src/Microsoft.Sbom.Api/Output/Telemetry/IRecorder.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/IRecorder.cs
@@ -89,7 +89,7 @@ public interface IRecorder
     /// </summary>
     /// <param name="validationResultSigntoolExe">The result from validating signatures using the signtool.exe verify command</param>
     /// <param name="validationResultNonSigntoolExe">The result from validating signatures using our own implementation (without signtool.exe)</param>
-    public void RecordSignatureValidationResult(bool validationResultSigntoolExe, bool validationResultNonSigntoolExe);
+    public void RecordSignatureValidationResult(bool? validationResultSigntoolExe, bool? validationResultNonSigntoolExe);
 
     /// <summary>
     /// Finalize the recorder, and log the telemetry.

--- a/src/Microsoft.Sbom.Api/Output/Telemetry/IRecorder.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/IRecorder.cs
@@ -85,6 +85,13 @@ public interface IRecorder
     public void RecordMetadataException(Exception exception);
 
     /// <summary>
+    /// Record the results from validating the signatures using 1) signtool.exe verify command and 2) our own implementation (without signtool.exe).
+    /// </summary>
+    /// <param name="validationResultSigntoolExe">The result from validating signatures using the signtool.exe verify command</param>
+    /// <param name="validationResultNonSigntoolExe">The result from validating signatures using our own implementation (without signtool.exe)</param>
+    public void RecordSignatureValidationResult(bool validationResultSigntoolExe, bool validationResultNonSigntoolExe);
+
+    /// <summary>
     /// Finalize the recorder, and log the telemetry.
     /// </summary>
     public Task FinalizeAndLogTelemetryAsync();

--- a/src/Microsoft.Sbom.Api/Output/Telemetry/TelemetryRecorder.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/TelemetryRecorder.cs
@@ -42,8 +42,8 @@ public class TelemetryRecorder : IRecorder
     private int totalNumberOfLicenses = 0;
     private int packageDetailsEntries = 0;
 
-    private bool validationResultNonSigntoolExe;
-    private bool validationResultSigntoolExe;
+    private bool? validationResultNonSigntoolExe;
+    private bool? validationResultSigntoolExe;
 
     public IFileSystemUtils FileSystemUtils { get; }
 
@@ -288,7 +288,7 @@ public class TelemetryRecorder : IRecorder
     /// </summary>
     /// <param name="validationResultSigntoolExe">The result from validating signatures using the signtool.exe verify command</param>
     /// <param name="validationResultNonSigntoolExe">The result from validating signatures using our own implementation (without signtool.exe)</param>
-    public void RecordSignatureValidationResult(bool validationResultSigntoolExe, bool validationResultNonSigntoolExe)
+    public void RecordSignatureValidationResult(bool? validationResultSigntoolExe, bool? validationResultNonSigntoolExe)
     {
         this.validationResultNonSigntoolExe = validationResultNonSigntoolExe;
         this.validationResultSigntoolExe = validationResultSigntoolExe;
@@ -339,7 +339,7 @@ public class TelemetryRecorder : IRecorder
                 PackageDetailsEntries = this.packageDetailsEntries,
                 // Temporary telemetry to record the results from running the signtool.exe verify command versus the results from running our own implementation.
                 // We should remove this once we migrate completely from the signtool.exe implementation.
-                SbomValidationResults = new Dictionary<string, bool>
+                SbomValidationResults = new Dictionary<string, bool?>
                 {
                     { "ValidationResultSigntoolExe", this.validationResultSigntoolExe },
                     { "ValidationResultNonSigntoolExe", this.validationResultNonSigntoolExe }

--- a/src/Microsoft.Sbom.Api/SignValidator/ISignatureValidationProvider.cs
+++ b/src/Microsoft.Sbom.Api/SignValidator/ISignatureValidationProvider.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Sbom.Extensions;
+
+namespace Microsoft.Sbom.Api.SignValidator;
+
+/// <summary>
+/// A type that provides a <see cref="ISignatureValidator"/> implementation based on the
+/// current operating system type.
+/// </summary>
+public interface ISignatureValidationProvider
+{
+    ISignatureValidator Get();
+
+    void Init();
+}

--- a/src/Microsoft.Sbom.Api/SignValidator/ISignatureValidationProvider.cs
+++ b/src/Microsoft.Sbom.Api/SignValidator/ISignatureValidationProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Sbom.Api.SignValidator;
 /// </summary>
 public interface ISignatureValidationProvider
 {
-    ISignatureValidator Get();
+    public ISignatureValidator Get();
 
-    void Init();
+    public void Init();
 }

--- a/src/Microsoft.Sbom.Api/SignValidator/SignatureValidationProvider.cs
+++ b/src/Microsoft.Sbom.Api/SignValidator/SignatureValidationProvider.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Microsoft.Sbom.Common;
+using Microsoft.Sbom.Extensions;
+
+namespace Microsoft.Sbom.Api.SignValidator;
+
+/// <summary>
+/// Factory class that provides a <see cref="ISignatureValidator"/> implementation based on the
+/// current operating system type.
+/// </summary>
+public class SignatureValidationProvider : ISignatureValidationProvider
+{
+    private readonly IEnumerable<ISignatureValidator> signValidators;
+    private readonly Dictionary<OSPlatform, ISignatureValidator> signValidatorsMap;
+    private readonly IOSUtils osUtils;
+
+    public SignatureValidationProvider(IEnumerable<ISignatureValidator> signValidators, IOSUtils osUtils)
+    {
+        this.signValidators = signValidators ?? throw new ArgumentNullException(nameof(signValidators));
+        this.osUtils = osUtils ?? throw new ArgumentNullException(nameof(osUtils));
+
+        signValidatorsMap = new Dictionary<OSPlatform, ISignatureValidator>();
+
+        this.Init();
+    }
+
+    public void Init()
+    {
+        foreach (var signValidator in signValidators)
+        {
+            signValidatorsMap[signValidator.SupportedPlatform] = signValidator;
+        }
+    }
+
+    public ISignatureValidator Get()
+    {
+        if (signValidatorsMap.TryGetValue(osUtils.GetCurrentOSPlatform(), out var signValidator))
+        {
+            return signValidator;
+        }
+
+        return null;
+    }
+}

--- a/src/Microsoft.Sbom.Api/Workflows/SbomParserBasedValidationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SbomParserBasedValidationWorkflow.cs
@@ -69,8 +69,8 @@ public class SbomParserBasedValidationWorkflow : IWorkflow<SbomParserBasedValida
         IEnumerable<FileValidationResult> validFailures = null;
         var totalNumberOfPackages = 0;
 
-        var validationResultSigntoolExe = false;
-        var validationResultNonSigntoolExe = false;
+        bool? validationResultSigntoolExe = null;
+        bool? validationResultNonSigntoolExe = null;
         using (recorder.TraceEvent(Events.SbomValidationWorkflow))
         {
             try
@@ -93,14 +93,14 @@ public class SbomParserBasedValidationWorkflow : IWorkflow<SbomParserBasedValida
                     }
                     else
                     {
-                        validationResultSigntoolExe = signValidator.Validate();
-                        if (!validationResultSigntoolExe)
+                        if (!signValidator.Validate())
                         {
                             log.Error("Sign validation failed.");
                             validFailures = new List<FileValidationResult> { new FileValidationResult { ErrorType = ErrorType.ManifestFileSigningError } };
                             return false;
                         }
 
+                        validationResultSigntoolExe = true;
                         log.Debug("Sign validation passed (using signtool.exe).");
                     }
 
@@ -115,8 +115,7 @@ public class SbomParserBasedValidationWorkflow : IWorkflow<SbomParserBasedValida
                     }
                     else
                     {
-                        validationResultNonSigntoolExe = signatureValidator.Validate();
-                        if (!validationResultNonSigntoolExe)
+                        if (!signatureValidator.Validate())
                         {
                             log.Error("Signature validation using the non-signtool.exe way failed.");
 
@@ -130,6 +129,7 @@ public class SbomParserBasedValidationWorkflow : IWorkflow<SbomParserBasedValida
                         }
                         else
                         {
+                            validationResultNonSigntoolExe = true;
                             log.Debug("Signature validation using the non-signtool.exe way passed.");
                         }
                     }

--- a/src/Microsoft.Sbom.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Sbom.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -124,6 +124,7 @@ public static class ServiceCollectionExtensions
             .AddSingleton<IRecorder, TelemetryRecorder>()
             .AddSingleton<IFileTypeUtils, FileTypeUtils>()
             .AddSingleton<ISignValidationProvider, SignValidationProvider>()
+            .AddSingleton<ISignatureValidationProvider, SignatureValidationProvider>()
             .AddSingleton<IManifestParserProvider, ManifestParserProvider>()
             .AddSingleton(x => {
                 var comparer = x.GetRequiredService<IOSUtils>().GetFileSystemStringComparer();
@@ -146,6 +147,7 @@ public static class ServiceCollectionExtensions
                     typeof(IAlgorithmNames),
                     typeof(IManifestConfigHandler),
                     typeof(ISignValidator),
+                    typeof(ISignatureValidator),
                     typeof(ISourcesProvider),
                     typeof(IManifestGenerator),
                     typeof(IMetadataProvider),

--- a/src/Microsoft.Sbom.Extensions/ISignatureValidator.cs
+++ b/src/Microsoft.Sbom.Extensions/ISignatureValidator.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Sbom.Extensions;
+
+/// <summary>
+/// Validates the given manifest.json using the platform specific sign verification mechanism.
+/// </summary>
+public interface ISignatureValidator
+{
+    /// <summary>
+    /// Gets the OS Platform that this validator supports, ex. Windows or Linux.
+    /// </summary>
+    public OSPlatform SupportedPlatform { get; }
+
+    /// <summary>
+    /// Validates the given manifest.json using the platform specific sign verification mechanism.
+    /// </summary>
+    /// <returns>true if valid, false otherwise.</returns>
+    bool Validate();
+}

--- a/src/Microsoft.Sbom.Extensions/ISignatureValidator.cs
+++ b/src/Microsoft.Sbom.Extensions/ISignatureValidator.cs
@@ -19,5 +19,5 @@ public interface ISignatureValidator
     /// Validates the given manifest.json using the platform specific sign verification mechanism.
     /// </summary>
     /// <returns>true if valid, false otherwise.</returns>
-    bool Validate();
+    public bool Validate();
 }

--- a/test/Microsoft.Sbom.Api.Tests/SignValidator/SignatureValidationProviderTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/SignValidator/SignatureValidationProviderTests.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.Sbom.Api.SignValidator;
+using Microsoft.Sbom.Common;
+using Microsoft.Sbom.Extensions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.Sbom.Api.Tests.SignValidator;
+
+[TestClass]
+public class SignatureValidationProviderTests
+{
+    [TestMethod]
+    public void SignatureValidationProvider_AddsValidator_Windows_Succeeds()
+    {
+        var mockSignatureValidator = new Mock<ISignatureValidator>();
+        mockSignatureValidator.SetupGet(s => s.SupportedPlatform).Returns(OSPlatform.Windows);
+
+        var mockOSUtilsWindows = new Mock<IOSUtils>();
+        mockOSUtilsWindows.Setup(o => o.GetCurrentOSPlatform()).Returns(OSPlatform.Windows);
+
+        var signatureValidator = new SignatureValidationProvider(new ISignatureValidator[] { mockSignatureValidator.Object }, mockOSUtilsWindows.Object);
+        signatureValidator.Init();
+        Assert.IsTrue(signatureValidator.Get().Equals(mockSignatureValidator.Object));
+
+        mockOSUtilsWindows.VerifyAll();
+        mockSignatureValidator.VerifyAll();
+    }
+
+    [TestMethod]
+    public void SignatureValidationProvider_AddsValidator_Linux_Succeeds()
+    {
+        var mockSignatureValidator = new Mock<ISignatureValidator>();
+        mockSignatureValidator.SetupGet(s => s.SupportedPlatform).Returns(OSPlatform.Linux);
+
+        var mockOSUtilsLinux = new Mock<IOSUtils>();
+        mockOSUtilsLinux.Setup(o => o.GetCurrentOSPlatform()).Returns(OSPlatform.Linux);
+
+        var signatureValidator = new SignatureValidationProvider(new ISignatureValidator[] { mockSignatureValidator.Object }, mockOSUtilsLinux.Object);
+        signatureValidator.Init();
+        Assert.IsTrue(signatureValidator.Get().Equals(mockSignatureValidator.Object));
+
+        mockOSUtilsLinux.VerifyAll();
+        mockSignatureValidator.VerifyAll();
+    }
+
+    [TestMethod]
+    public void SignatureValidationProvider_AddsValidator_Mac_Succeeds()
+    {
+        var mockSignatureValidator = new Mock<ISignatureValidator>();
+        mockSignatureValidator.SetupGet(s => s.SupportedPlatform).Returns(OSPlatform.OSX);
+
+        var mockOSUtilsMac = new Mock<IOSUtils>();
+        mockOSUtilsMac.Setup(o => o.GetCurrentOSPlatform()).Returns(OSPlatform.OSX);
+
+        var signatureValidator = new SignatureValidationProvider(new ISignatureValidator[] { mockSignatureValidator.Object }, mockOSUtilsMac.Object);
+        signatureValidator.Init();
+        Assert.IsTrue(signatureValidator.Get().Equals(mockSignatureValidator.Object));
+
+        mockOSUtilsMac.VerifyAll();
+        mockSignatureValidator.VerifyAll();
+    }
+
+    [TestMethod]
+    public void SignatureValidationProvider_NullValidators_Throws()
+    {
+        var mockOSUtils = new Mock<IOSUtils>();
+        mockOSUtils.Setup(o => o.GetCurrentOSPlatform()).Returns(OSPlatform.Windows);
+
+        Assert.ThrowsException<ArgumentNullException>(() => new SignatureValidationProvider(null, mockOSUtils.Object));
+    }
+}

--- a/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
@@ -134,7 +134,7 @@ public class InterfaceConcretionTests
         public void RecordAPIException(Exception exception) => throw new NotImplementedException();
         public void RecordException(Exception exception) => throw new NotImplementedException();
         public void RecordMetadataException(Exception exception) => throw new NotImplementedException();
-        public void RecordSignatureValidationResult(bool validationResultSigntoolExe, bool validationResultNonSigntoolExe) => throw new NotImplementedException();
+        public void RecordSignatureValidationResult(bool? validationResultSigntoolExe, bool? validationResultNonSigntoolExe) => throw new NotImplementedException();
         public void RecordSbomFormat(ManifestInfo manifestInfo, string sbomFilePath) => throw new NotImplementedException();
         public void RecordSwitch(string switchName, object value) => throw new NotImplementedException();
         public void RecordTotalErrors(IList<FileValidationResult> errors) => throw new NotImplementedException();

--- a/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
@@ -134,6 +134,7 @@ public class InterfaceConcretionTests
         public void RecordAPIException(Exception exception) => throw new NotImplementedException();
         public void RecordException(Exception exception) => throw new NotImplementedException();
         public void RecordMetadataException(Exception exception) => throw new NotImplementedException();
+        public void RecordSignatureValidationResult(bool validationResultSigntoolExe, bool validationResultNonSigntoolExe) => throw new NotImplementedException();
         public void RecordSbomFormat(ManifestInfo manifestInfo, string sbomFilePath) => throw new NotImplementedException();
         public void RecordSwitch(string switchName, object value) => throw new NotImplementedException();
         public void RecordTotalErrors(IList<FileValidationResult> errors) => throw new NotImplementedException();

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/SbomParserBasedValidationWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/SbomParserBasedValidationWorkflowTests.cs
@@ -50,6 +50,8 @@ public class SbomParserBasedValidationWorkflowTests : ValidationWorkflowTestsBas
     private readonly Mock<IFileSystemUtilsExtension> fileSystemUtilsExtensionMock = new();
     private readonly Mock<ISignValidator> signValidatorMock = new();
     private readonly Mock<ISignValidationProvider> signValidationProviderMock = new();
+    private readonly Mock<ISignatureValidator> signatureValidatorMock = new();
+    private readonly Mock<ISignatureValidationProvider> signatureValidationProviderMock = new();
 
     private const string SPDX22ManifestInfoJsonFilePath = "/root/_manifest/spdx_2.2/manifest.spdx.json";
     private const string SPDX30ManifestInfoJsonFilePath = "/root/_manifest/spdx_3.0/manifest.spdx.json";
@@ -59,6 +61,9 @@ public class SbomParserBasedValidationWorkflowTests : ValidationWorkflowTestsBas
     {
         signValidatorMock.Setup(s => s.Validate()).Returns(true);
         signValidationProviderMock.Setup(s => s.Get()).Returns(signValidatorMock.Object);
+
+        signatureValidatorMock.Setup(s => s.Validate()).Returns(true);
+        signatureValidationProviderMock.Setup(s => s.Get()).Returns(signatureValidatorMock.Object);
     }
 
     [TestCleanup]
@@ -182,6 +187,7 @@ public class SbomParserBasedValidationWorkflowTests : ValidationWorkflowTestsBas
         var validator = new SbomParserBasedValidationWorkflow(
             recorder.Object,
             signValidationProviderMock.Object,
+            signatureValidationProviderMock.Object,
             mockLogger.Object,
             manifestParserProvider.Object,
             configurationMock.Object,
@@ -343,6 +349,7 @@ public class SbomParserBasedValidationWorkflowTests : ValidationWorkflowTestsBas
         var validator = new SbomParserBasedValidationWorkflow(
             recorder.Object,
             signValidationProviderMock.Object,
+            signatureValidationProviderMock.Object,
             mockLogger.Object,
             manifestParserProvider.Object,
             configurationMock.Object,

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/SbomParserBasedValidationWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/SbomParserBasedValidationWorkflowTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.Sbom.Api.Convertors;
 using Microsoft.Sbom.Api.Entities.Output;
@@ -229,6 +230,7 @@ public class SbomParserBasedValidationWorkflowTests : ValidationWorkflowTestsBas
 
         configurationMock.VerifyAll();
         signValidatorMock.VerifyAll();
+        signatureValidatorMock.VerifyAll();
         fileSystemMock.VerifyAll();
         osUtilsMock.VerifyAll();
     }
@@ -394,6 +396,496 @@ public class SbomParserBasedValidationWorkflowTests : ValidationWorkflowTestsBas
 
         configurationMock.VerifyAll();
         signValidatorMock.VerifyAll();
+        signatureValidatorMock.VerifyAll();
+        fileSystemMock.VerifyAll();
+        osUtilsMock.VerifyAll();
+    }
+
+    [DataRow(SPDX22ManifestInfoJsonFilePath)]
+    [DataRow(SPDX30ManifestInfoJsonFilePath)]
+    [TestMethod]
+    public async Task SbomParserBasedValidationWorkflowTests_ReturnsSuccessAndValidationFailures_ValidationResultsMismatch_SigntoolFailsNonSigntoolSucceeds(string manifestInfoJsonFilePath)
+    {
+        var manifestInfo = manifestInfoJsonFilePath.Contains("2.2") ? Constants.SPDX22ManifestInfo : Constants.SPDX30ManifestInfo;
+
+        var manifestParserProvider = new Mock<IManifestParserProvider>();
+        var manifestInterface = new Mock<IManifestInterface>();
+        var sbomParser = new Mock<ISbomParser>();
+        var configurationMock = new Mock<IConfiguration>();
+        var sbomConfigs = new Mock<ISbomConfigProvider>();
+        var fileSystemMock = new Mock<IFileSystemUtils>();
+        var outputWriterMock = new Mock<IOutputWriter>();
+        var recorder = new Mock<IRecorder>();
+        var hashCodeGeneratorMock = new Mock<IHashCodeGenerator>();
+
+        sbomParser.SetupSequence(p => p.Next())
+            .Returns(new FilesResult(new ParserStateResult(SPDXParser.FilesProperty, GetSpdxFiles(GetSpdxFilesDictionary()), ExplicitField: true, YieldReturn: true)))
+            .Returns((ParserStateResult?)null);
+
+        manifestInterface.Setup(m => m.CreateParser(It.IsAny<Stream>()))
+            .Returns(sbomParser.Object);
+        manifestParserProvider.Setup(m => m.Get(It.IsAny<ManifestInfo>())).Returns(manifestInterface.Object);
+
+        configurationMock.SetupGet(c => c.BuildDropPath).Returns(new ConfigurationSetting<string> { Value = "/root" });
+        configurationMock.SetupGet(c => c.RootPathFilter).Returns(new ConfigurationSetting<string> { Value = "child1;child2;child3" });
+        configurationMock.SetupGet(c => c.FollowSymlinks).Returns(new ConfigurationSetting<bool> { Value = true });
+        configurationMock.SetupGet(c => c.ValidateSignature).Returns(new ConfigurationSetting<bool> { Value = true });
+        configurationMock.SetupGet(c => c.ManifestInfo).Returns(new ConfigurationSetting<IList<ManifestInfo>>
+        {
+            Value = new List<ManifestInfo>() { manifestInfo }
+        });
+
+        ISbomConfig sbomConfig = new SbomConfig(fileSystemMock.Object)
+        {
+            ManifestInfo = manifestInfo,
+            ManifestJsonDirPath = "/root/_manifest",
+            ManifestJsonFilePath = manifestInfoJsonFilePath,
+            MetadataBuilder = null,
+            Recorder = new SbomPackageDetailsRecorder()
+        };
+        sbomConfigs.Setup(c => c.Get(manifestInfo)).Returns(sbomConfig);
+
+        fileSystemMock.Setup(f => f.JoinPaths(It.IsAny<string>(), It.IsAny<string>())).Returns((string r, string p) => $"{r}/{p}");
+        fileSystemMock.Setup(f => f.OpenRead(manifestInfoJsonFilePath)).Returns(Stream.Null);
+
+        fileSystemUtilsExtensionMock.Setup(f => f.IsTargetPathInSource(It.IsAny<string>(), It.IsAny<string>())).Returns(true);
+
+        var validationResultGenerator = new ValidationResultGenerator(configurationMock.Object);
+
+        var directoryWalker = new DirectoryWalker(fileSystemMock.Object, mockLogger.Object, configurationMock.Object);
+
+        hashCodeGeneratorMock.Setup(h => h.GenerateHashes(
+                It.IsAny<string>(),
+                new AlgorithmName[] { Constants.DefaultHashAlgorithmName }))
+            .Returns((string fileName, AlgorithmName[] algos) =>
+                new Checksum[]
+                {
+                    new Checksum
+                    {
+                        ChecksumValue = $"{fileName}hash",
+                        Algorithm = Constants.DefaultHashAlgorithmName
+                    }
+                });
+
+        hashCodeGeneratorMock.Setup(h => h.GenerateHashes(
+                It.Is<string>(a => a == "/root/child2/grandchild1/file10"),
+                new AlgorithmName[] { Constants.DefaultHashAlgorithmName }))
+            .Throws(new FileNotFoundException());
+
+        var fileHasher = new FileHasher(
+            hashCodeGeneratorMock.Object,
+            new SbomToolManifestPathConverter(configurationMock.Object, mockOSUtils.Object, fileSystemMock.Object, fileSystemUtilsExtensionMock.Object),
+            mockLogger.Object,
+            configurationMock.Object,
+            new Mock<ISbomConfigProvider>().Object,
+            new ManifestGeneratorProvider(null),
+            new FileTypeUtils());
+
+        var manifestFilterMock = new ManifestFolderFilter(configurationMock.Object, mockOSUtils.Object);
+        manifestFilterMock.Init();
+        var fileFilterer = new ManifestFolderFilterer(manifestFilterMock, mockLogger.Object);
+
+        var rootFileFilterMock = new DownloadedRootPathFilter(configurationMock.Object, fileSystemMock.Object, mockLogger.Object);
+        rootFileFilterMock.Init();
+
+        var osUtilsMock = new Mock<IOSUtils>(MockBehavior.Strict);
+
+        var hashValidator = new ConcurrentSha256HashValidator(FileHashesDictionarySingleton.Instance);
+        var enumeratorChannel = new EnumeratorChannel(mockLogger.Object);
+        var fileConverter = new SbomFileToFileInfoConverter(new FileTypeUtils());
+        var spdxFileFilterer = new FileFilterer(rootFileFilterMock, mockLogger.Object, configurationMock.Object, fileSystemMock.Object);
+
+        var filesValidator = new FilesValidator(
+            directoryWalker,
+            configurationMock.Object,
+            mockLogger.Object,
+            fileHasher,
+            fileFilterer,
+            hashValidator,
+            enumeratorChannel,
+            fileConverter,
+            FileHashesDictionarySingleton.Instance,
+            spdxFileFilterer);
+
+        // The validation should fail because on Windows platforms, we temporarily (until we migrate away from signtool.exe completely)
+        // let the signtool.exe tool determine the final result
+        signValidatorMock.Setup(signValidatorMock => signValidatorMock.Validate()).Returns(false);   // signtool.exe validator
+        signatureValidatorMock.Setup(signatureValidatorMock => signatureValidatorMock.Validate()).Returns(true);   // non-signtool.exe validator
+
+        var validator = new SbomParserBasedValidationWorkflow(
+            recorder.Object,
+            signValidationProviderMock.Object,
+            signatureValidationProviderMock.Object,
+            mockLogger.Object,
+            manifestParserProvider.Object,
+            configurationMock.Object,
+            sbomConfigs.Object,
+            filesValidator,
+            validationResultGenerator,
+            outputWriterMock.Object,
+            fileSystemMock.Object,
+            osUtilsMock.Object);
+
+        var cc = new ConsoleCapture();
+
+        // Act
+        try
+        {
+            var result = await validator.RunAsync();
+            Assert.IsFalse(result);
+        }
+        finally
+        {
+            cc.Restore();
+        }
+
+        // Assert
+        var nodeValidationResults = validationResultGenerator.NodeValidationResults;
+
+        configurationMock.VerifyAll();
+        signValidatorMock.VerifyAll();
+        fileSystemMock.VerifyAll();
+        osUtilsMock.VerifyAll();
+    }
+
+    [DataRow(SPDX22ManifestInfoJsonFilePath)]
+    [DataRow(SPDX30ManifestInfoJsonFilePath)]
+    [TestMethod]
+    public async Task SbomParserBasedValidationWorkflowTests_ReturnsSuccessAndValidationFailures_ValidationResultsMismatch_SigntoolSucceedsNonSigntoolFails(string manifestInfoJsonFilePath)
+    {
+        var manifestInfo = manifestInfoJsonFilePath.Contains("2.2") ? Constants.SPDX22ManifestInfo : Constants.SPDX30ManifestInfo;
+
+        var manifestParserProvider = new Mock<IManifestParserProvider>();
+        var manifestInterface = new Mock<IManifestInterface>();
+        var sbomParser = new Mock<ISbomParser>();
+        var configurationMock = new Mock<IConfiguration>();
+        var sbomConfigs = new Mock<ISbomConfigProvider>();
+        var fileSystemMock = GetDefaultFileSystemMock();
+        var outputWriterMock = new Mock<IOutputWriter>();
+        var recorder = new Mock<IRecorder>();
+        var hashCodeGeneratorMock = new Mock<IHashCodeGenerator>();
+
+        sbomParser.SetupSequence(p => p.Next())
+            .Returns(new FilesResult(new ParserStateResult(SPDXParser.FilesProperty, GetSpdxFiles(GetSpdxFilesDictionary()), ExplicitField: true, YieldReturn: true)))
+            .Returns((ParserStateResult?)null);
+
+        manifestInterface.Setup(m => m.CreateParser(It.IsAny<Stream>()))
+            .Returns(sbomParser.Object);
+        manifestParserProvider.Setup(m => m.Get(It.IsAny<ManifestInfo>())).Returns(manifestInterface.Object);
+
+        configurationMock.SetupGet(c => c.BuildDropPath).Returns(new ConfigurationSetting<string> { Value = "/root" });
+        configurationMock.SetupGet(c => c.ManifestDirPath).Returns(new ConfigurationSetting<string> { Value = PathUtils.Join("/root", "_manifest") });
+        configurationMock.SetupGet(c => c.Parallelism).Returns(new ConfigurationSetting<int> { Value = 3 });
+        configurationMock.SetupGet(c => c.HashAlgorithm).Returns(new ConfigurationSetting<AlgorithmName> { Value = Constants.DefaultHashAlgorithmName });
+        configurationMock.SetupGet(c => c.RootPathFilter).Returns(new ConfigurationSetting<string> { Value = "child1;child2;child3" });
+        configurationMock.SetupGet(c => c.IgnoreMissing).Returns(new ConfigurationSetting<bool> { Value = false });
+        configurationMock.SetupGet(c => c.ManifestToolAction).Returns(ManifestToolActions.Validate);
+        configurationMock.SetupGet(c => c.FollowSymlinks).Returns(new ConfigurationSetting<bool> { Value = true });
+        configurationMock.SetupGet(c => c.ValidateSignature).Returns(new ConfigurationSetting<bool> { Value = true });
+        configurationMock.SetupGet(c => c.ManifestInfo).Returns(new ConfigurationSetting<IList<ManifestInfo>>
+        {
+            Value = new List<ManifestInfo>() { manifestInfo }
+        });
+
+        ISbomConfig sbomConfig = new SbomConfig(fileSystemMock.Object)
+        {
+            ManifestInfo = manifestInfo,
+            ManifestJsonDirPath = "/root/_manifest",
+            ManifestJsonFilePath = manifestInfoJsonFilePath,
+            MetadataBuilder = null,
+            Recorder = new SbomPackageDetailsRecorder()
+        };
+        sbomConfigs.Setup(c => c.Get(manifestInfo)).Returns(sbomConfig);
+
+        fileSystemMock.Setup(f => f.OpenRead(manifestInfoJsonFilePath)).Returns(Stream.Null);
+        fileSystemMock.Setup(f => f.GetRelativePath(It.IsAny<string>(), It.IsAny<string>()))
+            .Returns((string r, string p) => PathUtils.GetRelativePath(r, p));
+
+        fileSystemUtilsExtensionMock.Setup(f => f.IsTargetPathInSource(It.IsAny<string>(), It.IsAny<string>())).Returns(true);
+
+        var validationResultGenerator = new ValidationResultGenerator(configurationMock.Object);
+
+        var directoryWalker = new DirectoryWalker(fileSystemMock.Object, mockLogger.Object, configurationMock.Object);
+
+        hashCodeGeneratorMock.Setup(h => h.GenerateHashes(
+                It.IsAny<string>(),
+                new AlgorithmName[] { Constants.DefaultHashAlgorithmName }))
+            .Returns((string fileName, AlgorithmName[] algos) =>
+                new Checksum[]
+                {
+                    new Checksum
+                    {
+                        ChecksumValue = $"{fileName}hash",
+                        Algorithm = Constants.DefaultHashAlgorithmName
+                    }
+                });
+
+        hashCodeGeneratorMock.Setup(h => h.GenerateHashes(
+                It.Is<string>(a => a == "/root/child2/grandchild1/file10"),
+                new AlgorithmName[] { Constants.DefaultHashAlgorithmName }))
+            .Throws(new FileNotFoundException());
+
+        var fileHasher = new FileHasher(
+            hashCodeGeneratorMock.Object,
+            new SbomToolManifestPathConverter(configurationMock.Object, mockOSUtils.Object, fileSystemMock.Object, fileSystemUtilsExtensionMock.Object),
+            mockLogger.Object,
+            configurationMock.Object,
+            new Mock<ISbomConfigProvider>().Object,
+            new ManifestGeneratorProvider(null),
+            new FileTypeUtils());
+
+        var manifestFilterMock = new ManifestFolderFilter(configurationMock.Object, mockOSUtils.Object);
+        manifestFilterMock.Init();
+        var fileFilterer = new ManifestFolderFilterer(manifestFilterMock, mockLogger.Object);
+
+        var rootFileFilterMock = new DownloadedRootPathFilter(configurationMock.Object, fileSystemMock.Object, mockLogger.Object);
+        rootFileFilterMock.Init();
+
+        var osUtilsMock = new Mock<IOSUtils>(MockBehavior.Strict);
+        osUtilsMock.Setup(x => x.IsCaseSensitiveOS()).Returns(false);
+
+        var hashValidator = new ConcurrentSha256HashValidator(FileHashesDictionarySingleton.Instance);
+        var enumeratorChannel = new EnumeratorChannel(mockLogger.Object);
+        var fileConverter = new SbomFileToFileInfoConverter(new FileTypeUtils());
+        var spdxFileFilterer = new FileFilterer(rootFileFilterMock, mockLogger.Object, configurationMock.Object, fileSystemMock.Object);
+
+        var filesValidator = new FilesValidator(
+            directoryWalker,
+            configurationMock.Object,
+            mockLogger.Object,
+            fileHasher,
+            fileFilterer,
+            hashValidator,
+            enumeratorChannel,
+            fileConverter,
+            FileHashesDictionarySingleton.Instance,
+            spdxFileFilterer);
+
+        // The validation should succeed because on Windows platforms, we temporarily (until we migrate away from signtool.exe completely)
+        // let the signtool.exe tool determine the final result
+        signValidatorMock.Setup(s => s.Validate()).Returns(true);       // signtool.exe validator
+        signatureValidatorMock.Setup(s => s.Validate()).Returns(false); // non-signtool.exe validator
+
+        var validator = new SbomParserBasedValidationWorkflow(
+            recorder.Object,
+            signValidationProviderMock.Object,
+            signatureValidationProviderMock.Object,
+            mockLogger.Object,
+            manifestParserProvider.Object,
+            configurationMock.Object,
+            sbomConfigs.Object,
+            filesValidator,
+            validationResultGenerator,
+            outputWriterMock.Object,
+            fileSystemMock.Object,
+            osUtilsMock.Object);
+
+        var cc = new ConsoleCapture();
+
+        try
+        {
+            var result = await validator.RunAsync();
+            Assert.IsFalse(result);
+        }
+        finally
+        {
+            cc.Restore();
+        }
+
+        var nodeValidationResults = validationResultGenerator.NodeValidationResults;
+
+        var additionalFileErrors = nodeValidationResults.Where(a => a.ErrorType == ErrorType.AdditionalFile).ToList();
+        Assert.AreEqual(1, additionalFileErrors.Count);
+        Assert.AreEqual("./child2/grandchild1/file7", additionalFileErrors.First().Path);
+
+        var missingFileErrors = nodeValidationResults.Where(a => a.ErrorType == ErrorType.MissingFile).ToList();
+        Assert.AreEqual(1, missingFileErrors.Count);
+        Assert.AreEqual("./child2/grandchild2/file10", missingFileErrors.First().Path);
+
+        var invalidHashErrors = nodeValidationResults.Where(a => a.ErrorType == ErrorType.InvalidHash).ToList();
+        Assert.AreEqual(1, invalidHashErrors.Count);
+        Assert.AreEqual("./child2/grandchild1/file9", invalidHashErrors.First().Path);
+
+        var otherErrors = nodeValidationResults.Where(a => a.ErrorType == ErrorType.Other).ToList();
+        Assert.AreEqual(1, otherErrors.Count);
+        Assert.AreEqual("./child2/grandchild1/file10", otherErrors.First().Path);
+
+        Assert.IsTrue(cc.CapturedStdOut.Contains(CaseSensitiveMessageMarker), "Case-sensitive marker should have been output");
+
+        configurationMock.VerifyAll();
+        signValidatorMock.VerifyAll();
+        signatureValidatorMock.VerifyAll();
+        fileSystemMock.VerifyAll();
+        osUtilsMock.VerifyAll();
+    }
+
+    [DataRow(SPDX22ManifestInfoJsonFilePath)]
+    [DataRow(SPDX30ManifestInfoJsonFilePath)]
+    [TestMethod]
+    public async Task SbomParserBasedValidationWorkflowTests_ReturnsSuccessAndValidationFailures_LinuxOS_Succeeds(string manifestInfoJsonFilePath)
+    {
+        var manifestInfo = manifestInfoJsonFilePath.Contains("2.2") ? Constants.SPDX22ManifestInfo : Constants.SPDX30ManifestInfo;
+
+        var manifestParserProvider = new Mock<IManifestParserProvider>();
+        var manifestInterface = new Mock<IManifestInterface>();
+        var sbomParser = new Mock<ISbomParser>();
+        var configurationMock = new Mock<IConfiguration>();
+        var sbomConfigs = new Mock<ISbomConfigProvider>();
+        var fileSystemMock = GetDefaultFileSystemMock();
+        var outputWriterMock = new Mock<IOutputWriter>();
+        var recorder = new Mock<IRecorder>();
+        var hashCodeGeneratorMock = new Mock<IHashCodeGenerator>();
+
+        sbomParser.SetupSequence(p => p.Next())
+            .Returns(new FilesResult(new ParserStateResult(SPDXParser.FilesProperty, GetSpdxFiles(GetSpdxFilesDictionary()), ExplicitField: true, YieldReturn: true)))
+            .Returns((ParserStateResult?)null);
+
+        manifestInterface.Setup(m => m.CreateParser(It.IsAny<Stream>()))
+            .Returns(sbomParser.Object);
+        manifestParserProvider.Setup(m => m.Get(It.IsAny<ManifestInfo>())).Returns(manifestInterface.Object);
+
+        configurationMock.SetupGet(c => c.BuildDropPath).Returns(new ConfigurationSetting<string> { Value = "/root" });
+        configurationMock.SetupGet(c => c.ManifestDirPath).Returns(new ConfigurationSetting<string> { Value = PathUtils.Join("/root", "_manifest") });
+        configurationMock.SetupGet(c => c.Parallelism).Returns(new ConfigurationSetting<int> { Value = 3 });
+        configurationMock.SetupGet(c => c.HashAlgorithm).Returns(new ConfigurationSetting<AlgorithmName> { Value = Constants.DefaultHashAlgorithmName });
+        configurationMock.SetupGet(c => c.RootPathFilter).Returns(new ConfigurationSetting<string> { Value = "child1;child2;child3" });
+        configurationMock.SetupGet(c => c.IgnoreMissing).Returns(new ConfigurationSetting<bool> { Value = false });
+        configurationMock.SetupGet(c => c.ManifestToolAction).Returns(ManifestToolActions.Validate);
+        configurationMock.SetupGet(c => c.FollowSymlinks).Returns(new ConfigurationSetting<bool> { Value = true });
+        configurationMock.SetupGet(c => c.ValidateSignature).Returns(new ConfigurationSetting<bool> { Value = true });
+        configurationMock.SetupGet(c => c.ManifestInfo).Returns(new ConfigurationSetting<IList<ManifestInfo>>
+        {
+            Value = new List<ManifestInfo>() { manifestInfo }
+        });
+
+        ISbomConfig sbomConfig = new SbomConfig(fileSystemMock.Object)
+        {
+            ManifestInfo = manifestInfo,
+            ManifestJsonDirPath = "/root/_manifest",
+            ManifestJsonFilePath = manifestInfoJsonFilePath,
+            MetadataBuilder = null,
+            Recorder = new SbomPackageDetailsRecorder()
+        };
+        sbomConfigs.Setup(c => c.Get(manifestInfo)).Returns(sbomConfig);
+
+        fileSystemMock.Setup(f => f.OpenRead(manifestInfoJsonFilePath)).Returns(Stream.Null);
+        fileSystemMock.Setup(f => f.GetRelativePath(It.IsAny<string>(), It.IsAny<string>()))
+            .Returns((string r, string p) => PathUtils.GetRelativePath(r, p));
+
+        fileSystemUtilsExtensionMock.Setup(f => f.IsTargetPathInSource(It.IsAny<string>(), It.IsAny<string>())).Returns(true);
+
+        var validationResultGenerator = new ValidationResultGenerator(configurationMock.Object);
+
+        var directoryWalker = new DirectoryWalker(fileSystemMock.Object, mockLogger.Object, configurationMock.Object);
+
+        hashCodeGeneratorMock.Setup(h => h.GenerateHashes(
+                It.IsAny<string>(),
+                new AlgorithmName[] { Constants.DefaultHashAlgorithmName }))
+            .Returns((string fileName, AlgorithmName[] algos) =>
+                new Checksum[]
+                {
+                    new Checksum
+                    {
+                        ChecksumValue = $"{fileName}hash",
+                        Algorithm = Constants.DefaultHashAlgorithmName
+                    }
+                });
+
+        hashCodeGeneratorMock.Setup(h => h.GenerateHashes(
+                It.Is<string>(a => a == "/root/child2/grandchild1/file10"),
+                new AlgorithmName[] { Constants.DefaultHashAlgorithmName }))
+            .Throws(new FileNotFoundException());
+
+        var fileHasher = new FileHasher(
+            hashCodeGeneratorMock.Object,
+            new SbomToolManifestPathConverter(configurationMock.Object, mockOSUtils.Object, fileSystemMock.Object, fileSystemUtilsExtensionMock.Object),
+            mockLogger.Object,
+            configurationMock.Object,
+            new Mock<ISbomConfigProvider>().Object,
+            new ManifestGeneratorProvider(null),
+            new FileTypeUtils());
+
+        var manifestFilterMock = new ManifestFolderFilter(configurationMock.Object, mockOSUtils.Object);
+        manifestFilterMock.Init();
+        var fileFilterer = new ManifestFolderFilterer(manifestFilterMock, mockLogger.Object);
+
+        var rootFileFilterMock = new DownloadedRootPathFilter(configurationMock.Object, fileSystemMock.Object, mockLogger.Object);
+        rootFileFilterMock.Init();
+
+        var osUtilsMock = new Mock<IOSUtils>(MockBehavior.Strict);
+        osUtilsMock.Setup(x => x.IsCaseSensitiveOS()).Returns(false);
+
+        var hashValidator = new ConcurrentSha256HashValidator(FileHashesDictionarySingleton.Instance);
+        var enumeratorChannel = new EnumeratorChannel(mockLogger.Object);
+        var fileConverter = new SbomFileToFileInfoConverter(new FileTypeUtils());
+        var spdxFileFilterer = new FileFilterer(rootFileFilterMock, mockLogger.Object, configurationMock.Object, fileSystemMock.Object);
+
+        var filesValidator = new FilesValidator(
+            directoryWalker,
+            configurationMock.Object,
+            mockLogger.Object,
+            fileHasher,
+            fileFilterer,
+            hashValidator,
+            enumeratorChannel,
+            fileConverter,
+            FileHashesDictionarySingleton.Instance,
+            spdxFileFilterer);
+
+        // The validation results should match the output from the non-signtool.exe implementation where Linux and MacOS systems are supported
+#pragma warning disable CS8603
+        signValidationProviderMock.Setup(s => s.Get()).Returns(() => null);
+#pragma warning restore CS8603
+        signatureValidatorMock.Setup(s => s.SupportedPlatform).Returns(OSPlatform.Linux);
+        signatureValidatorMock.Setup(s => s.Validate()).Returns(true); // non-signtool.exe validator
+
+        var validator = new SbomParserBasedValidationWorkflow(
+            recorder.Object,
+            signValidationProviderMock.Object,
+            signatureValidationProviderMock.Object,
+            mockLogger.Object,
+            manifestParserProvider.Object,
+            configurationMock.Object,
+            sbomConfigs.Object,
+            filesValidator,
+            validationResultGenerator,
+            outputWriterMock.Object,
+            fileSystemMock.Object,
+            osUtilsMock.Object);
+
+        var cc = new ConsoleCapture();
+
+        try
+        {
+            var result = await validator.RunAsync();
+            Assert.IsFalse(result);
+        }
+        finally
+        {
+            cc.Restore();
+        }
+
+        var nodeValidationResults = validationResultGenerator.NodeValidationResults;
+
+        var additionalFileErrors = nodeValidationResults.Where(a => a.ErrorType == ErrorType.AdditionalFile).ToList();
+        Assert.AreEqual(1, additionalFileErrors.Count);
+        Assert.AreEqual("./child2/grandchild1/file7", additionalFileErrors.First().Path);
+
+        var missingFileErrors = nodeValidationResults.Where(a => a.ErrorType == ErrorType.MissingFile).ToList();
+        Assert.AreEqual(1, missingFileErrors.Count);
+        Assert.AreEqual("./child2/grandchild2/file10", missingFileErrors.First().Path);
+
+        var invalidHashErrors = nodeValidationResults.Where(a => a.ErrorType == ErrorType.InvalidHash).ToList();
+        Assert.AreEqual(1, invalidHashErrors.Count);
+        Assert.AreEqual("./child2/grandchild1/file9", invalidHashErrors.First().Path);
+
+        var otherErrors = nodeValidationResults.Where(a => a.ErrorType == ErrorType.Other).ToList();
+        Assert.AreEqual(1, otherErrors.Count);
+        Assert.AreEqual("./child2/grandchild1/file10", otherErrors.First().Path);
+
+        Assert.IsTrue(cc.CapturedStdOut.Contains(CaseSensitiveMessageMarker), "Case-sensitive marker should have been output");
+
+        configurationMock.VerifyAll();
         fileSystemMock.VerifyAll();
         osUtilsMock.VerifyAll();
     }


### PR DESCRIPTION
This PR contains the functionality to enable signature validation of the manifest.cat catalog file and manifest json files on non-Windows machines. We use the signtool.exe tool and our own implementation to validate the signatures on Windows machines but let the signtool.exe tool decide the outcome of the validation. We then record the validation results of both implementations on the telemetry file.