### PR TITLE
Teach ManifestValidator about extensions

### DIFF
--- a/src/Microsoft.Sbom.Api/Config/Validators/ManifestInfoValidator.cs
+++ b/src/Microsoft.Sbom.Api/Config/Validators/ManifestInfoValidator.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Sbom.Api.Manifest;
 using Microsoft.Sbom.Api.Utils;
 using Microsoft.Sbom.Common.Config.Attributes;
 using Microsoft.Sbom.Common.Config.Validators;
@@ -17,17 +18,38 @@ namespace Microsoft.Sbom.Api.Config.Validators;
 /// </summary>
 public class ManifestInfoValidator : ConfigValidator
 {
-    public ManifestInfoValidator(IAssemblyConfig assemblyConfig)
-        : base(typeof(ValidManifestInfoAttribute), assemblyConfig)
+    private readonly HashSet<ManifestInfo> supportedManifestInfos;
+
+    /// <summary>
+    /// Production constructor (satisfied by dependency injection)
+    /// </summary>
+    public ManifestInfoValidator(IAssemblyConfig assemblyConfig, ManifestGeneratorProvider manifestGeneratorProvider)
+        : this(assemblyConfig, GetAvailableManifestInfos(manifestGeneratorProvider))
     {
+    }
+
+    /// <summary>
+    /// Test constructor
+    /// </summary>
+    public ManifestInfoValidator(IAssemblyConfig assemblyConfig, HashSet<ManifestInfo> supportedManifestInfos)
+    : base(typeof(ValidManifestInfoAttribute), assemblyConfig)
+    {
+        this.supportedManifestInfos = supportedManifestInfos ?? throw new ArgumentNullException(nameof(supportedManifestInfos));
     }
 
     public override void ValidateInternal(string paramName, object paramValue, Attribute attribute)
     {
-        if (paramValue is not null && paramValue is List<ManifestInfo> listOfManifestInfos && !Constants.SupportedSpdxManifests.Any(listOfManifestInfos.Contains))
+        if (paramValue is not null && paramValue is List<ManifestInfo> listOfManifestInfos && !supportedManifestInfos.Any(listOfManifestInfos.Contains))
         {
-            var supportedManifests = string.Join(", ", Constants.SupportedSpdxManifests.Select(m => m.ToString()));
-            throw new ValidationArgException($"Please provide a valid value for the ManifestInfo (-mi) parameter. Supported values include: {supportedManifests}. The values are case-insensitive.");
+            var providedValues = string.Join(", ", listOfManifestInfos);
+            var validManifestInfoa = string.Join(", ", supportedManifestInfos.Select(m => m.ToString()));
+            throw new ValidationArgException($"The value '{providedValues}' contains no values supported by the ManifestInfo (-mi) parameter. Please provide supported values. Supported values include: {validManifestInfoa}. The values are case-insensitive.");
         }
+    }
+
+    private static HashSet<ManifestInfo> GetAvailableManifestInfos(ManifestGeneratorProvider manifestGeneratorProvider)
+    {
+        ArgumentNullException.ThrowIfNull(manifestGeneratorProvider, nameof(manifestGeneratorProvider));
+        return [.. manifestGeneratorProvider.GetSupportedManifestInfos()];
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsBase.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using AutoMapper;
 using Microsoft.Sbom.Api.Config.Validators;
 using Microsoft.Sbom.Api.Hashing;
@@ -10,6 +11,7 @@ using Microsoft.Sbom.Common;
 using Microsoft.Sbom.Common.Config.Validators;
 using Microsoft.Sbom.Contracts.Entities;
 using Microsoft.Sbom.Contracts.Interfaces;
+using Microsoft.Sbom.Extensions.Entities;
 using Moq;
 using Constants = Microsoft.Sbom.Api.Utils.Constants;
 
@@ -38,7 +40,7 @@ public class ConfigurationBuilderTestsBase
             new DirectoryExistsValidator(fileSystemUtilsMock.Object, mockAssemblyConfig.Object),
             new DirectoryPathIsWritableValidator(fileSystemUtilsMock.Object, mockAssemblyConfig.Object),
             new UriValidator(mockAssemblyConfig.Object),
-            new ManifestInfoValidator(mockAssemblyConfig.Object)
+            new ManifestInfoValidator(mockAssemblyConfig.Object, new HashSet<ManifestInfo> { Constants.SPDX22ManifestInfo }) // We only need 1 for testing
         };
 
         var hashAlgorithmProvider = new HashAlgorithmProvider(new IAlgorithmNames[] { new AlgorithmNames() });

--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForGeneration.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsForGeneration.cs
@@ -323,6 +323,6 @@ public class ConfigurationBuilderTestsForGeneration : ConfigurationBuilderTestsB
         };
 
         var exception = await Assert.ThrowsExceptionAsync<ValidationArgException>(() => cb.GetConfiguration(args));
-        Assert.IsTrue(exception.Message.Contains("Please provide a valid value for the ManifestInfo"));
+        Assert.IsTrue(exception.Message.Contains("contains no values supported by the ManifestInfo (-mi) parameter. Please provide supported values."));
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/Config/Validators/ManifestInfoValidatorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/Validators/ManifestInfoValidatorTests.cs
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.Sbom.Api.Config.Validators;
+using Microsoft.Sbom.Api.Manifest;
 using Microsoft.Sbom.Api.Utils;
 using Microsoft.Sbom.Extensions.Entities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -15,6 +17,11 @@ namespace Microsoft.Sbom.Api.Tests.Config.Validators;
 public class ManifestInfoValidatorTests
 {
     private readonly Mock<IAssemblyConfig> mockAssemblyConfig = new Mock<IAssemblyConfig>();
+    private readonly HashSet<ManifestInfo> supportedManifestInfosForTesting = new HashSet<ManifestInfo>
+    {
+        Constants.SPDX22ManifestInfo,
+        Constants.SPDX30ManifestInfo,
+    };
 
     [DataRow("randomName", "2.2")]
     [DataRow("randomName", "3.0")]
@@ -31,7 +38,7 @@ public class ManifestInfoValidatorTests
 
         IList<ManifestInfo> listOfManifestInfos = new List<ManifestInfo> { invalidManifestInfo };
 
-        var validator = new ManifestInfoValidator(mockAssemblyConfig.Object);
+        var validator = new ManifestInfoValidator(mockAssemblyConfig.Object, supportedManifestInfosForTesting);
         Assert.ThrowsException<ValidationArgException>(() => validator.ValidateInternal("property", listOfManifestInfos, null));
     }
 
@@ -50,7 +57,21 @@ public class ManifestInfoValidatorTests
 
         IList<ManifestInfo> listOfManifestInfos = new List<ManifestInfo> { validManifestInfo };
 
-        var validator = new ManifestInfoValidator(mockAssemblyConfig.Object);
+        var validator = new ManifestInfoValidator(mockAssemblyConfig.Object, supportedManifestInfosForTesting);
         validator.ValidateInternal("property", listOfManifestInfos, null);
+    }
+
+    [TestMethod]
+    public void Constructor_ManifestGeneratorProviderIsNull_ThrowsException()
+    {
+        var e = Assert.ThrowsException<ArgumentNullException>(() => new ManifestInfoValidator(mockAssemblyConfig.Object, null as ManifestGeneratorProvider));
+        Assert.AreEqual("manifestGeneratorProvider", e.ParamName);
+    }
+
+    [TestMethod]
+    public void Constructor_AvailableManifestInfosIsNull_ThrowsException()
+    {
+        var e = Assert.ThrowsException<ArgumentNullException>(() => new ManifestInfoValidator(mockAssemblyConfig.Object, null as HashSet<ManifestInfo>));
+        Assert.AreEqual("supportedManifestInfosForTesting", e.ParamName);
     }
 }


### PR DESCRIPTION
The `ManifestValidator` class works against a static list of manifest types. This constant list doesn't allow us to specify a ManifestInfo for a single extension, which is problematic. The `ManifestGeneratorProvider` class knows about all registered manifest types, so is it the authoritative list of valid types that should be accepted.

Validated with our internal client that has additional manifest types.

Note: I considered completely removing `Constants.SupportedSpdxManifests` completely, but it is used in both `ComponentDetectionBaseWalker` and `BaseManifestConfigHandler`. I wanted to keep this PR tightly focused, but we should consider removing this constant in the future if it's not too much effort.