### PR TITLE
Add null check for SPDX 3.0 external identifiers

### DIFF
--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Utils/SPDXToSbomFormatConverterExtensions.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Utils/SPDXToSbomFormatConverterExtensions.cs
@@ -206,6 +206,6 @@ public static class SPDXToSbomFormatConverterExtensions
 
         var externalIdentifier = (ExternalIdentifier)spdx30Elements
             .FirstOrDefault(element => element is ExternalIdentifier && element.SpdxId == externalIdentifierSpdxId);
-        return externalIdentifier.Identifier;
+        return externalIdentifier?.Identifier;
     }
 }


### PR DESCRIPTION
This a bug fix that targets the case of a null external identifier in SPDX 3.0. Without this null check we threw a null reference exception when converting from SPDX to the internal SBOM format.