### PR TITLE
Rename NTIA to NTIAMin - no functional changes

### DIFF
--- a/src/Microsoft.Sbom.Api/Utils/Constants.cs
+++ b/src/Microsoft.Sbom.Api/Utils/Constants.cs
@@ -49,7 +49,7 @@ public static class Constants
 
     public static Collection<ConformanceType> SupportedConformances = new()
     {
-        ConformanceType.NTIA,
+        ConformanceType.NTIAMin,
         ConformanceType.None
     };
 

--- a/src/Microsoft.Sbom.Api/Workflows/SbomParserBasedValidationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SbomParserBasedValidationWorkflow.cs
@@ -330,8 +330,8 @@ public class SbomParserBasedValidationWorkflow : IWorkflow<SbomParserBasedValida
 
         switch (configuration.Conformance?.Value?.Name)
         {
-            case "NTIA":
-                AddInvalidNTIAElementsToFailures(fileValidationFailures, invalidElements);
+            case "NTIAMin":
+                AddInvalidNTIAMinElementsToFailures(fileValidationFailures, invalidElements);
                 break;
             case "None":
                 break;
@@ -340,7 +340,7 @@ public class SbomParserBasedValidationWorkflow : IWorkflow<SbomParserBasedValida
         }
     }
 
-    private void AddInvalidNTIAElementsToFailures(List<FileValidationResult> fileValidationFailures, HashSet<InvalidElementInfo> invalidElements)
+    private void AddInvalidNTIAMinElementsToFailures(List<FileValidationResult> fileValidationFailures, HashSet<InvalidElementInfo> invalidElements)
     {
         foreach (var invalidElementInfo in invalidElements)
         {

--- a/src/Microsoft.Sbom.Common/Conformance/ConformanceEnforcerFactory.cs
+++ b/src/Microsoft.Sbom.Common/Conformance/ConformanceEnforcerFactory.cs
@@ -13,7 +13,7 @@ public static class ConformanceEnforcerFactory
     {
         return conformance.Name switch
         {
-            "NTIA" => new NTIAConformanceEnforcer(),
+            "NTIAMin" => new NTIAMinConformanceEnforcer(),
             "None" => new NoneConformanceEnforcer(),
             _ => throw new ArgumentException($"Unsupported conformance: {conformance.Name}")
         };

--- a/src/Microsoft.Sbom.Common/Conformance/Enums/NTIAMinErrorType.cs
+++ b/src/Microsoft.Sbom.Common/Conformance/Enums/NTIAMinErrorType.cs
@@ -6,11 +6,11 @@ using Microsoft.Sbom.Parsers.Spdx30SbomParser.Conformance.Interfaces;
 
 namespace Microsoft.Sbom.Common.Conformance.Enums;
 
-public class NTIAErrorType : IConformanceErrorType, IEquatable<NTIAErrorType>
+public class NTIAMinErrorType : IConformanceErrorType, IEquatable<NTIAMinErrorType>
 {
     public string Name { get; set; }
 
-    public NTIAErrorType(string name)
+    public NTIAMinErrorType(string name)
     {
         Name = name;
     }
@@ -22,10 +22,10 @@ public class NTIAErrorType : IConformanceErrorType, IEquatable<NTIAErrorType>
 
     public override bool Equals(object obj)
     {
-        return Equals(obj as NTIAErrorType);
+        return Equals(obj as NTIAMinErrorType);
     }
 
-    public bool Equals(NTIAErrorType other)
+    public bool Equals(NTIAMinErrorType other)
     {
         if (other == null)
         {
@@ -35,13 +35,13 @@ public class NTIAErrorType : IConformanceErrorType, IEquatable<NTIAErrorType>
         return string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase);
     }
 
-    public static NTIAErrorType InvalidNTIAElement => new NTIAErrorType("InvalidNTIAElement");
+    public static NTIAMinErrorType InvalidNTIAMinElement => new NTIAMinErrorType("InvalidNTIAMinElement");
 
-    public static NTIAErrorType MissingValidSpdxDocument => new NTIAErrorType("MissingValidSpdxDocument");
+    public static NTIAMinErrorType MissingValidSpdxDocument => new NTIAMinErrorType("MissingValidSpdxDocument");
 
-    public static NTIAErrorType AdditionalSpdxDocument => new NTIAErrorType("AdditionalSpdxDocument");
+    public static NTIAMinErrorType AdditionalSpdxDocument => new NTIAMinErrorType("AdditionalSpdxDocument");
 
-    public static NTIAErrorType MissingValidCreationInfo => new NTIAErrorType("MissingValidCreationInfo");
+    public static NTIAMinErrorType MissingValidCreationInfo => new NTIAMinErrorType("MissingValidCreationInfo");
 
     public override int GetHashCode()
     {

--- a/src/Microsoft.Sbom.Common/Conformance/InvalidElementInfo.cs
+++ b/src/Microsoft.Sbom.Common/Conformance/InvalidElementInfo.cs
@@ -31,15 +31,15 @@ public class InvalidElementInfo
 
     public override string ToString()
     {
-        if (this.ErrorType.Equals(NTIAErrorType.MissingValidCreationInfo))
+        if (this.ErrorType.Equals(NTIAMinErrorType.MissingValidCreationInfo))
         {
-            return NTIAErrorType.MissingValidCreationInfo.ToString();
+            return NTIAMinErrorType.MissingValidCreationInfo.ToString();
         }
-        else if (this.ErrorType.Equals(NTIAErrorType.MissingValidSpdxDocument))
+        else if (this.ErrorType.Equals(NTIAMinErrorType.MissingValidSpdxDocument))
         {
-            return NTIAErrorType.MissingValidSpdxDocument.ToString();
+            return NTIAMinErrorType.MissingValidSpdxDocument.ToString();
         }
-        else if (this.ErrorType.Equals(NTIAErrorType.AdditionalSpdxDocument))
+        else if (this.ErrorType.Equals(NTIAMinErrorType.AdditionalSpdxDocument))
         {
             return $"AdditionalSpdxDocument. SpdxId: {this.SpdxId}. Name: {this.Name}";
         }

--- a/src/Microsoft.Sbom.Common/Conformance/NTIAMinConformanceEnforcer.cs
+++ b/src/Microsoft.Sbom.Common/Conformance/NTIAMinConformanceEnforcer.cs
@@ -14,9 +14,9 @@ using Microsoft.Sbom.Parsers.Spdx30SbomParser.Conformance.Interfaces;
 
 namespace Microsoft.Sbom.Common.Conformance;
 
-public class NTIAConformanceEnforcer : IConformanceEnforcer
+public class NTIAMinConformanceEnforcer : IConformanceEnforcer
 {
-    private static readonly IReadOnlyCollection<string> EntitiesWithDifferentNTIARequirements = new List<string>
+    private static readonly IReadOnlyCollection<string> EntitiesWithDifferentNTIAMinRequirements = new List<string>
     {
         "SpdxDocument",
         "File",
@@ -26,9 +26,9 @@ public class NTIAConformanceEnforcer : IConformanceEnforcer
 
     public string GetConformanceEntityType(string? entityType)
     {
-        if (EntitiesWithDifferentNTIARequirements.Contains(entityType))
+        if (EntitiesWithDifferentNTIAMinRequirements.Contains(entityType))
         {
-            return string.IsNullOrEmpty(entityType) ? string.Empty : "NTIA" + entityType.GetCommonEntityType();
+            return string.IsNullOrEmpty(entityType) ? string.Empty : "NTIAMin" + entityType.GetCommonEntityType();
         }
         else
         {
@@ -41,7 +41,7 @@ public class NTIAConformanceEnforcer : IConformanceEnforcer
         try
         {
             var deserializedAsElement = JsonSerializer.Deserialize(jsonObjectAsString, typeof(Element), jsonSerializerOptions) as Element;
-            var invalidElementInfo = GetInvalidElementInfo(deserializedAsElement, errorType: NTIAErrorType.InvalidNTIAElement);
+            var invalidElementInfo = GetInvalidElementInfo(deserializedAsElement, errorType: NTIAMinErrorType.InvalidNTIAMinElement);
             invalidElements.Add(invalidElementInfo);
         }
         catch
@@ -51,13 +51,13 @@ public class NTIAConformanceEnforcer : IConformanceEnforcer
     }
 
     /// <summary>
-    /// Add invalid NTIA elements to the list of invalid elements after deserialization.
+    /// Add invalid NTIAMin elements to the list of invalid elements after deserialization.
     /// </summary>
     public void AddInvalidElements(ElementsResult elementsResult)
     {
-        ValidateSbomDocCreationForNTIA(elementsResult.SpdxDocuments, elementsResult.CreationInfos, elementsResult.InvalidConformanceElements);
-        ValidateSbomFilesForNTIA(elementsResult.Files, elementsResult.InvalidConformanceElements);
-        ValidateSbomPackagesForNTIA(elementsResult.Packages, elementsResult.InvalidConformanceElements);
+        ValidateSbomDocCreationForNTIAMin(elementsResult.SpdxDocuments, elementsResult.CreationInfos, elementsResult.InvalidConformanceElements);
+        ValidateSbomFilesForNTIAMin(elementsResult.Files, elementsResult.InvalidConformanceElements);
+        ValidateSbomPackagesForNTIAMin(elementsResult.Packages, elementsResult.InvalidConformanceElements);
     }
 
     /// <summary>
@@ -65,17 +65,17 @@ public class NTIAConformanceEnforcer : IConformanceEnforcer
     /// </summary>
     /// <param name="elementsList"></param>
     /// <exception cref="ParserException"></exception>
-    private void ValidateSbomDocCreationForNTIA(List<SpdxDocument> spdxDocuments, List<CreationInfo> creationInfos, HashSet<InvalidElementInfo> invalidElements)
+    private void ValidateSbomDocCreationForNTIAMin(List<SpdxDocument> spdxDocuments, List<CreationInfo> creationInfos, HashSet<InvalidElementInfo> invalidElements)
     {
         // There should only be one SPDX document element in the SBOM.
         if (spdxDocuments.Count == 0)
         {
-            invalidElements.Add(GetInvalidElementInfo(null, errorType: NTIAErrorType.MissingValidSpdxDocument));
+            invalidElements.Add(GetInvalidElementInfo(null, errorType: NTIAMinErrorType.MissingValidSpdxDocument));
         }
         else if (spdxDocuments.Count > 1)
         {
             invalidElements.UnionWith(spdxDocuments.Select(
-                spdxDocument => GetInvalidElementInfo(spdxDocument, errorType: NTIAErrorType.AdditionalSpdxDocument)));
+                spdxDocument => GetInvalidElementInfo(spdxDocument, errorType: NTIAMinErrorType.AdditionalSpdxDocument)));
         }
         else
         {
@@ -85,7 +85,7 @@ public class NTIAConformanceEnforcer : IConformanceEnforcer
 
             if (spdxCreationInfoElement is null)
             {
-                invalidElements.Add(GetInvalidElementInfo(null, errorType: NTIAErrorType.MissingValidCreationInfo));
+                invalidElements.Add(GetInvalidElementInfo(null, errorType: NTIAMinErrorType.MissingValidCreationInfo));
             }
         }
     }
@@ -95,7 +95,7 @@ public class NTIAConformanceEnforcer : IConformanceEnforcer
     /// </summary>
     /// <param name="elementsList"></param>
     /// <exception cref="ParserException"></exception>
-    private void ValidateSbomFilesForNTIA(List<File> files, HashSet<InvalidElementInfo> invalidElements)
+    private void ValidateSbomFilesForNTIAMin(List<File> files, HashSet<InvalidElementInfo> invalidElements)
     {
         foreach (var file in files)
         {
@@ -106,7 +106,7 @@ public class NTIAConformanceEnforcer : IConformanceEnforcer
 
             if (fileHasSha256Hash is null || fileHasSha256Hash == false)
             {
-                invalidElements.Add(GetInvalidElementInfo(file, errorType: NTIAErrorType.InvalidNTIAElement));
+                invalidElements.Add(GetInvalidElementInfo(file, errorType: NTIAMinErrorType.InvalidNTIAMinElement));
             }
         }
     }
@@ -116,7 +116,7 @@ public class NTIAConformanceEnforcer : IConformanceEnforcer
     /// </summary>
     /// <param name="elementsList"></param>
     /// <exception cref="ParserException"></exception>
-    private void ValidateSbomPackagesForNTIA(List<Package> packages, HashSet<InvalidElementInfo> invalidElements)
+    private void ValidateSbomPackagesForNTIAMin(List<Package> packages, HashSet<InvalidElementInfo> invalidElements)
     {
         foreach (var package in packages)
         {
@@ -127,7 +127,7 @@ public class NTIAConformanceEnforcer : IConformanceEnforcer
 
             if (packageHasSha256Hash is null || packageHasSha256Hash == false)
             {
-                invalidElements.Add(GetInvalidElementInfo(package, errorType: NTIAErrorType.InvalidNTIAElement));
+                invalidElements.Add(GetInvalidElementInfo(package, errorType: NTIAMinErrorType.InvalidNTIAMinElement));
             }
         }
     }

--- a/src/Microsoft.Sbom.Common/Spdx30Entities/NTIAMinFile.cs
+++ b/src/Microsoft.Sbom.Common/Spdx30Entities/NTIAMinFile.cs
@@ -10,11 +10,11 @@ namespace Microsoft.Sbom.Common.Spdx30Entities;
 /// Refers to any object that stores content on a computer.
 /// The type of content can optionally be provided in the contentType property.
 /// https://spdx.github.io/spdx-spec/v3.0.1/model/Software/Classes/File/
-/// An NTIA file specifically describes a file compliant with the NTIA SBOM standard.
+/// An NTIAMin file specifically describes a file compliant with the NTIAMin SBOM standard.
 /// </summary>
-public class NTIAFile : File
+public class NTIAMinFile : File
 {
-    public NTIAFile()
+    public NTIAMinFile()
     {
         Type = "software_File";
     }

--- a/src/Microsoft.Sbom.Common/Spdx30Entities/NTIAMinSpdxDocument.cs
+++ b/src/Microsoft.Sbom.Common/Spdx30Entities/NTIAMinSpdxDocument.cs
@@ -8,11 +8,11 @@ namespace Microsoft.Sbom.Common.Spdx30Entities;
 /// <summary>
 /// The SpdxDocument provides a convenient way to express information about collections of SPDX Elements that could potentially be serialized as complete units (e.g., all in-scope SPDX data within a single JSON-LD file).
 /// https://spdx.github.io/spdx-spec/v3.0.1/model/Core/Classes/SpdxDocument/
-/// An NTIA SpdxDocument specifically describes a SpdxDocument entity compliant with the NTIA SBOM standard.
+/// An NTIAMin SpdxDocument specifically describes a SpdxDocument entity compliant with the NTIAMin SBOM standard.
 /// </summary>
-public class NTIASpdxDocument : SpdxDocument
+public class NTIAMinSpdxDocument : SpdxDocument
 {
-    public NTIASpdxDocument()
+    public NTIAMinSpdxDocument()
     {
         Type = nameof(SpdxDocument);
     }

--- a/src/Microsoft.Sbom.Contracts/Contracts/Enums/ConformanceType.cs
+++ b/src/Microsoft.Sbom.Contracts/Contracts/Enums/ConformanceType.cs
@@ -31,9 +31,9 @@ public class ConformanceType : IEquatable<ConformanceType>
             return None;
         }
 
-        if (string.Equals(name, NTIA.Name, StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(name, NTIAMin.Name, StringComparison.OrdinalIgnoreCase))
         {
-            return NTIA;
+            return NTIAMin;
         }
 
         throw new ArgumentException($"Unknown Conformance '{name}'.");
@@ -56,7 +56,7 @@ public class ConformanceType : IEquatable<ConformanceType>
 
     public static ConformanceType None => new ConformanceType("None");
 
-    public static ConformanceType NTIA => new ConformanceType("NTIA");
+    public static ConformanceType NTIAMin => new ConformanceType("NTIAMin");
 
     public override int GetHashCode()
     {

--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Parser/SPDX30Parser.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Parser/SPDX30Parser.cs
@@ -212,7 +212,7 @@ public class SPDX30Parser : ISbomParser
         var typeFromSbom = jsonObject["type"]?.ToString();
         var entityType = typeFromSbom;
 
-        // If the entity type is in the list of entities that require different NTIA requirements, then add the NTIA prefix.
+        // If the entity type is in the list of entities that require different NTIAMin requirements, then add the NTIAMin prefix.
         // This will allow for deserialization based on conformance so that we can detect if certain required fields are missing.
         entityType = conformanceEnforcer.GetConformanceEntityType(entityType);
 

--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigSanitizerTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigSanitizerTests.cs
@@ -125,11 +125,11 @@ public class ConfigSanitizerTests
         config.Conformance = new ConfigurationSetting<ConformanceType>
         {
             Source = SettingSource.CommandLine,
-            Value = ConformanceType.NTIA
+            Value = ConformanceType.NTIAMin
         };
 
         configSanitizer.SanitizeConfig(config);
-        Assert.AreEqual(ConformanceType.NTIA, config.Conformance.Value);
+        Assert.AreEqual(ConformanceType.NTIAMin, config.Conformance.Value);
     }
 
     [TestMethod]
@@ -156,7 +156,7 @@ public class ConfigSanitizerTests
         config.Conformance = new ConfigurationSetting<ConformanceType>
         {
             Source = SettingSource.CommandLine,
-            Value = ConformanceType.NTIA
+            Value = ConformanceType.NTIAMin
         };
 
         var exception = Assert.ThrowsException<ValidationArgException>(() => configSanitizer.SanitizeConfig(config));

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/SbomParserBasedValidationWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/SbomParserBasedValidationWorkflowTests.cs
@@ -411,7 +411,7 @@ public class SbomParserBasedValidationWorkflowTests : ValidationWorkflowTestsBas
     }
 
     [TestMethod]
-    public async Task SbomParserBasedValidationWorkflowTests_ReturnsNTIAValidationFailures_Succeeds()
+    public async Task SbomParserBasedValidationWorkflowTests_ReturnsNTIAMinValidationFailures_Succeeds()
     {
         var manifestInfo = Constants.SPDX30ManifestInfo;
         var manifestParserProvider = new Mock<IManifestParserProvider>();
@@ -438,7 +438,7 @@ public class SbomParserBasedValidationWorkflowTests : ValidationWorkflowTestsBas
         {
             Value = new List<ManifestInfo>() { manifestInfo }
         });
-        configurationMock.SetupGet(c => c.Conformance).Returns(new ConfigurationSetting<ConformanceType> { Value = ConformanceType.NTIA });
+        configurationMock.SetupGet(c => c.Conformance).Returns(new ConfigurationSetting<ConformanceType> { Value = ConformanceType.NTIAMin });
 
         ISbomConfig sbomConfig = new SbomConfig(fileSystemMock.Object)
         {
@@ -460,10 +460,10 @@ public class SbomParserBasedValidationWorkflowTests : ValidationWorkflowTestsBas
 
         var elementsResult = new ElementsResult(new ParserStateResult(Constants.SPDXGraphHeaderName, null, ExplicitField: true, YieldReturn: true));
 
-        elementsResult.InvalidConformanceElements.Add(new InvalidElementInfo(NTIAErrorType.MissingValidSpdxDocument));
-        elementsResult.InvalidConformanceElements.Add(new InvalidElementInfo("spdxDocElementName", "spdxDocElementSpdxId", NTIAErrorType.AdditionalSpdxDocument));
-        elementsResult.InvalidConformanceElements.Add(new InvalidElementInfo(NTIAErrorType.MissingValidCreationInfo));
-        elementsResult.InvalidConformanceElements.Add(new InvalidElementInfo("elementName", "elementSpdxId", NTIAErrorType.InvalidNTIAElement));
+        elementsResult.InvalidConformanceElements.Add(new InvalidElementInfo(NTIAMinErrorType.MissingValidSpdxDocument));
+        elementsResult.InvalidConformanceElements.Add(new InvalidElementInfo("spdxDocElementName", "spdxDocElementSpdxId", NTIAMinErrorType.AdditionalSpdxDocument));
+        elementsResult.InvalidConformanceElements.Add(new InvalidElementInfo(NTIAMinErrorType.MissingValidCreationInfo));
+        elementsResult.InvalidConformanceElements.Add(new InvalidElementInfo("elementName", "elementSpdxId", NTIAMinErrorType.InvalidNTIAMinElement));
 
         sbomParser.SetupSequence(p => p.Next()).Returns(elementsResult);
 
@@ -502,7 +502,7 @@ public class SbomParserBasedValidationWorkflowTests : ValidationWorkflowTestsBas
         Assert.AreEqual("MissingValidCreationInfo", ntiaErrors[2].Path);
         Assert.AreEqual("SpdxId: elementSpdxId. Name: elementName", ntiaErrors[3].Path);
 
-        Assert.IsTrue(cc.CapturedStdOut.Contains("Elements in the manifest that are non-compliant with NTIA . . . 4"), "Number of invalid NTIA elements is incorrect in stdout");
+        Assert.IsTrue(cc.CapturedStdOut.Contains("Elements in the manifest that are non-compliant with NTIAMin . . . 4"), "Number of invalid NTIAMin elements is incorrect in stdout");
         Assert.IsTrue(cc.CapturedStdOut.Contains("MissingValidSpdxDocument"));
         Assert.IsTrue(cc.CapturedStdOut.Contains("AdditionalSpdxDocument. SpdxId: spdxDocElementSpdxId. Name: spdxDocElementName"));
         Assert.IsTrue(cc.CapturedStdOut.Contains("MissingValidCreationInfo"));

--- a/test/Microsoft.Sbom.Parsers.Spdx30SbomParser.Tests/Parser/JsonStrings/SbomFullDocWithPackagesStrings.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx30SbomParser.Tests/Parser/JsonStrings/SbomFullDocWithPackagesStrings.cs
@@ -225,7 +225,7 @@ public static class SbomFullDocWithPackagesStrings
     ";
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "JSON002:Probable JSON string detected", Justification = "Need to use JSON string")]
-    public const string SbomNTIAValidPackageJsonString =
+    public const string SbomNTIAMinValidPackageJsonString =
     @"
     {
         ""@context"": [

--- a/test/Microsoft.Sbom.Parsers.Spdx30SbomParser.Tests/Parser/SbomFileParserTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx30SbomParser.Tests/Parser/SbomFileParserTests.cs
@@ -28,18 +28,18 @@ public class SbomFileParserTests : SbomParserTestsBase
     [DataRow(SbomFullDocWithFilesStrings.SbomFileWithMissingVerificationJsonString)]
     [DataRow(SbomFullDocWithFilesStrings.SbomFileWithMissingSHA256JsonString)]
     [TestMethod]
-    public void MissingPropertiesTest_NTIA_NoVerificationCode_Throws(string jsonString)
+    public void MissingPropertiesTest_NTIAMin_NoVerificationCode_Throws(string jsonString)
     {
         var bytes = Encoding.UTF8.GetBytes(jsonString);
         using var stream = new MemoryStream(bytes);
         var parser = new SPDX30Parser(stream);
-        parser.EnforceConformance(Contracts.Enums.ConformanceType.NTIA);
+        parser.EnforceConformance(Contracts.Enums.ConformanceType.NTIAMin);
         var result = this.Parse(parser);
 
         var invalidElement = result.InvalidConformanceElements.First();
         Assert.AreEqual("SPDXRef-software_File-B4A9F99A3A03B9273AE34753D96564CB4F2B0FAD885BBD36B0DD619E9E8AC967", invalidElement.SpdxId);
         Assert.AreEqual("./sample/path", invalidElement.Name);
-        Assert.AreEqual(NTIAErrorType.InvalidNTIAElement, invalidElement.ErrorType);
+        Assert.AreEqual(NTIAMinErrorType.InvalidNTIAMinElement, invalidElement.ErrorType);
     }
 
     [DataRow(SbomFullDocWithFilesStrings.SbomFileWithMissingVerificationJsonString)]

--- a/test/Microsoft.Sbom.Parsers.Spdx30SbomParser.Tests/Parser/SbomMetadataParserTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx30SbomParser.Tests/Parser/SbomMetadataParserTests.cs
@@ -64,13 +64,13 @@ public class SbomMetadataParserTests : SbomParserTestsBase
     }
 
     [TestMethod]
-    public void DocCreation_NoName_NTIA_Throws()
+    public void DocCreation_NoName_NTIAMin_Throws()
     {
         var bytes = Encoding.UTF8.GetBytes(SbomFullDocWithMetadataJsonStrings.SbomWithSpdxDocumentMissingNameJsonString);
         using var stream = new MemoryStream(bytes);
 
         var parser = new SPDX30Parser(stream);
-        parser.EnforceConformance(Contracts.Enums.ConformanceType.NTIA);
+        parser.EnforceConformance(Contracts.Enums.ConformanceType.NTIAMin);
         var results = this.Parse(parser);
         Assert.AreEqual(2, results.InvalidConformanceElements.Count);
 
@@ -78,11 +78,11 @@ public class SbomMetadataParserTests : SbomParserTestsBase
         Assert.IsNotNull(invalidElement1);
         Assert.AreEqual("SPDXRef-SpdxDocument-B93EED20C16A89A887B753958D42B794DD3C6570D3C2725B56B43477B38E05A1", invalidElement1.SpdxId);
         Assert.IsNull(invalidElement1.Name);
-        Assert.AreEqual(NTIAErrorType.InvalidNTIAElement, invalidElement1.ErrorType);
+        Assert.AreEqual(NTIAMinErrorType.InvalidNTIAMinElement, invalidElement1.ErrorType);
 
-        var invalidElement2 = results.InvalidConformanceElements.FirstOrDefault(e => e.ErrorType.Equals(NTIAErrorType.MissingValidSpdxDocument));
+        var invalidElement2 = results.InvalidConformanceElements.FirstOrDefault(e => e.ErrorType.Equals(NTIAMinErrorType.MissingValidSpdxDocument));
         Assert.IsNotNull(invalidElement2);
-        Assert.AreEqual(NTIAErrorType.MissingValidSpdxDocument, invalidElement2.ErrorType);
+        Assert.AreEqual(NTIAMinErrorType.MissingValidSpdxDocument, invalidElement2.ErrorType);
     }
 
     [TestMethod]
@@ -100,13 +100,13 @@ public class SbomMetadataParserTests : SbomParserTestsBase
     }
 
     [TestMethod]
-    public void DocCreation_MultipleSpdxDocuments_NTIA_Throws()
+    public void DocCreation_MultipleSpdxDocuments_NTIAMin_Throws()
     {
         var bytes = Encoding.UTF8.GetBytes(SbomFullDocWithMetadataJsonStrings.SbomWithMultipleSpdxDocumentsJsonString);
         using var stream = new MemoryStream(bytes);
 
         var parser = new SPDX30Parser(stream);
-        parser.EnforceConformance(Contracts.Enums.ConformanceType.NTIA);
+        parser.EnforceConformance(Contracts.Enums.ConformanceType.NTIAMin);
         var results = this.Parse(parser);
         Assert.AreEqual(2, results.InvalidConformanceElements.Count);
 
@@ -114,13 +114,13 @@ public class SbomMetadataParserTests : SbomParserTestsBase
         Assert.IsNotNull(invalidElement1);
         Assert.AreEqual("SPDXRef-SpdxDocument-B93EED20C16A89A887B753958D42B794DD3C6570D3C2725B56B43477B38E05A1", invalidElement1.SpdxId);
         Assert.AreEqual("spdx-doc1-name", invalidElement1.Name);
-        Assert.AreEqual(NTIAErrorType.AdditionalSpdxDocument, invalidElement1.ErrorType);
+        Assert.AreEqual(NTIAMinErrorType.AdditionalSpdxDocument, invalidElement1.ErrorType);
 
         var invalidElement2 = results.InvalidConformanceElements.FirstOrDefault(e => e.SpdxId == "SPDXRef-SpdxDocument-A93EED20C16A89A887B753958D42B794DD3C6570D3C2725B56B43477B38E05A1");
         Assert.IsNotNull(invalidElement2);
         Assert.AreEqual("SPDXRef-SpdxDocument-A93EED20C16A89A887B753958D42B794DD3C6570D3C2725B56B43477B38E05A1", invalidElement2.SpdxId);
         Assert.AreEqual("spdx-doc2-name", invalidElement2.Name);
-        Assert.AreEqual(NTIAErrorType.AdditionalSpdxDocument, invalidElement2.ErrorType);
+        Assert.AreEqual(NTIAMinErrorType.AdditionalSpdxDocument, invalidElement2.ErrorType);
     }
 
     [TestMethod]
@@ -140,19 +140,19 @@ public class SbomMetadataParserTests : SbomParserTestsBase
     [DataRow(SbomFullDocWithMetadataJsonStrings.SbomWithMissingValidCreationInfoJsonString)]
     [DataRow(SbomFullDocWithMetadataJsonStrings.SbomWithMissingCreationInfoJsonString)]
     [TestMethod]
-    public void DocCreation_InvalidCreationInfo_NTIA_Throws(string jsonString)
+    public void DocCreation_InvalidCreationInfo_NTIAMin_Throws(string jsonString)
     {
         var bytes = Encoding.UTF8.GetBytes(jsonString);
         using var stream = new MemoryStream(bytes);
 
         var parser = new SPDX30Parser(stream);
-        parser.EnforceConformance(Contracts.Enums.ConformanceType.NTIA);
+        parser.EnforceConformance(Contracts.Enums.ConformanceType.NTIAMin);
         var results = this.Parse(parser);
         Assert.AreEqual(1, results.InvalidConformanceElements.Count);
 
-        var invalidElement = results.InvalidConformanceElements.FirstOrDefault(e => e.ErrorType.Equals(NTIAErrorType.MissingValidCreationInfo));
+        var invalidElement = results.InvalidConformanceElements.FirstOrDefault(e => e.ErrorType.Equals(NTIAMinErrorType.MissingValidCreationInfo));
         Assert.IsNotNull(invalidElement);
-        Assert.AreEqual(NTIAErrorType.MissingValidCreationInfo, invalidElement.ErrorType);
+        Assert.AreEqual(NTIAMinErrorType.MissingValidCreationInfo, invalidElement.ErrorType);
     }
 
     [TestMethod]

--- a/test/Microsoft.Sbom.Parsers.Spdx30SbomParser.Tests/Parser/SbomPackageParserTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx30SbomParser.Tests/Parser/SbomPackageParserTests.cs
@@ -41,12 +41,12 @@ public class SbomPackageParserTests : SbomParserTestsBase
     [DataRow(SbomFullDocWithPackagesStrings.SbomPackageWithMissingVerificationJsonString)]
     [DataRow(SbomFullDocWithPackagesStrings.SbomPackageWithMissingSHA256JsonString)]
     [TestMethod]
-    public void MissingPropertiesTest_NTIA_VerificationCode_Throws(string json)
+    public void MissingPropertiesTest_NTIAMin_VerificationCode_Throws(string json)
     {
         var bytes = Encoding.UTF8.GetBytes(SbomFullDocWithPackagesStrings.SbomPackageWithMissingVerificationJsonString);
         using var stream = new MemoryStream(bytes);
         var parser = new SPDX30Parser(stream);
-        parser.EnforceConformance(Contracts.Enums.ConformanceType.NTIA);
+        parser.EnforceConformance(Contracts.Enums.ConformanceType.NTIAMin);
         var result = this.Parse(parser);
 
         Assert.AreEqual(1, result.InvalidConformanceElements.Count);
@@ -54,7 +54,7 @@ public class SbomPackageParserTests : SbomParserTestsBase
         var invalidElement = result.InvalidConformanceElements.First();
         Assert.AreEqual("SPDXRef-software_Package-4739C82D88855A138C811B8CE05CC97113BEC7F7C7F66EC7E4C6C176EEA0FECE", invalidElement.SpdxId);
         Assert.AreEqual("test", invalidElement.Name);
-        Assert.AreEqual(NTIAErrorType.InvalidNTIAElement, invalidElement.ErrorType);
+        Assert.AreEqual(NTIAMinErrorType.InvalidNTIAMinElement, invalidElement.ErrorType);
     }
 
     [TestMethod]
@@ -68,12 +68,12 @@ public class SbomPackageParserTests : SbomParserTestsBase
     }
 
     [TestMethod]
-    public void ValidNTIA_Succeeds()
+    public void ValidNTIAMin_Succeeds()
     {
-        var bytes = Encoding.UTF8.GetBytes(SbomFullDocWithPackagesStrings.SbomNTIAValidPackageJsonString);
+        var bytes = Encoding.UTF8.GetBytes(SbomFullDocWithPackagesStrings.SbomNTIAMinValidPackageJsonString);
         using var stream = new MemoryStream(bytes);
         var parser = new SPDX30Parser(stream);
-        parser.EnforceConformance(Contracts.Enums.ConformanceType.NTIA);
+        parser.EnforceConformance(Contracts.Enums.ConformanceType.NTIAMin);
         var result = this.Parse(parser);
         Assert.AreEqual(1, result.PackagesCount);
     }

--- a/test/Microsoft.Sbom.Tool.Tests/IntegrationTests.cs
+++ b/test/Microsoft.Sbom.Tool.Tests/IntegrationTests.cs
@@ -242,7 +242,7 @@ public class IntegrationTests
 
         var (stdout, stderr, exitCode) = LaunchAndCaptureOutput(arguments);
 
-        Assert.IsTrue(stdout.Contains("Unknown Conformance 'aeg12'. Options are NTIA"));
+        Assert.IsTrue(stdout.Contains("Unknown Conformance 'aeg12'. Options are NTIAMin"));
         Assert.AreEqual(1, exitCode.Value);
     }
 
@@ -259,7 +259,7 @@ public class IntegrationTests
         GenerateManifestAndValidateSuccess(testFolderPath, manifestInfoSpdxVersion: "2.2");
 
         // Add the conformance
-        var (arguments, outputFile) = GetValidateManifestArguments(testFolderPath, manifestInfoSpdxVersion: "2.2", conformanceValue: "NTIA");
+        var (arguments, outputFile) = GetValidateManifestArguments(testFolderPath, manifestInfoSpdxVersion: "2.2", conformanceValue: "NTIAMin");
 
         var (stdout, stderr, exitCode) = LaunchAndCaptureOutput(arguments);
 
@@ -289,7 +289,7 @@ public class IntegrationTests
     }
 
     [TestMethod]
-    public void E2E_Validate_WithValidConformance_SupportedManifestInfo_StdOutContainsNTIAErrors()
+    public void E2E_Validate_WithValidConformance_SupportedManifestInfo_StdOutContainsNTIAMinErrors()
     {
         if (!IsWindows)
         {
@@ -301,12 +301,12 @@ public class IntegrationTests
         GenerateManifestAndValidateSuccess(testFolderPath, manifestInfoSpdxVersion: "3.0");
 
         // Add the conformance
-        var (arguments, outputFile) = GetValidateManifestArguments(testFolderPath, manifestInfoSpdxVersion: "3.0", conformanceValue: "NTIA");
+        var (arguments, outputFile) = GetValidateManifestArguments(testFolderPath, manifestInfoSpdxVersion: "3.0", conformanceValue: "NTIAMin");
 
         var (stdout, stderr, exitCode) = LaunchAndCaptureOutput(arguments);
 
         // Assert that the validation failures show up
-        Assert.IsFalse(stdout.Contains("Elements in the manifest that are non-compliant with NTIA . . . 0"));
+        Assert.IsFalse(stdout.Contains("Elements in the manifest that are non-compliant with NTIAMin . . . 0"));
         Assert.IsTrue(stdout.Contains("SPDXRef-Package"));
     }
 


### PR DESCRIPTION
This is basically a global search and replace of "NTIA" to "NTIAMin", with appropriate type renames for the types that changed. There some test files that contain the word "CONSEQUENTIAL" (a superset of "NTIA") that were not changed.

This changes nothing about the implementation of the validation, and is intended only to pull the API-breaking changes in the 4.0.2 release. We can always treat the implementation changes as a bug fix.