### PR TITLE
Fix casing of ValidatedSbomFactory.CreateValidatedSBOM

### DIFF
--- a/src/Microsoft.Sbom.Api/FormatValidator/ValidatedSbomFactory.cs
+++ b/src/Microsoft.Sbom.Api/FormatValidator/ValidatedSbomFactory.cs
@@ -7,7 +7,7 @@ using System.IO;
 
 public class ValidatedSbomFactory
 {
-    public virtual IValidatedSbom CreateValidatedSBOM(string sbomFilePath)
+    public virtual IValidatedSbom CreateValidatedSbom(string sbomFilePath)
     {
         var sbomStream = new StreamReader(sbomFilePath);
         var validatedSbom = new ValidatedSbom(sbomStream.BaseStream);

--- a/src/Microsoft.Sbom.Api/Workflows/SbomRedactionWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SbomRedactionWorkflow.cs
@@ -53,7 +53,7 @@ public class SbomRedactionWorkflow : IWorkflow<SbomRedactionWorkflow>
             try
             {
                 log.Information($"Validating SBOM {sbomPath}");
-                validatedSbom = validatedSbomFactory.CreateValidatedSBOM(sbomPath);
+                validatedSbom = validatedSbomFactory.CreateValidatedSbom(sbomPath);
                 var validationDetails = await validatedSbom.GetValidationResults();
                 if (validationDetails.Status != FormatValidationStatus.Valid)
                 {

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/SbomRedactionWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/SbomRedactionWorkflowTests.cs
@@ -107,7 +107,7 @@ public class SbomRedactionWorkflowTests
 
         fileSystemUtilsMock.Setup(m => m.GetFilesInDirectory(SbomDirStub, true)).Returns(new string[] { SbomPathStub }).Verifiable();
         var validatedSbomMock = new Mock<IValidatedSbom>();
-        validatedSBOMFactoryMock.Setup(m => m.CreateValidatedSBOM(SbomPathStub)).Returns(validatedSbomMock.Object).Verifiable();
+        validatedSBOMFactoryMock.Setup(m => m.CreateValidatedSbom(SbomPathStub)).Returns(validatedSbomMock.Object).Verifiable();
         var validationRes = new FormatValidationResults();
         validationRes.AggregateValidationStatus(FormatValidationStatus.NotValid);
         validatedSbomMock.Setup(m => m.GetValidationResults()).ReturnsAsync(validationRes).Verifiable();
@@ -123,7 +123,7 @@ public class SbomRedactionWorkflowTests
 
         fileSystemUtilsMock.Setup(m => m.GetFilesInDirectory(SbomDirStub, true)).Returns(new string[] { SbomPathStub }).Verifiable();
         var validatedSbomMock = new Mock<IValidatedSbom>();
-        validatedSBOMFactoryMock.Setup(m => m.CreateValidatedSBOM(SbomPathStub)).Returns(validatedSbomMock.Object).Verifiable();
+        validatedSBOMFactoryMock.Setup(m => m.CreateValidatedSbom(SbomPathStub)).Returns(validatedSbomMock.Object).Verifiable();
         var validationRes = new FormatValidationResults();
         validationRes.AggregateValidationStatus(FormatValidationStatus.Valid);
         validatedSbomMock.Setup(m => m.GetValidationResults()).ReturnsAsync(validationRes).Verifiable();


### PR DESCRIPTION
While preparing the docs for releasing the 4.0 interface, I found that `ValidatedSbomFactory.CreateValidatedSBOM` was not renamed in #950. This simply renames the method to `CreateValidatedSbom` before we release