### PR TITLE
Updates license compliance info matrix

### DIFF
--- a/docs/feature-overview.md
+++ b/docs/feature-overview.md
@@ -39,7 +39,7 @@ Note: These are not the only entries found in the packages section. To view a fu
 | Cargo | <ul><li>Cargo.lock (v1, v2, v3)</li></ul> | - | ✔ | ✔ (Via RustCli detector) | ✔ |
 | Ruby | <ul><li>gemfile.lock</li></ul> | - | ✔ | ✔ | ✔ |
 | Pip (Python) | <ul><li>setup.py</li><li>requirements.txt</li><li>*setup=distutils.core.run_setup({setup.py}); setup.install_requires*</li><li>dist package METADATA file</li></ul> | <ul><li>Python 2 or Python 3</li><li>Internet connection</li></ul> | ✔ | ✔ | ✔ |
-| Maven | <ul><li>pom.xml</li></ul> | <ul><li>Maven</li></ul> | ✔  | ✔ | ✔ |
+| Maven | <ul><li>pom.xml</li></ul> | <ul><li>Maven</li></ul> | - | - | - |
 | NPM | <ul><li>package.json</li></ul> | - | ✔ | ✔ | ✔ |
 | NuGet | <ul><li>project.assets.json</li><li>*.nupkg</li><li>*.nuspec</li><li>packages.config</li><li>nuget.config</li></ul> | - | ✔ | ✔ | ✔ |
 | Linux (Debian, Alpine, Rhel, Centos, Fedora, Ubuntu)| <ul><li>(via [syft](https://github.com/anchore/syft))</li></ul> | - | ✔ | - | ✔ |


### PR DESCRIPTION
This documentation appears inaccurate. Based on warnings seen in SBOM tool run there is not support for Maven license information:
```
##[debug]License retrieval for component type maven is not supported yet.
```

but it is listed as supported:
![image](https://github.com/user-attachments/assets/8de124f7-8d7a-4cba-877c-ed8c51851fc8)


The only supported ecosystems (this appears to be the only `ILicenseInformationFetcher` implemenataion) are: 
https://github.com/microsoft/sbom-tool/blob/6a2699dd4ac13d8557d5b7f1cdda1737bd91f772/src/Microsoft.Sbom.Api/Executors/LicenseInformationFetcher.cs#L54-L80


See rendered updates: https://github.com/felickz/sbom-tool/blob/patch-1/docs/feature-overview.md#packages-section