### PR TITLE
Update spdx22 external doc ref extension

### DIFF
--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/SPDXToSbomFormatConverterExtensions.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/SPDXToSbomFormatConverterExtensions.cs
@@ -94,7 +94,7 @@ public static class SPDXToSbomFormatConverterExtensions
     {
         return new SbomReference
         {
-            Checksum = spdxExternalDocumentReference.Checksum.ToSbomChecksum(),
+            Checksum = spdxExternalDocumentReference.Checksum?.ToSbomChecksum(),
             ExternalDocumentId = spdxExternalDocumentReference.ExternalDocumentId,
             Document = spdxExternalDocumentReference.SpdxDocument,
         };
@@ -114,14 +114,19 @@ public static class SPDXToSbomFormatConverterExtensions
     /// <summary>
     /// Convert a <see cref="SPDXChecksum"/> object to a <see cref="SbomChecksum"/> object.
     /// </summary>
-    /// <param name="spdxChecksums"></param>
+    /// <param name="spdxChecksum"></param>
     /// <returns></returns>
-    internal static SbomChecksum ToSbomChecksum(this SPDXChecksum spdxChecksums)
+    internal static SbomChecksum ToSbomChecksum(this SPDXChecksum spdxChecksum)
     {
+        if (spdxChecksum is null)
+        {
+            return null;
+        }
+
         return new SbomChecksum
         {
-            Algorithm = new AlgorithmName(spdxChecksums.Algorithm, null),
-            ChecksumValue = spdxChecksums.ChecksumValue,
+            Algorithm = new AlgorithmName(spdxChecksum.Algorithm, null),
+            ChecksumValue = spdxChecksum.ChecksumValue,
         };
     }
 }

--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Utils/SPDXToSbomFormatConverterExtensions.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Utils/SPDXToSbomFormatConverterExtensions.cs
@@ -41,6 +41,11 @@ public static class SPDXToSbomFormatConverterExtensions
     /// <returns></returns>
     internal static SbomChecksum ToSbomChecksum(this PackageVerificationCode spdxPackageVerificationCode)
     {
+        if (spdxPackageVerificationCode is null)
+        {
+            return null;
+        }
+
         return new SbomChecksum
         {
             Algorithm = AlgorithmName.FromString(spdxPackageVerificationCode.Algorithm.ToString()),

--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Utils/SPDXToSbomFormatConverterExtensions.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Utils/SPDXToSbomFormatConverterExtensions.cs
@@ -92,12 +92,6 @@ public static class SPDXToSbomFormatConverterExtensions
     /// <returns></returns>
     internal static List<SbomChecksum> ToSbomChecksum(this List<PackageVerificationCode> verificationCodes)
     {
-        if (spdxPackageVerificationCode is null)
-        {
-            return null;
-        }
-
-        return new SbomChecksum
         if (verificationCodes is null)
         {
             return null;

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Utils/SbomFormatConverterTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Utils/SbomFormatConverterTests.cs
@@ -50,4 +50,12 @@ public class SbomFormatConverterTests
 
         Assert.IsNotNull(sbomPackage);
     }
+
+    [TestMethod]
+    public void ToSbomChecksum_NullChecksum_ReturnsNull()
+    {
+        Checksum spdxChecksum = null;
+        var sbomChecksum = spdxChecksum.ToSbomChecksum();
+        Assert.IsNull(sbomChecksum, "ToSbomChecksum should return null when the input checksum is null.");
+    }
 }


### PR DESCRIPTION
Update the `ToSbomReference` extension method to handle null values for the `Checksum` property.