### PR TITLE
SPDX to internal SBOM conversion of supplier info for root packages (special case)

### DIFF
--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Utils/SPDXToSbomFormatConverterExtensions.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Utils/SPDXToSbomFormatConverterExtensions.cs
@@ -185,15 +185,30 @@ public static class SPDXToSbomFormatConverterExtensions
 
     private static string GetSupplier(this Package spdxPackage, List<Element> spdx30Elements)
     {
-        var organizationSpdxId = spdxPackage.SuppliedBy;
+        var organizationSpdxId = spdxPackage.GetOrganizationSpdxId(spdx30Elements);
         if (organizationSpdxId is null)
         {
             return null;
         }
 
         var organizationElement = spdx30Elements
-            .FirstOrDefault(element => element is Organization && element.SpdxId == organizationSpdxId);
+            .FirstOrDefault(element => element.SpdxId == organizationSpdxId);
         return organizationElement?.Name;
+    }
+
+    private static string GetOrganizationSpdxId(this Package spdxPackage, List<Element> spdx30Elements)
+    {
+        // Handle special case for the root package.
+        if (spdxPackage.SpdxId == Parsers.Spdx30SbomParser.Constants.RootPackageIdValue)
+        {
+            var creationInfo = spdx30Elements
+            .First(element => element is CreationInfo) as CreationInfo;
+            return creationInfo.CreatedBy.First();
+        }
+        else
+        {
+            return spdxPackage.SuppliedBy;
+        }
     }
 
     private static string GetPackageUrl(this Package spdxPackage, List<Element> spdx30Elements)

--- a/test/Microsoft.Sbom.Parsers.Spdx30SbomParser.Tests/Utils/SbomFormatConverterTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx30SbomParser.Tests/Utils/SbomFormatConverterTests.cs
@@ -153,6 +153,39 @@ public class SbomFormatConverterTests
     }
 
     [TestMethod]
+    public void ToSbomPackage_RootPackage_ReturnsExpectedSupplier()
+    {
+        var rootPackage = new Package
+        {
+            SpdxId = Parsers.Spdx30SbomParser.Constants.RootPackageIdValue,
+            Name = "Package1"
+        };
+
+        var creationInfo = new CreationInfo
+        {
+            SpdxId = "CreationInfoId",
+            CreatedBy = new List<string> { "SPDXRef-Organization" }
+        };
+
+        var organization = new Organization
+        {
+            SpdxId = "SPDXRef-Organization",
+            Name = "Microsoft"
+        };
+
+        var spdx30Elements = new List<Element>
+        {
+            rootPackage,
+            creationInfo,
+            organization
+        };
+
+        var sbomPackage = rootPackage.ToSbomPackage(spdx30Elements, new List<Relationship>());
+
+        Assert.AreEqual("Microsoft", sbomPackage.Supplier, "The supplier for the root package should be derived from the CreatedBy field.");
+    }
+
+    [TestMethod]
     public void ToSbomRelationship_SimpleConversion_ReturnsExpectedRelationships()
     {
         var spdxRelationship = new Relationship


### PR DESCRIPTION
In SPDX 3.0 the supplier information for root packages is stored in the CreationInfo element which is different from SPDX 2.2. This PR handles this special case and gets the supplier info correctly for SPDX 3.0 so that this information is present when converting to the internal SBOM format.