### PR TITLE
Don't run auto-comment workflow on PR's from forks

### DIFF
--- a/.github/workflows/pr-comment-api-change.yml
+++ b/.github/workflows/pr-comment-api-change.yml
@@ -7,6 +7,7 @@ on:
       
 jobs:
   auto-comment:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
We've had a few PR's from forks lately, and they get stuck in the auto-comment workflow with an error like this:
```
gh pr comment $PRNUM --body-file .github/workflows/pr-comment-api-change.md
  shell: /usr/bin/bash -e {0}
  env:
    GITHUB_TOKEN: ***
    GH_REPO: microsoft/sbom-tool
    PRNUM: 99[4](https://github.com/microsoft/sbom-tool/actions/runs/14227841901/job/39877790647?pr=994#step:3:4)
GraphQL: Resource not accessible by integration (addComment)
Error: Process completed with exit code 1.
```

This PR scopes the auto-comment workflow to run only if the PR comes from a branch within the primary repo. It's unfortunate to need to lose this warning, but it's more important at the moment to be able to merge from forks.

The change is derived from [this comment](https://github.com/orgs/community/discussions/26079#discussioncomment-3250306) from the GitHub community discussion forum.