### PR TITLE
Add ability to pass additional telemetry data back from ISignValidator.Validate

### DIFF
--- a/src/Microsoft.Sbom.Api/Workflows/SbomParserBasedValidationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SbomParserBasedValidationWorkflow.cs
@@ -90,7 +90,10 @@ public class SbomParserBasedValidationWorkflow : IWorkflow<SbomParserBasedValida
                     }
                     else
                     {
-                        if (!signValidator.Validate())
+                        Dictionary<string, string> additionalTelemetry = new();
+                        var signatureIsValid = signValidator.Validate(additionalTelemetry);
+                        RecordAdditionalTelemetry(additionalTelemetry);
+                        if (!signatureIsValid)
                         {
                             log.Error("Sign validation failed.");
                             validFailures = new List<FileValidationResult> { new FileValidationResult { ErrorType = ErrorType.ManifestFileSigningError } };
@@ -203,6 +206,14 @@ public class SbomParserBasedValidationWorkflow : IWorkflow<SbomParserBasedValida
                 LogResultsSummary(validationResultOutput, validFailures);
                 LogIndividualFileResults(validFailures);
             }
+        }
+    }
+
+    private void RecordAdditionalTelemetry(IDictionary<string, string> additionalTelemetry)
+    {
+        foreach (var pair in additionalTelemetry)
+        {
+            recorder.AddResult(pair.Key, pair.Value);
         }
     }
 

--- a/src/Microsoft.Sbom.Extensions/ISignValidator.cs
+++ b/src/Microsoft.Sbom.Extensions/ISignValidator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.Sbom.Extensions;
@@ -18,6 +19,7 @@ public interface ISignValidator
     /// <summary>
     /// Validates the given manifest.json using the platform specific sign verification mechanism.
     /// </summary>
+    /// <param name="additionalTelemetry">Property bag where the validation can add additional telemetry info</param>
     /// <returns>true if valid, false otherwise.</returns>
-    public bool Validate();
+    public bool Validate(IDictionary<string, string> additionalTelemetry);
 }

--- a/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
@@ -283,8 +283,7 @@ public class InterfaceConcretionTests
     private class PinnedISignValidator : ISignValidator
     {
         public OSPlatform SupportedPlatform => throw new NotImplementedException();
-
-        public bool Validate() => throw new NotImplementedException();
+        public bool Validate(IDictionary<string, string> additionalTelemetry) => throw new NotImplementedException();
     }
 
     private class PinnedISbomParser : ISbomParser

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/SbomParserBasedValidationWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/SbomParserBasedValidationWorkflowTests.cs
@@ -227,6 +227,7 @@ public class SbomParserBasedValidationWorkflowTests : ValidationWorkflowTestsBas
         signValidatorMock.VerifyAll();
         fileSystemMock.VerifyAll();
         osUtilsMock.VerifyAll();
+        recorder.Verify(r => r.AddResult(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
     }
 
     [DataRow(SPDX22ManifestInfoJsonFilePath)]
@@ -234,6 +235,19 @@ public class SbomParserBasedValidationWorkflowTests : ValidationWorkflowTestsBas
     [TestMethod]
     public async Task SbomParserBasedValidationWorkflowTests_ReturnsSuccessAndValidationFailures_Succeeds(string manifestInfoJsonFilePath)
     {
+        const string key1 = "key1";
+        const string key2 = "key2";
+        const string value1 = "value1";
+        const string value2 = "value2";
+
+        signValidatorMock
+            .Setup(s => s.Validate(It.IsAny<IDictionary<string, string>>()))
+            .Returns(true)
+            .Callback<IDictionary<string, string>>(additionalTelemetry =>
+            {
+                additionalTelemetry.Add(key1, value1);
+                additionalTelemetry.Add(key2, value2);
+            });
         var manifestInfo = manifestInfoJsonFilePath.Contains("2.2") ? Constants.SPDX22ManifestInfo : Constants.SPDX30ManifestInfo;
 
         var manifestParserProvider = new Mock<IManifestParserProvider>();
@@ -243,8 +257,10 @@ public class SbomParserBasedValidationWorkflowTests : ValidationWorkflowTestsBas
         var sbomConfigs = new Mock<ISbomConfigProvider>();
         var fileSystemMock = GetDefaultFileSystemMock();
         var outputWriterMock = new Mock<IOutputWriter>();
-        var recorder = new Mock<IRecorder>();
         var hashCodeGeneratorMock = new Mock<IHashCodeGenerator>();
+        var recorder = new Mock<IRecorder>();
+        recorder.Setup(r => r.AddResult(key1, value1));
+        recorder.Setup(r => r.AddResult(key2, value2));
 
         sbomParser.SetupSequence(p => p.Next())
             .Returns(new FilesResult(new ParserStateResult(SPDXParser.FilesProperty, GetSpdxFiles(GetSpdxFilesDictionary()), ExplicitField: true, YieldReturn: true)))
@@ -391,6 +407,7 @@ public class SbomParserBasedValidationWorkflowTests : ValidationWorkflowTestsBas
         signValidatorMock.VerifyAll();
         fileSystemMock.VerifyAll();
         osUtilsMock.VerifyAll();
+        recorder.VerifyAll();
     }
 
     [TestMethod]

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/SbomParserBasedValidationWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/SbomParserBasedValidationWorkflowTests.cs
@@ -59,7 +59,7 @@ public class SbomParserBasedValidationWorkflowTests : ValidationWorkflowTestsBas
     [TestInitialize]
     public void Init()
     {
-        signValidatorMock.Setup(s => s.Validate()).Returns(true);
+        signValidatorMock.Setup(s => s.Validate(It.IsAny<IDictionary<string, string>>())).Returns(true);
         signValidationProviderMock.Setup(s => s.Get()).Returns(signValidatorMock.Object);
     }
 


### PR DESCRIPTION
We need to be able to capture additional telemetry from `ISignValidator.Validate`. Dependency Injection didn't allow us to do this via the constructor, so we set the value via a parameter on the interface.