### PR TITLE
Update SPDX 2.2 extension

### DIFF
--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/SPDXToSbomFormatConverterExtensions.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/SPDXToSbomFormatConverterExtensions.cs
@@ -110,7 +110,8 @@ public static class SPDXToSbomFormatConverterExtensions
 
         return new ExternalDocumentReferenceInfo
         {
-            Checksum = new List<SbomChecksum> { externalDocumentReference.Checksum.ToSbomChecksum() },
+            ExternalDocumentName = externalDocumentReference.ExternalDocumentId,
+            Checksum = new List<SbomChecksum> { externalDocumentReference.Checksum?.ToSbomChecksum() },
             DocumentNamespace = externalDocumentReference.SpdxDocument,
         };
     }

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/SPDXToSbomFormatConverterExtensions.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/SPDXToSbomFormatConverterExtensions.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Sbom.Contracts;
 using Microsoft.Sbom.Contracts.Enums;
+using Microsoft.Sbom.Extensions.Entities;
 using Microsoft.Sbom.JsonAsynchronousNodeKit.Exceptions;
 using Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
 using SbomChecksum = Microsoft.Sbom.Contracts.Checksum;
@@ -97,6 +98,20 @@ public static class SPDXToSbomFormatConverterExtensions
             Checksum = spdxExternalDocumentReference.Checksum.ToSbomChecksum(),
             ExternalDocumentId = spdxExternalDocumentReference.ExternalDocumentId,
             Document = spdxExternalDocumentReference.SpdxDocument,
+        };
+    }
+
+    public static ExternalDocumentReferenceInfo ToExternalDocumentReferenceInfo(this SpdxExternalDocumentReference externalDocumentReference)
+    {
+        if (externalDocumentReference is null)
+        {
+            return null;
+        }
+
+        return new ExternalDocumentReferenceInfo
+        {
+            Checksum = new List<SbomChecksum> { externalDocumentReference.Checksum.ToSbomChecksum() },
+            DocumentNamespace = externalDocumentReference.SpdxDocument,
         };
     }
 

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Utils/SbomFormatConverterTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Utils/SbomFormatConverterTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
 using Microsoft.Sbom.Utils;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -49,5 +50,47 @@ public class SbomFormatConverterTests
         var sbomPackage = spdxPackage.ToSbomPackage();
 
         Assert.IsNotNull(sbomPackage);
+    }
+
+    [TestMethod]
+    public void ToExternalDocumentReferenceInfo_HappyPath()
+    {
+        var spdxExternalDocumentReference = new SpdxExternalDocumentReference
+        {
+            ExternalDocumentId = "ExternalDocId",
+            SpdxDocument = "https://example.com/spdx-document",
+            Checksum = new Checksum
+            {
+                ChecksumValue = "checksumValue",
+                Algorithm = "SHA256"
+            }
+        };
+
+        var externalDocumentReferenceInfo = spdxExternalDocumentReference.ToExternalDocumentReferenceInfo();
+
+        Assert.IsNotNull(externalDocumentReferenceInfo);
+        Assert.AreEqual(spdxExternalDocumentReference.ExternalDocumentId, externalDocumentReferenceInfo.ExternalDocumentName);
+        Assert.AreEqual(spdxExternalDocumentReference.SpdxDocument, externalDocumentReferenceInfo.DocumentNamespace);
+        Assert.IsNotNull(externalDocumentReferenceInfo.Checksum);
+        Assert.AreEqual(spdxExternalDocumentReference.Checksum.ChecksumValue, externalDocumentReferenceInfo.Checksum.First().ChecksumValue);
+        Assert.AreEqual(spdxExternalDocumentReference.Checksum.Algorithm, externalDocumentReferenceInfo.Checksum.First().Algorithm.ToString());
+    }
+
+    [TestMethod]
+    public void ToExternalDocumentReferenceInfo_NullChecksum_ReturnsObjectWithNullChecksum()
+    {
+        var spdxExternalDocumentReference = new SpdxExternalDocumentReference
+        {
+            ExternalDocumentId = "ExternalDocId",
+            SpdxDocument = "https://example.com/spdx-document",
+            Checksum = null
+        };
+
+        var externalDocumentReferenceInfo = spdxExternalDocumentReference.ToExternalDocumentReferenceInfo();
+
+        Assert.IsNotNull(externalDocumentReferenceInfo);
+        Assert.AreEqual(spdxExternalDocumentReference.ExternalDocumentId, externalDocumentReferenceInfo.ExternalDocumentName);
+        Assert.AreEqual(spdxExternalDocumentReference.SpdxDocument, externalDocumentReferenceInfo.DocumentNamespace);
+        Assert.IsNull(externalDocumentReferenceInfo.Checksum.First());
     }
 }


### PR DESCRIPTION
This pull request updates the SPDX 2.2 extension to include new functionality for converting an External Document Reference to an internal SBOM component that is standardized.