### PR TITLE
External Map generation bug

### DIFF
--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Generator.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Generator.cs
@@ -295,14 +295,13 @@ public class Generator : IManifestGenerator
         };
 
         spdxExternalMap.AddExternalSpdxId(externalDocumentReferenceInfo.ExternalDocumentName, externalDocumentReferenceInfo.Checksum);
-        var externalDocumentReferenceId = spdxExternalMap.ExternalSpdxId;
 
         return new GenerationResult
         {
             Document = JsonDocument.Parse(JsonSerializer.Serialize(spdxExternalMap, this.serializerOptions)),
             ResultMetadata = new ResultMetadata
             {
-                EntityId = externalDocumentReferenceId
+                EntityId = spdxExternalMap.SpdxId
             }
         };
     }

--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Utils/SPDXExtensions.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Utils/SPDXExtensions.cs
@@ -90,9 +90,8 @@ public static class SPDXExtensions
         // Get the SHA1 for this file.
         var sha1Value = sha1checksums.FirstOrDefault().ChecksumValue;
 
-        reference.ExternalSpdxId = CommonSPDXUtils.GenerateSpdxExternalDocumentId(name, sha1Value);
-        reference.SpdxId = reference.ExternalSpdxId;
-        return reference.ExternalSpdxId;
+        reference.SpdxId = CommonSPDXUtils.GenerateSpdxExternalDocumentId(name, sha1Value);
+        return reference.SpdxId;
     }
 
     public static void AddSpdxId(this Element element)

--- a/test/Microsoft.Sbom.Parsers.Spdx30SbomParser.Tests/Parser/JsonStrings/SbomExternalMapJsonStrings.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx30SbomParser.Tests/Parser/JsonStrings/SbomExternalMapJsonStrings.cs
@@ -9,7 +9,7 @@ public static class SbomExternalMapJsonStrings
     public const string ExternalMapJsonString =
     @"
     {
-        ""externalSpdxId"": ""DocumentRef-sample-external-doc-sha1Value"",
+        ""externalSpdxId"": ""sample-namespace"",
         ""creationInfo"": ""_:creationinfo"",
         ""spdxId"": ""DocumentRef-sample-external-doc-sha1Value"",
         ""verifiedUsing"": [

--- a/test/Microsoft.Sbom.Parsers.Spdx30SbomParser.Tests/Utils/SPDXExtensionsTest.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx30SbomParser.Tests/Utils/SPDXExtensionsTest.cs
@@ -141,7 +141,6 @@ public class SPDXExtensionsTest
     public void AddSpdxIdToExternalReference_Succeeds()
     {
         externalMap.AddExternalSpdxId("externalRefName", checksums);
-        Assert.AreEqual(ExternalReferenceSpdxId, externalMap.ExternalSpdxId);
         Assert.AreEqual(ExternalReferenceSpdxId, externalMap.SpdxId);
     }
 


### PR DESCRIPTION
Previously, we were overwriting ExternalSpdxId. The expected behavior, however, is that ExternalSpdxId represents the external document that the SBOM is linking to.

This PR includes that fix and updates the corresponding unit tests.