### PR TITLE
Introduce new telemetry method to record signature validation results

### DIFF
--- a/src/Microsoft.Sbom.Api/Output/Telemetry/Entities/SbomTelemetry.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/Entities/SbomTelemetry.cs
@@ -75,4 +75,6 @@ public class SbomTelemetry
     /// Gets or sets the total number of PackageDetails entries created during the execution of the tool.
     /// </summary>
     public int PackageDetailsEntries { get; set; }
+
+    public Dictionary<string, string> Properties { get; set; }
 }

--- a/src/Microsoft.Sbom.Api/Output/Telemetry/Entities/SbomTelemetry.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/Entities/SbomTelemetry.cs
@@ -76,5 +76,8 @@ public class SbomTelemetry
     /// </summary>
     public int PackageDetailsEntries { get; set; }
 
-    public Dictionary<string, string> Properties { get; set; }
+    /// <summary>
+    /// Gets or sets additional properties, like signature validation results, etc.
+    /// </summary>
+    public Dictionary<string, string> AdditionalResults { get; set; }
 }

--- a/src/Microsoft.Sbom.Api/Output/Telemetry/IRecorder.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/IRecorder.cs
@@ -90,9 +90,9 @@ public interface IRecorder
     public Task FinalizeAndLogTelemetryAsync();
 
     /// <summary>
-    /// Add an extra key/value pair to the telemetry
+    /// Add an extra result in the form of a key-value pair to the telemetry.
     /// </summary>
-    public void AddProperty(string propertyName, string value);
+    public void AddResult(string propertyName, string value);
 
     public IList<FileValidationResult> Errors { get; }
 }

--- a/src/Microsoft.Sbom.Api/Output/Telemetry/IRecorder.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/IRecorder.cs
@@ -89,5 +89,10 @@ public interface IRecorder
     /// </summary>
     public Task FinalizeAndLogTelemetryAsync();
 
+    /// <summary>
+    /// Add an extra key/value pair to the telemetry
+    /// </summary>
+    public void AddProperty(string propertyName, string value);
+
     public IList<FileValidationResult> Errors { get; }
 }

--- a/src/Microsoft.Sbom.Api/Output/Telemetry/TelemetryRecorder.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/TelemetryRecorder.cs
@@ -324,7 +324,8 @@ public class TelemetryRecorder : IRecorder
                 APIExceptions = this.apiExceptions.GroupBy(e => e.GetType().ToString()).ToDictionary(group => group.Key, group => group.First().Message),
                 MetadataExceptions = this.metadataExceptions.GroupBy(e => e.GetType().ToString()).ToDictionary(g => g.Key, g => g.First().Message),
                 TotalLicensesDetected = this.totalNumberOfLicenses,
-                PackageDetailsEntries = this.packageDetailsEntries
+                PackageDetailsEntries = this.packageDetailsEntries,
+                AdditionalResults = this.additionalResults,
             };
 
             // Log to logger.

--- a/src/Microsoft.Sbom.Api/Output/Telemetry/TelemetryRecorder.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/TelemetryRecorder.cs
@@ -35,6 +35,7 @@ public class TelemetryRecorder : IRecorder
     private readonly IList<Exception> exceptions = new List<Exception>();
     private readonly IList<Exception> apiExceptions = new List<Exception>();
     private readonly IList<Exception> metadataExceptions = new List<Exception>();
+    private readonly Dictionary<string, string> propertyBag = new Dictionary<string, string>();
     private IList<FileValidationResult> errors = new List<FileValidationResult>();
     private Result result = Result.Success;
 
@@ -102,6 +103,7 @@ public class TelemetryRecorder : IRecorder
                 Switches = this.switches,
                 Parameters = Configuration,
                 Exceptions = exceptionList.ToDictionary(k => k.GetType().ToString(), v => v.Message),
+                Properties = propertyBag,
             };
 
             // Log to logger.
@@ -343,5 +345,10 @@ public class TelemetryRecorder : IRecorder
             // Just log the result and return silently.
             Log.Warning($"Failed to log telemetry. Exception: {ex.Message}");
         }
+    }
+
+    public void AddProperty(string propertyName, string value)
+    {
+        propertyBag[propertyName] = value;
     }
 }

--- a/src/Microsoft.Sbom.Api/Output/Telemetry/TelemetryRecorder.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/TelemetryRecorder.cs
@@ -35,7 +35,7 @@ public class TelemetryRecorder : IRecorder
     private readonly IList<Exception> exceptions = new List<Exception>();
     private readonly IList<Exception> apiExceptions = new List<Exception>();
     private readonly IList<Exception> metadataExceptions = new List<Exception>();
-    private readonly Dictionary<string, string> propertyBag = new Dictionary<string, string>();
+    private readonly Dictionary<string, string> additionalResults = new Dictionary<string, string>();
     private IList<FileValidationResult> errors = new List<FileValidationResult>();
     private Result result = Result.Success;
 
@@ -103,7 +103,7 @@ public class TelemetryRecorder : IRecorder
                 Switches = this.switches,
                 Parameters = Configuration,
                 Exceptions = exceptionList.ToDictionary(k => k.GetType().ToString(), v => v.Message),
-                Properties = propertyBag,
+                AdditionalResults = additionalResults,
             };
 
             // Log to logger.
@@ -347,8 +347,11 @@ public class TelemetryRecorder : IRecorder
         }
     }
 
-    public void AddProperty(string propertyName, string value)
+    /// <summary>
+    /// Add an extra result in the form of a key-value pair to the telemetry.
+    /// </summary>
+    public void AddResult(string propertyName, string propertyValue)
     {
-        propertyBag[propertyName] = value;
+        this.additionalResults[propertyName] = propertyValue;
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/Output/Telemetry/TelemetryRecorderTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Output/Telemetry/TelemetryRecorderTests.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+namespace Microsoft.Sbom.Api.Output.Telemetry.Tests;
+
+using System.Collections.Generic;
+using Microsoft.Sbom.Api.Output.Telemetry;
+using Microsoft.Sbom.Common;
+using Microsoft.Sbom.Common.Config;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Serilog;
+
+[TestClass]
+public class TelemetryRecorderTests
+{
+    private Mock<IFileSystemUtils> fileSystemUtilsMock;
+    private Mock<IConfiguration> configMock;
+    private Mock<ILogger> loggerMock;
+
+    [TestInitialize]
+    public void Init()
+    {
+        fileSystemUtilsMock = new Mock<IFileSystemUtils>();
+        configMock = new Mock<IConfiguration>();
+        loggerMock = new Mock<ILogger>();
+    }
+
+    [TestMethod]
+    public void TelemetryRecorderTest_AddResult()
+    {
+        var telemetryRecorder = new TelemetryRecorder(fileSystemUtilsMock.Object, configMock.Object, loggerMock.Object);
+        var testKey = "TestKey";
+        var testValue1 = "TestValue";
+
+        telemetryRecorder.AddResult(testKey, testValue1);
+
+        var additionalResultsField = typeof(TelemetryRecorder).GetField("additionalResults", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var additionalResults = (Dictionary<string, string>)additionalResultsField.GetValue(telemetryRecorder);
+
+        Assert.IsTrue(additionalResults.ContainsKey(testKey));
+        Assert.AreEqual(testValue1, additionalResults[testKey]);
+
+        var testValue2 = "AnotherTestValue";
+        telemetryRecorder.AddResult(testKey, testValue2);
+        Assert.AreEqual(testValue2, additionalResults[testKey]);
+        Assert.AreNotEqual(testValue1, additionalResults[testKey]);
+    }
+}

--- a/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
@@ -128,6 +128,7 @@ public class InterfaceConcretionTests
     {
         public IList<FileValidationResult> Errors => throw new NotImplementedException();
 
+        public void AddProperty(string propertyName, string value) => throw new NotImplementedException();
         public void AddToTotalCountOfLicenses(int count) => throw new NotImplementedException();
         public void AddToTotalNumberOfPackageDetailsEntries(int count) => throw new NotImplementedException();
         public Task FinalizeAndLogTelemetryAsync() => throw new NotImplementedException();

--- a/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
@@ -128,7 +128,7 @@ public class InterfaceConcretionTests
     {
         public IList<FileValidationResult> Errors => throw new NotImplementedException();
 
-        public void AddProperty(string propertyName, string value) => throw new NotImplementedException();
+        public void AddResult(string propertyName, string value) => throw new NotImplementedException();
         public void AddToTotalCountOfLicenses(int count) => throw new NotImplementedException();
         public void AddToTotalNumberOfPackageDetailsEntries(int count) => throw new NotImplementedException();
         public Task FinalizeAndLogTelemetryAsync() => throw new NotImplementedException();


### PR DESCRIPTION
The changes to the interface allow for recording additional results in the telemetry file in the form of a key-value pair of strings.