### PR TITLE
Generate only supported manifests, get target configs, and use SourcesProviders as the source of truth

### DIFF
--- a/src/Microsoft.Sbom.Api/Executors/GenerationResult.cs
+++ b/src/Microsoft.Sbom.Api/Executors/GenerationResult.cs
@@ -17,18 +17,18 @@ public class GenerationResult
 
     public Dictionary<IManifestToolJsonSerializer, List<JsonDocument>> SerializerToJsonDocuments { get; }
 
-    public bool JsonArrayStarted { get; }
+    public Dictionary<ISbomConfig, bool> JsonArrayStartedForConfig { get; }
 
     /// <summary>
     /// Result from generators. This result is used to write to the SBOM manifest file.
     /// </summary>
     /// <param name="errors">List of FileValidationResult errors.</param>
     /// <param name="serializerToJsonDocuments">Dictionary to map serializer to the JSON document that should be written to it.</param>
-    /// <param name="jsonArrayStarted">This value determines whether a JSON array for a section is started. This is only used for SPDX 2.2 SBOM generation.</param>
-    public GenerationResult(List<FileValidationResult> errors, Dictionary<IManifestToolJsonSerializer, List<JsonDocument>> serializerToJsonDocuments, bool jsonArrayStarted)
+    /// <param name="jsonArrayStartedForConfig">This value determines whether a JSON array for a section is started for the specified config. This is only used for SPDX 2.2 SBOM generation.</param>
+    public GenerationResult(List<FileValidationResult> errors, Dictionary<IManifestToolJsonSerializer, List<JsonDocument>> serializerToJsonDocuments, Dictionary<ISbomConfig, bool> jsonArrayStartedForConfig)
     {
         Errors = errors;
         SerializerToJsonDocuments = serializerToJsonDocuments;
-        JsonArrayStarted = jsonArrayStarted;
+        JsonArrayStartedForConfig = jsonArrayStartedForConfig;
     }
 }

--- a/src/Microsoft.Sbom.Api/Executors/GenerationResult.cs
+++ b/src/Microsoft.Sbom.Api/Executors/GenerationResult.cs
@@ -15,9 +15,9 @@ public class GenerationResult
 {
     public List<FileValidationResult> Errors { get; }
 
-    public Dictionary<IManifestToolJsonSerializer, List<JsonDocument>> SerializerToJsonDocuments { get; }
+    public IReadOnlyDictionary<IManifestToolJsonSerializer, List<JsonDocument>> SerializerToJsonDocuments { get; }
 
-    public Dictionary<ISbomConfig, bool> JsonArrayStartedForConfig { get; }
+    public IReadOnlyDictionary<ISbomConfig, bool> JsonArrayStartedForConfig { get; }
 
     /// <summary>
     /// Result from generators. This result is used to write to the SBOM manifest file.
@@ -25,7 +25,7 @@ public class GenerationResult
     /// <param name="errors">List of FileValidationResult errors.</param>
     /// <param name="serializerToJsonDocuments">Dictionary to map serializer to the JSON document that should be written to it.</param>
     /// <param name="jsonArrayStartedForConfig">This value determines whether a JSON array for a section is started for the specified config. This is only used for SPDX 2.2 SBOM generation.</param>
-    public GenerationResult(List<FileValidationResult> errors, Dictionary<IManifestToolJsonSerializer, List<JsonDocument>> serializerToJsonDocuments, Dictionary<ISbomConfig, bool> jsonArrayStartedForConfig)
+    public GenerationResult(List<FileValidationResult> errors, IReadOnlyDictionary<IManifestToolJsonSerializer, List<JsonDocument>> serializerToJsonDocuments, IReadOnlyDictionary<ISbomConfig, bool> jsonArrayStartedForConfig)
     {
         Errors = errors;
         SerializerToJsonDocuments = serializerToJsonDocuments;

--- a/src/Microsoft.Sbom.Api/Executors/IJsonSerializationStrategy.cs
+++ b/src/Microsoft.Sbom.Api/Executors/IJsonSerializationStrategy.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using Microsoft.Sbom.Extensions;
-using Microsoft.Sbom.Extensions.Entities;
 
 namespace Microsoft.Sbom.Api.Workflows.Helpers;
 
@@ -53,17 +52,15 @@ internal interface IJsonSerializationStrategy
     /// Starts an array with a graph header that is only used in SPDX 3.0 and above.
     /// This does not apply to SPDX 2.2 SBOM generation.
     /// </summary>
-    /// <param name="manifestInfosFromConfig"></param>
-    /// <param name="sbomConfigs"></param>
-    public void StartGraphArray(IList<ManifestInfo> manifestInfosFromConfig, ISbomConfigProvider sbomConfigs);
+    /// <param name="sbomConfig"></param>
+    public void StartGraphArray(ISbomConfig sbomConfig);
 
     /// <summary>
     /// Ends an array with a graph header that is only used in SPDX 3.0 and above.
     /// This does not apply to SPDX 2.2 SBOM generation.
     /// </summary>
-    /// <param name="manifestInfosFromConfig"></param>
-    /// <param name="sbomConfigs"></param>
-    public void EndGraphArray(IList<ManifestInfo> manifestInfosFromConfig, ISbomConfigProvider sbomConfigs);
+    /// <param name="sbomConfig"></param>
+    public void EndGraphArray(ISbomConfig sbomConfig);
 
-    public void WriteJsonObjectsToManifest(GenerationResult generationResult, HashSet<string> elementsSpdxIdList);
+    public void WriteJsonObjectsToManifest(GenerationResult generationResult, ISbomConfig config, HashSet<string> elementsSpdxIdList);
 }

--- a/src/Microsoft.Sbom.Api/Executors/IJsonSerializationStrategy.cs
+++ b/src/Microsoft.Sbom.Api/Executors/IJsonSerializationStrategy.cs
@@ -23,5 +23,5 @@ internal interface IJsonSerializationStrategy
 
     public void EndGraphArray(IList<ManifestInfo> manifestInfosFromConfig, ISbomConfigProvider sbomConfigs);
 
-    public void WriteJsonObjectsToManifest(GenerationResult generationResult);
+    public void WriteJsonObjectsToManifest(GenerationResult generationResult, HashSet<string> elementsSpdxIdList);
 }

--- a/src/Microsoft.Sbom.Api/Executors/IJsonSerializationStrategy.cs
+++ b/src/Microsoft.Sbom.Api/Executors/IJsonSerializationStrategy.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.Threading.Tasks;
-using Microsoft.Sbom.Api.Entities;
 using Microsoft.Sbom.Extensions;
+using Microsoft.Sbom.Extensions.Entities;
 
 namespace Microsoft.Sbom.Api.Workflows.Helpers;
 
@@ -18,15 +17,11 @@ internal interface IJsonSerializationStrategy
 
     public bool AddToExternalDocRefsSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config);
 
-    public void AddHeadersToSbom(ISbomConfigProvider sbomConfigs, ISbomConfig config)
-    {
-    }
+    public void AddMetadataToSbom(ISbomConfigProvider sbomConfigs, ISbomConfig config);
 
-    public Task<List<FileValidationResult>> WriteJsonObjectsToSbomAsync(
-        ISbomConfig sbomConfig,
-        string spdxManifestVersion,
-        IJsonArrayGenerator<FileArrayGenerator> fileArrayGenerator,
-        IJsonArrayGenerator<PackageArrayGenerator> packageArrayGenerator,
-        IJsonArrayGenerator<RelationshipsArrayGenerator> relationshipsArrayGenerator,
-        IJsonArrayGenerator<ExternalDocumentReferenceGenerator> externalDocumentReferenceGenerator);
+    public void StartGraphArray(IList<ManifestInfo> manifestInfosFromConfig, ISbomConfigProvider sbomConfigs);
+
+    public void EndGraphArray(IList<ManifestInfo> manifestInfosFromConfig, ISbomConfigProvider sbomConfigs);
+
+    public void WriteJsonObjectsToManifest(GenerationResult generationResult);
 }

--- a/src/Microsoft.Sbom.Api/Executors/IJsonSerializationStrategy.cs
+++ b/src/Microsoft.Sbom.Api/Executors/IJsonSerializationStrategy.cs
@@ -14,7 +14,7 @@ internal interface IJsonSerializationStrategy
     /// <param name="elementsSupportingConfigs"></param>
     /// <param name="config"></param>
     /// <returns></returns>
-    public bool AddToFilesSupportingConfig(IEnumerable<ISbomConfig> elementsSupportingConfigs, ISbomConfig config);
+    public bool AddToFilesSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config);
 
     /// <summary>
     /// Adds the config to the list of configs that support packages.
@@ -22,7 +22,7 @@ internal interface IJsonSerializationStrategy
     /// <param name="elementsSupportingConfigs"></param>
     /// <param name="config"></param>
     /// <returns></returns>
-    public bool AddToPackagesSupportingConfig(IEnumerable<ISbomConfig> elementsSupportingConfigs, ISbomConfig config);
+    public bool AddToPackagesSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config);
 
     /// <summary>
     /// Adds the config to the list of configs that support relationships.
@@ -30,7 +30,7 @@ internal interface IJsonSerializationStrategy
     /// <param name="elementsSupportingConfigs"></param>
     /// <param name="config"></param>
     /// <returns></returns>
-    public bool AddToRelationshipsSupportingConfig(IEnumerable<ISbomConfig> elementsSupportingConfigs, ISbomConfig config);
+    public bool AddToRelationshipsSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config);
 
     /// <summary>
     /// Adds the config to the list of configs that support external document references.
@@ -38,7 +38,7 @@ internal interface IJsonSerializationStrategy
     /// <param name="elementsSupportingConfigs"></param>
     /// <param name="config"></param>
     /// <returns></returns>
-    public bool AddToExternalDocRefsSupportingConfig(IEnumerable<ISbomConfig> elementsSupportingConfigs, ISbomConfig config);
+    public bool AddToExternalDocRefsSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config);
 
     /// <summary>
     /// Adds a metadata dictionary as a JSON element to the SBOM, if required by this format.

--- a/src/Microsoft.Sbom.Api/Executors/IJsonSerializationStrategy.cs
+++ b/src/Microsoft.Sbom.Api/Executors/IJsonSerializationStrategy.cs
@@ -9,18 +9,60 @@ namespace Microsoft.Sbom.Api.Workflows.Helpers;
 
 internal interface IJsonSerializationStrategy
 {
+    /// <summary>
+    /// Adds the config to the list of configs that support files.
+    /// </summary>
+    /// <param name="elementsSupportingConfigs"></param>
+    /// <param name="config"></param>
+    /// <returns></returns>
     public bool AddToFilesSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config);
 
+    /// <summary>
+    /// Adds the config to the list of configs that support packages.
+    /// </summary>
+    /// <param name="elementsSupportingConfigs"></param>
+    /// <param name="config"></param>
+    /// <returns></returns>
     public bool AddToPackagesSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config);
 
+    /// <summary>
+    /// Adds the config to the list of configs that support relationships.
+    /// </summary>
+    /// <param name="elementsSupportingConfigs"></param>
+    /// <param name="config"></param>
+    /// <returns></returns>
     public bool AddToRelationshipsSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config);
 
+    /// <summary>
+    /// Adds the config to the list of configs that support external document references.
+    /// </summary>
+    /// <param name="elementsSupportingConfigs"></param>
+    /// <param name="config"></param>
+    /// <returns></returns>
     public bool AddToExternalDocRefsSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config);
 
+    /// <summary>
+    /// Adds a metadata dictionary as a JSON element to the SBOM.
+    /// This is only used for SPDX 2.2 SBOM generation, metadata is added differently for SPDX 3.0 and above.
+    /// </summary>
+    /// <param name="sbomConfigs"></param>
+    /// <param name="config"></param>
     public void AddMetadataToSbom(ISbomConfigProvider sbomConfigs, ISbomConfig config);
 
+    /// <summary>
+    /// Starts an array with a graph header that is only used in SPDX 3.0 and above.
+    /// This does not apply to SPDX 2.2 SBOM generation.
+    /// </summary>
+    /// <param name="manifestInfosFromConfig"></param>
+    /// <param name="sbomConfigs"></param>
     public void StartGraphArray(IList<ManifestInfo> manifestInfosFromConfig, ISbomConfigProvider sbomConfigs);
 
+    /// <summary>
+    /// Ends an array with a graph header that is only used in SPDX 3.0 and above.
+    /// This does not apply to SPDX 2.2 SBOM generation.
+    /// </summary>
+    /// <param name="manifestInfosFromConfig"></param>
+    /// <param name="sbomConfigs"></param>
     public void EndGraphArray(IList<ManifestInfo> manifestInfosFromConfig, ISbomConfigProvider sbomConfigs);
 
     public void WriteJsonObjectsToManifest(GenerationResult generationResult, HashSet<string> elementsSpdxIdList);

--- a/src/Microsoft.Sbom.Api/Executors/IJsonSerializationStrategy.cs
+++ b/src/Microsoft.Sbom.Api/Executors/IJsonSerializationStrategy.cs
@@ -41,23 +41,20 @@ internal interface IJsonSerializationStrategy
     public bool AddToExternalDocRefsSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config);
 
     /// <summary>
-    /// Adds a metadata dictionary as a JSON element to the SBOM.
-    /// This is only used for SPDX 2.2 SBOM generation, metadata is added differently for SPDX 3.0 and above.
+    /// Adds a metadata dictionary as a JSON element to the SBOM, if required by this format.
     /// </summary>
     /// <param name="sbomConfigs"></param>
     /// <param name="config"></param>
     public void AddMetadataToSbom(ISbomConfigProvider sbomConfigs, ISbomConfig config);
 
     /// <summary>
-    /// Starts an array with a graph header that is only used in SPDX 3.0 and above.
-    /// This does not apply to SPDX 2.2 SBOM generation.
+    /// Starts an array with a graph header, if required by this format.
     /// </summary>
     /// <param name="sbomConfig"></param>
     public void StartGraphArray(ISbomConfig sbomConfig);
 
     /// <summary>
-    /// Ends an array with a graph header that is only used in SPDX 3.0 and above.
-    /// This does not apply to SPDX 2.2 SBOM generation.
+    /// Ends an array with a graph header, if required by this format.
     /// </summary>
     /// <param name="sbomConfig"></param>
     public void EndGraphArray(ISbomConfig sbomConfig);

--- a/src/Microsoft.Sbom.Api/Executors/IJsonSerializationStrategy.cs
+++ b/src/Microsoft.Sbom.Api/Executors/IJsonSerializationStrategy.cs
@@ -14,7 +14,7 @@ internal interface IJsonSerializationStrategy
     /// <param name="elementsSupportingConfigs"></param>
     /// <param name="config"></param>
     /// <returns></returns>
-    public bool AddToFilesSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config);
+    public bool AddToFilesSupportingConfig(IEnumerable<ISbomConfig> elementsSupportingConfigs, ISbomConfig config);
 
     /// <summary>
     /// Adds the config to the list of configs that support packages.
@@ -22,7 +22,7 @@ internal interface IJsonSerializationStrategy
     /// <param name="elementsSupportingConfigs"></param>
     /// <param name="config"></param>
     /// <returns></returns>
-    public bool AddToPackagesSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config);
+    public bool AddToPackagesSupportingConfig(IEnumerable<ISbomConfig> elementsSupportingConfigs, ISbomConfig config);
 
     /// <summary>
     /// Adds the config to the list of configs that support relationships.
@@ -30,7 +30,7 @@ internal interface IJsonSerializationStrategy
     /// <param name="elementsSupportingConfigs"></param>
     /// <param name="config"></param>
     /// <returns></returns>
-    public bool AddToRelationshipsSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config);
+    public bool AddToRelationshipsSupportingConfig(IEnumerable<ISbomConfig> elementsSupportingConfigs, ISbomConfig config);
 
     /// <summary>
     /// Adds the config to the list of configs that support external document references.
@@ -38,7 +38,7 @@ internal interface IJsonSerializationStrategy
     /// <param name="elementsSupportingConfigs"></param>
     /// <param name="config"></param>
     /// <returns></returns>
-    public bool AddToExternalDocRefsSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config);
+    public bool AddToExternalDocRefsSupportingConfig(IEnumerable<ISbomConfig> elementsSupportingConfigs, ISbomConfig config);
 
     /// <summary>
     /// Adds a metadata dictionary as a JSON element to the SBOM, if required by this format.
@@ -59,5 +59,5 @@ internal interface IJsonSerializationStrategy
     /// <param name="sbomConfig"></param>
     public void EndGraphArray(ISbomConfig sbomConfig);
 
-    public void WriteJsonObjectsToManifest(GenerationResult generationResult, ISbomConfig config, HashSet<string> elementsSpdxIdList);
+    public void WriteJsonObjectsToManifest(GenerationResult generationResult, ISbomConfig config, ISet<string> elementsSpdxIdList);
 }

--- a/src/Microsoft.Sbom.Api/Executors/Spdx22SerializationStrategy.cs
+++ b/src/Microsoft.Sbom.Api/Executors/Spdx22SerializationStrategy.cs
@@ -74,7 +74,12 @@ internal class Spdx22SerializationStrategy : IJsonSerializationStrategy
         // Not supported for SPDX 2.2, only supported for SPDX 3.0 and above.
     }
 
-    public void WriteJsonObjectsToManifest(GenerationResult generationResult)
+    /// <summary>
+    /// Writes the json objects to the manifest in SPDX 2.2 format.
+    /// </summary>
+    /// <param name="generationResult"></param>
+    /// <param name="elementsSpdxIdList">Not used for deduplication. Only used for >= SPDX 3.0.</param>
+    public void WriteJsonObjectsToManifest(GenerationResult generationResult, HashSet<string> elementsSpdxIdList)
     {
         foreach (var serializer in generationResult.SerializerToJsonDocuments.Keys)
         {

--- a/src/Microsoft.Sbom.Api/Executors/Spdx22SerializationStrategy.cs
+++ b/src/Microsoft.Sbom.Api/Executors/Spdx22SerializationStrategy.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.Sbom.Extensions;
 
 namespace Microsoft.Sbom.Api.Workflows.Helpers;
@@ -12,31 +11,31 @@ namespace Microsoft.Sbom.Api.Workflows.Helpers;
 /// </summary>
 internal class Spdx22SerializationStrategy : IJsonSerializationStrategy
 {
-    public bool AddToFilesSupportingConfig(IEnumerable<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
+    public bool AddToFilesSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
     {
         if (config.MetadataBuilder.TryGetFilesArrayHeaderName(out var headerName))
         {
             config.JsonSerializer.StartJsonArray(headerName);
-            elementsSupportingConfigs = elementsSupportingConfigs.Append(config);
+            elementsSupportingConfigs.Add(config);
             return true;
         }
 
         return false;
     }
 
-    public bool AddToPackagesSupportingConfig(IEnumerable<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
+    public bool AddToPackagesSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
     {
         if (config.MetadataBuilder.TryGetPackageArrayHeaderName(out var headerName))
         {
             config.JsonSerializer.StartJsonArray(headerName);
-            elementsSupportingConfigs = elementsSupportingConfigs.Append(config);
+            elementsSupportingConfigs.Add(config);
             return true;
         }
 
         return false;
     }
 
-    public bool AddToRelationshipsSupportingConfig(IEnumerable<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
+    public bool AddToRelationshipsSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
     {
         if (config.MetadataBuilder.TryGetRelationshipsHeaderName(out var headerName))
         {
@@ -47,12 +46,12 @@ internal class Spdx22SerializationStrategy : IJsonSerializationStrategy
         return false;
     }
 
-    public bool AddToExternalDocRefsSupportingConfig(IEnumerable<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
+    public bool AddToExternalDocRefsSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
     {
         if (config.MetadataBuilder.TryGetExternalRefArrayHeaderName(out var headerName))
         {
             config.JsonSerializer.StartJsonArray(headerName);
-            elementsSupportingConfigs = elementsSupportingConfigs.Append(config);
+            elementsSupportingConfigs.Add(config);
             return true;
         }
 

--- a/src/Microsoft.Sbom.Api/Executors/Spdx22SerializationStrategy.cs
+++ b/src/Microsoft.Sbom.Api/Executors/Spdx22SerializationStrategy.cs
@@ -65,12 +65,12 @@ internal class Spdx22SerializationStrategy : IJsonSerializationStrategy
 
     public void StartGraphArray(ISbomConfig sbomConfig)
     {
-        // Not supported for SPDX 2.2, only supported for SPDX 3.0 and above.
+        // Not supported for SPDX 2.2.
     }
 
     public void EndGraphArray(ISbomConfig sbomConfig)
     {
-        // Not supported for SPDX 2.2, only supported for SPDX 3.0 and above.
+        // Not supported for SPDX 2.2.
     }
 
     /// <summary>

--- a/src/Microsoft.Sbom.Api/Executors/Spdx22SerializationStrategy.cs
+++ b/src/Microsoft.Sbom.Api/Executors/Spdx22SerializationStrategy.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Sbom.Extensions;
 
 namespace Microsoft.Sbom.Api.Workflows.Helpers;
@@ -11,31 +12,31 @@ namespace Microsoft.Sbom.Api.Workflows.Helpers;
 /// </summary>
 internal class Spdx22SerializationStrategy : IJsonSerializationStrategy
 {
-    public bool AddToFilesSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
+    public bool AddToFilesSupportingConfig(IEnumerable<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
     {
         if (config.MetadataBuilder.TryGetFilesArrayHeaderName(out var headerName))
         {
             config.JsonSerializer.StartJsonArray(headerName);
-            elementsSupportingConfigs.Add(config);
+            elementsSupportingConfigs = elementsSupportingConfigs.Append(config);
             return true;
         }
 
         return false;
     }
 
-    public bool AddToPackagesSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
+    public bool AddToPackagesSupportingConfig(IEnumerable<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
     {
         if (config.MetadataBuilder.TryGetPackageArrayHeaderName(out var headerName))
         {
             config.JsonSerializer.StartJsonArray(headerName);
-            elementsSupportingConfigs.Add(config);
+            elementsSupportingConfigs = elementsSupportingConfigs.Append(config);
             return true;
         }
 
         return false;
     }
 
-    public bool AddToRelationshipsSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
+    public bool AddToRelationshipsSupportingConfig(IEnumerable<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
     {
         if (config.MetadataBuilder.TryGetRelationshipsHeaderName(out var headerName))
         {
@@ -46,12 +47,12 @@ internal class Spdx22SerializationStrategy : IJsonSerializationStrategy
         return false;
     }
 
-    public bool AddToExternalDocRefsSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
+    public bool AddToExternalDocRefsSupportingConfig(IEnumerable<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
     {
         if (config.MetadataBuilder.TryGetExternalRefArrayHeaderName(out var headerName))
         {
             config.JsonSerializer.StartJsonArray(headerName);
-            elementsSupportingConfigs.Add(config);
+            elementsSupportingConfigs = elementsSupportingConfigs.Append(config);
             return true;
         }
 
@@ -79,7 +80,7 @@ internal class Spdx22SerializationStrategy : IJsonSerializationStrategy
     /// <param name="generationResult"></param>
     /// <param name="config"></param>
     /// <param name="elementsSpdxIdList">Not used for deduplication. Only used for >= SPDX 3.0.</param>
-    public void WriteJsonObjectsToManifest(GenerationResult generationResult, ISbomConfig config, HashSet<string> elementsSpdxIdList)
+    public void WriteJsonObjectsToManifest(GenerationResult generationResult, ISbomConfig config, ISet<string> elementsSpdxIdList)
     {
         var serializer = config.JsonSerializer;
 

--- a/src/Microsoft.Sbom.Api/Executors/Spdx30SerializationStrategy.cs
+++ b/src/Microsoft.Sbom.Api/Executors/Spdx30SerializationStrategy.cs
@@ -14,8 +14,6 @@ namespace Microsoft.Sbom.Api.Workflows.Helpers;
 /// </summary>
 internal class Spdx30SerializationStrategy : IJsonSerializationStrategy
 {
-    private readonly HashSet<string> elementsSpdxIdList = new HashSet<string>();
-
     /// <summary>
     /// Adds the config to the list of configs that support files.
     /// </summary>
@@ -100,7 +98,12 @@ internal class Spdx30SerializationStrategy : IJsonSerializationStrategy
         }
     }
 
-    public void WriteJsonObjectsToManifest(GenerationResult generationResult)
+    /// <summary>
+    /// Writes the JSON objects in >=SPDX 3.0 format.
+    /// </summary>
+    /// <param name="generationResult"></param>
+    /// <param name="elementsSpdxIdList">Only used for SPDX 3.0 and above for deduplication. SPDX 2.2 handles deduplication differently.</param>
+    public void WriteJsonObjectsToManifest(GenerationResult generationResult, HashSet<string> elementsSpdxIdList)
     {
         foreach (var serializer in generationResult.SerializerToJsonDocuments.Keys)
         {

--- a/src/Microsoft.Sbom.Api/Executors/Spdx30SerializationStrategy.cs
+++ b/src/Microsoft.Sbom.Api/Executors/Spdx30SerializationStrategy.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Text.Json;
 using Microsoft.Sbom.Api.Utils;
 using Microsoft.Sbom.Extensions;
@@ -20,9 +19,9 @@ internal class Spdx30SerializationStrategy : IJsonSerializationStrategy
     /// <param name="elementsSupportingConfigs"></param>
     /// <param name="config"></param>
     /// <returns>Always returns false since we do not want to write a separate files array in SPDX 3.0.</returns>
-    public bool AddToFilesSupportingConfig(IEnumerable<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
+    public bool AddToFilesSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
     {
-        elementsSupportingConfigs = elementsSupportingConfigs.Append(config);
+        elementsSupportingConfigs.Add(config);
         return false;
     }
 
@@ -32,9 +31,9 @@ internal class Spdx30SerializationStrategy : IJsonSerializationStrategy
     /// <param name="elementsSupportingConfigs"></param>
     /// <param name="config"></param>
     /// <returns>Always returns false since we do not want to write a separate packages array in SPDX 3.0.</returns>
-    public bool AddToPackagesSupportingConfig(IEnumerable<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
+    public bool AddToPackagesSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
     {
-        elementsSupportingConfigs = elementsSupportingConfigs.Append(config);
+        elementsSupportingConfigs.Add(config);
         return false;
     }
 
@@ -44,7 +43,7 @@ internal class Spdx30SerializationStrategy : IJsonSerializationStrategy
     /// <param name="elementsSupportingConfigs"></param>
     /// <param name="config"></param>
     /// <returns>Always returns true since relationships are generated regardless of the config.</returns>
-    public bool AddToRelationshipsSupportingConfig(IEnumerable<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
+    public bool AddToRelationshipsSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
     {
         return true;
     }
@@ -55,9 +54,9 @@ internal class Spdx30SerializationStrategy : IJsonSerializationStrategy
     /// <param name="elementsSupportingConfigs"></param>
     /// <param name="config"></param>
     /// <returns>Always returns false since we do not want to write a separate external document references array in SPDX 3.0.</returns>
-    public bool AddToExternalDocRefsSupportingConfig(IEnumerable<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
+    public bool AddToExternalDocRefsSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
     {
-        elementsSupportingConfigs = elementsSupportingConfigs.Append(config);
+        elementsSupportingConfigs.Add(config);
         return false;
     }
 

--- a/src/Microsoft.Sbom.Api/Executors/Spdx30SerializationStrategy.cs
+++ b/src/Microsoft.Sbom.Api/Executors/Spdx30SerializationStrategy.cs
@@ -18,8 +18,7 @@ internal class Spdx30SerializationStrategy : IJsonSerializationStrategy
     /// </summary>
     /// <param name="elementsSupportingConfigs"></param>
     /// <param name="config"></param>
-    /// <returns>Always returns false since we do not want to write a separate files array in SPDX 3.0.
-    /// A separate files array is only supported for SPDX 2.2.</returns>
+    /// <returns>Always returns false since we do not want to write a separate files array in SPDX 3.0.</returns>
     public bool AddToFilesSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
     {
         elementsSupportingConfigs.Add(config);
@@ -31,8 +30,7 @@ internal class Spdx30SerializationStrategy : IJsonSerializationStrategy
     /// </summary>
     /// <param name="elementsSupportingConfigs"></param>
     /// <param name="config"></param>
-    /// <returns>Always returns false since we do not want to write a separate packages array in SPDX 3.0.
-    /// A separate packages array is only supported for SPDX 2.2.</returns>
+    /// <returns>Always returns false since we do not want to write a separate packages array in SPDX 3.0.</returns>
     public bool AddToPackagesSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
     {
         elementsSupportingConfigs.Add(config);
@@ -55,8 +53,7 @@ internal class Spdx30SerializationStrategy : IJsonSerializationStrategy
     /// </summary>
     /// <param name="elementsSupportingConfigs"></param>
     /// <param name="config"></param>
-    /// <returns>Always returns false since we do not want to write a separate external document references array in SPDX 3.0.
-    /// A separate external document references array is only supported for SPDX 2.2.</returns>
+    /// <returns>Always returns false since we do not want to write a separate external document references array in SPDX 3.0.</returns>
     public bool AddToExternalDocRefsSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
     {
         elementsSupportingConfigs.Add(config);
@@ -65,8 +62,7 @@ internal class Spdx30SerializationStrategy : IJsonSerializationStrategy
 
     public void AddMetadataToSbom(ISbomConfigProvider sbomConfigs, ISbomConfig config)
     {
-        // Not supported for SPDX 3.0 and above, only supported for SPDX 2.2.
-        // For SPDX 3.0 and above, the metadata is added as part of the SpdxDocument and CreationInfo elements.
+        // Not supported for SPDX 3.0.
     }
 
     public void StartGraphArray(ISbomConfig sbomConfig)
@@ -89,11 +85,11 @@ internal class Spdx30SerializationStrategy : IJsonSerializationStrategy
     }
 
     /// <summary>
-    /// Writes the JSON objects in >=SPDX 3.0 format.
+    /// Writes the JSON objects in SPDX 3.0 format.
     /// </summary>
     /// <param name="generationResult"></param>
     /// <param name="config"></param>
-    /// <param name="elementsSpdxIdList">Only used for SPDX 3.0 and above for deduplication. SPDX 2.2 handles deduplication differently.</param>
+    /// <param name="elementsSpdxIdList">Hashes for deduplication in SPDX 3.0.</param>
     public void WriteJsonObjectsToManifest(GenerationResult generationResult, ISbomConfig config, HashSet<string> elementsSpdxIdList)
     {
         var serializer = config.JsonSerializer;

--- a/src/Microsoft.Sbom.Api/Executors/Spdx30SerializationStrategy.cs
+++ b/src/Microsoft.Sbom.Api/Executors/Spdx30SerializationStrategy.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 using Microsoft.Sbom.Api.Utils;
 using Microsoft.Sbom.Extensions;
@@ -19,9 +20,9 @@ internal class Spdx30SerializationStrategy : IJsonSerializationStrategy
     /// <param name="elementsSupportingConfigs"></param>
     /// <param name="config"></param>
     /// <returns>Always returns false since we do not want to write a separate files array in SPDX 3.0.</returns>
-    public bool AddToFilesSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
+    public bool AddToFilesSupportingConfig(IEnumerable<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
     {
-        elementsSupportingConfigs.Add(config);
+        elementsSupportingConfigs = elementsSupportingConfigs.Append(config);
         return false;
     }
 
@@ -31,9 +32,9 @@ internal class Spdx30SerializationStrategy : IJsonSerializationStrategy
     /// <param name="elementsSupportingConfigs"></param>
     /// <param name="config"></param>
     /// <returns>Always returns false since we do not want to write a separate packages array in SPDX 3.0.</returns>
-    public bool AddToPackagesSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
+    public bool AddToPackagesSupportingConfig(IEnumerable<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
     {
-        elementsSupportingConfigs.Add(config);
+        elementsSupportingConfigs = elementsSupportingConfigs.Append(config);
         return false;
     }
 
@@ -43,7 +44,7 @@ internal class Spdx30SerializationStrategy : IJsonSerializationStrategy
     /// <param name="elementsSupportingConfigs"></param>
     /// <param name="config"></param>
     /// <returns>Always returns true since relationships are generated regardless of the config.</returns>
-    public bool AddToRelationshipsSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
+    public bool AddToRelationshipsSupportingConfig(IEnumerable<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
     {
         return true;
     }
@@ -54,9 +55,9 @@ internal class Spdx30SerializationStrategy : IJsonSerializationStrategy
     /// <param name="elementsSupportingConfigs"></param>
     /// <param name="config"></param>
     /// <returns>Always returns false since we do not want to write a separate external document references array in SPDX 3.0.</returns>
-    public bool AddToExternalDocRefsSupportingConfig(IList<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
+    public bool AddToExternalDocRefsSupportingConfig(IEnumerable<ISbomConfig> elementsSupportingConfigs, ISbomConfig config)
     {
-        elementsSupportingConfigs.Add(config);
+        elementsSupportingConfigs = elementsSupportingConfigs.Append(config);
         return false;
     }
 
@@ -90,7 +91,7 @@ internal class Spdx30SerializationStrategy : IJsonSerializationStrategy
     /// <param name="generationResult"></param>
     /// <param name="config"></param>
     /// <param name="elementsSpdxIdList">Hashes for deduplication in SPDX 3.0.</param>
-    public void WriteJsonObjectsToManifest(GenerationResult generationResult, ISbomConfig config, HashSet<string> elementsSpdxIdList)
+    public void WriteJsonObjectsToManifest(GenerationResult generationResult, ISbomConfig config, ISet<string> elementsSpdxIdList)
     {
         var serializer = config.JsonSerializer;
 
@@ -121,13 +122,13 @@ internal class Spdx30SerializationStrategy : IJsonSerializationStrategy
         sbomConfig.JsonSerializer.EndJsonArray();
     }
 
-    private void WriteElement(IManifestToolJsonSerializer serializer, JsonElement element, HashSet<string> elementsSpdxIdList)
+    private void WriteElement(IManifestToolJsonSerializer serializer, JsonElement element, ISet<string> elementsSpdxIdList)
     {
         if (element.TryGetProperty("spdxId", out var spdxIdField))
         {
             var spdxId = spdxIdField.GetString();
 
-            if (elementsSpdxIdList.TryGetValue(spdxId, out _))
+            if (elementsSpdxIdList.Contains(spdxId))
             {
                 return;
             }

--- a/src/Microsoft.Sbom.Api/Executors/Spdx30SerializationStrategy.cs
+++ b/src/Microsoft.Sbom.Api/Executors/Spdx30SerializationStrategy.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Sbom.Api.Workflows.Helpers;
 internal class Spdx30SerializationStrategy : IJsonSerializationStrategy
 {
     /// <summary>
-    /// Adds the config to the list of configs that support files.
+    /// inheritdoc
     /// </summary>
     /// <param name="elementsSupportingConfigs"></param>
     /// <param name="config"></param>
@@ -28,7 +28,7 @@ internal class Spdx30SerializationStrategy : IJsonSerializationStrategy
     }
 
     /// <summary>
-    /// Adds the config to the list of configs that support packages.
+    /// inheritdoc
     /// </summary>
     /// <param name="elementsSupportingConfigs"></param>
     /// <param name="config"></param>
@@ -41,7 +41,7 @@ internal class Spdx30SerializationStrategy : IJsonSerializationStrategy
     }
 
     /// <summary>
-    /// Adds the config to the list of configs that support relationships.
+    /// inheritdoc
     /// </summary>
     /// <param name="elementsSupportingConfigs"></param>
     /// <param name="config"></param>
@@ -53,7 +53,7 @@ internal class Spdx30SerializationStrategy : IJsonSerializationStrategy
     }
 
     /// <summary>
-    /// Adds the config to the list of configs that support external document references.
+    /// inheritdoc
     /// </summary>
     /// <param name="elementsSupportingConfigs"></param>
     /// <param name="config"></param>
@@ -68,7 +68,7 @@ internal class Spdx30SerializationStrategy : IJsonSerializationStrategy
     public void AddMetadataToSbom(ISbomConfigProvider sbomConfigs, ISbomConfig config)
     {
         // Not supported for SPDX 3.0 and above, only supported for SPDX 2.2.
-        // Metadata is written differently for SPDX 3.0 and above.
+        // For SPDX 3.0 and above, the metadata is added as part of the SpdxDocument and CreationInfo elements.
     }
 
     public void StartGraphArray(IList<ManifestInfo> manifestInfosFromConfig, ISbomConfigProvider sbomConfigs)

--- a/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfigProvider.cs
+++ b/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfigProvider.cs
@@ -127,8 +127,7 @@ public class SbomConfigProvider : ISbomConfigProvider
     {
         foreach (var manifestInfo in manifestInfosFromConfig)
         {
-            var supportedManifestInfo = this.TryGet(manifestInfo, out var config);
-            if (supportedManifestInfo)
+            if (this.TryGet(manifestInfo, out var config))
             {
                 config.StartJsonSerialization();
             }

--- a/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfigProvider.cs
+++ b/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfigProvider.cs
@@ -118,15 +118,22 @@ public class SbomConfigProvider : ISbomConfigProvider
         return this;
     }
 
-    public IAsyncDisposable StartJsonSerializationAsync()
+    /// <summary>
+    /// Starts asynchronous JSON serialization of supported ISbomConfig objects from IConfiguration.
+    /// </summary>
+    /// <param name="manifestInfosFromConfig"></param>
+    /// <returns></returns>
+    public IAsyncDisposable StartJsonSerializationAsync(IList<ManifestInfo> manifestInfosFromConfig)
     {
-        ApplyToEachConfig(c => c.StartJsonSerialization());
-        return this;
-    }
+        foreach (var manifestInfo in manifestInfosFromConfig)
+        {
+            var supportedManifestInfo = this.TryGet(manifestInfo, out var config);
+            if (supportedManifestInfo)
+            {
+                config.StartJsonSerialization();
+            }
+        }
 
-    public IAsyncDisposable StartJsonSerializationAsync(ISbomConfig configuration)
-    {
-        configuration.StartJsonSerialization();
         return this;
     }
 

--- a/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfigProvider.cs
+++ b/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfigProvider.cs
@@ -123,7 +123,7 @@ public class SbomConfigProvider : ISbomConfigProvider
     /// </summary>
     /// <param name="manifestInfosFromConfig"></param>
     /// <returns></returns>
-    public IAsyncDisposable StartJsonSerializationAsync(IList<ManifestInfo> manifestInfosFromConfig)
+    public IAsyncDisposable StartJsonSerializationAsync(IEnumerable<ManifestInfo> manifestInfosFromConfig)
     {
         foreach (var manifestInfo in manifestInfosFromConfig)
         {

--- a/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfigProvider.cs
+++ b/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfigProvider.cs
@@ -121,7 +121,7 @@ public class SbomConfigProvider : ISbomConfigProvider
     /// <summary>
     /// Starts asynchronous JSON serialization of supported ISbomConfig objects from IConfiguration.
     /// </summary>
-    /// <param name="manifestInfosFromConfig"></param>
+    /// <param name="targetConfigs"></param>
     /// <returns></returns>
     public IAsyncDisposable StartJsonSerializationAsync(IEnumerable<ISbomConfig> targetConfigs)
     {

--- a/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfigProvider.cs
+++ b/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfigProvider.cs
@@ -123,14 +123,11 @@ public class SbomConfigProvider : ISbomConfigProvider
     /// </summary>
     /// <param name="manifestInfosFromConfig"></param>
     /// <returns></returns>
-    public IAsyncDisposable StartJsonSerializationAsync(IEnumerable<ManifestInfo> manifestInfosFromConfig)
+    public IAsyncDisposable StartJsonSerializationAsync(IEnumerable<ISbomConfig> targetConfigs)
     {
-        foreach (var manifestInfo in manifestInfosFromConfig)
+        foreach (var config in targetConfigs)
         {
-            if (this.TryGet(manifestInfo, out var config))
-            {
-                config.StartJsonSerialization();
-            }
+            config.StartJsonSerialization();
         }
 
         return this;

--- a/src/Microsoft.Sbom.Api/Output/ManifestToolJsonSerializer.cs
+++ b/src/Microsoft.Sbom.Api/Output/ManifestToolJsonSerializer.cs
@@ -49,7 +49,7 @@ public sealed class ManifestToolJsonSerializer : IManifestToolJsonSerializer
 
     /// <summary>
     /// This writes a json document to the underlying stream.
-    /// We also call dispose on the JsonDocument once we finish writing.
+    /// Disposal is taken care of in implementations of IJsonArrayGenerator after writing.
     /// </summary>
     /// <param name="jsonDocument">The json document.</param>
     public void Write(JsonDocument jsonDocument)

--- a/src/Microsoft.Sbom.Api/Output/ManifestToolJsonSerializer.cs
+++ b/src/Microsoft.Sbom.Api/Output/ManifestToolJsonSerializer.cs
@@ -49,7 +49,7 @@ public sealed class ManifestToolJsonSerializer : IManifestToolJsonSerializer
 
     /// <summary>
     /// This writes a json document to the underlying stream.
-    /// Disposal is taken care of in implementations of IJsonArrayGenerator after writing.
+    /// The jsonDocument object gets cleaned up by the caller, not here.
     /// </summary>
     /// <param name="jsonDocument">The json document.</param>
     public void Write(JsonDocument jsonDocument)

--- a/src/Microsoft.Sbom.Api/Output/ManifestToolJsonSerializer.cs
+++ b/src/Microsoft.Sbom.Api/Output/ManifestToolJsonSerializer.cs
@@ -59,10 +59,7 @@ public sealed class ManifestToolJsonSerializer : IManifestToolJsonSerializer
             return;
         }
 
-        using (jsonDocument)
-        {
-            jsonDocument.WriteTo(jsonWriter);
-        }
+        jsonDocument.WriteTo(jsonWriter);
 
         // If the pending buffer size is greater than a megabyte, flush the stream.
         if (jsonWriter.BytesPending > 1_000_000)

--- a/src/Microsoft.Sbom.Api/Output/MetadataBuilder.cs
+++ b/src/Microsoft.Sbom.Api/Output/MetadataBuilder.cs
@@ -42,6 +42,14 @@ public class MetadataBuilder : IMetadataBuilder
     /// <returns></returns>
     public string GetHeaderJsonString(IInternalMetadataProvider internalMetadataProvider)
     {
+        // SPDX 3.0 and above handles writing the info in metadata dictionary differently.
+        // Note: manifestGenerator.Version is a string that is formatted as <manifestInfoName>-<manifestInfoVersion>.
+        if (manifestGenerator.Version.Contains(Constants.SPDX30ManifestInfo.Name)
+            && manifestGenerator.Version.Contains(Constants.SPDX30ManifestInfo.Version))
+        {
+            logger.Debug($"The SBOM format '{Constants.SPDX30ManifestInfo}' does not support writing a metadata dictionary.");
+        }
+
         using (recorder.TraceEvent(string.Format(Events.MetadataBuilder, manifestInfo)))
         {
             logger.Debug("Building the header object.");

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/ExternalDocumentReferenceGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/ExternalDocumentReferenceGenerator.cs
@@ -40,7 +40,7 @@ public class ExternalDocumentReferenceGenerator : IJsonArrayGenerator<ExternalDo
         this.recorder = recorder ?? throw new ArgumentNullException(nameof(recorder));
     }
 
-    public async Task<GenerationResult> GenerateAsync(IList<ManifestInfo> manifestInfosFromConfig)
+    public async Task<GenerationResult> GenerateAsync(IList<ManifestInfo> manifestInfosFromConfig, HashSet<string> elementsSpdxIdList)
     {
         using (recorder.TraceEvent(Events.ExternalDocumentReferenceGeneration))
         {
@@ -93,7 +93,7 @@ public class ExternalDocumentReferenceGenerator : IJsonArrayGenerator<ExternalDo
             {
                 var config = sbomConfigs.Get(manifestInfo);
                 var serializationStrategy = JsonSerializationStrategyFactory.GetStrategy(config.ManifestInfo.Version);
-                serializationStrategy.WriteJsonObjectsToManifest(generationResult);
+                serializationStrategy.WriteJsonObjectsToManifest(generationResult, elementsSpdxIdList);
             }
 
             return generationResult;

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/ExternalDocumentReferenceGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/ExternalDocumentReferenceGenerator.cs
@@ -40,7 +40,7 @@ public class ExternalDocumentReferenceGenerator : IJsonArrayGenerator<ExternalDo
         this.recorder = recorder ?? throw new ArgumentNullException(nameof(recorder));
     }
 
-    public async Task<GenerationResult> GenerateAsync(IList<ManifestInfo> manifestInfosFromConfig, HashSet<string> elementsSpdxIdList)
+    public async Task<GenerationResult> GenerateAsync(IEnumerable<ManifestInfo> manifestInfosFromConfig, HashSet<string> elementsSpdxIdList)
     {
         using (recorder.TraceEvent(Events.ExternalDocumentReferenceGeneration))
         {

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/ExternalDocumentReferenceGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/ExternalDocumentReferenceGenerator.cs
@@ -93,7 +93,7 @@ public class ExternalDocumentReferenceGenerator : IJsonArrayGenerator<ExternalDo
             {
                 var config = sbomConfigs.Get(manifestInfo);
                 var serializationStrategy = JsonSerializationStrategyFactory.GetStrategy(config.ManifestInfo.Version);
-                serializationStrategy.WriteJsonObjectsToManifest(generationResult, elementsSpdxIdList);
+                serializationStrategy.WriteJsonObjectsToManifest(generationResult, config, elementsSpdxIdList);
             }
 
             jsonDocumentCollection.DisposeAllJsonDocuments();

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/ExternalDocumentReferenceGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/ExternalDocumentReferenceGenerator.cs
@@ -40,7 +40,7 @@ public class ExternalDocumentReferenceGenerator : IJsonArrayGenerator<ExternalDo
         this.recorder = recorder ?? throw new ArgumentNullException(nameof(recorder));
     }
 
-    public async Task<GenerationResult> GenerateAsync(IEnumerable<ManifestInfo> manifestInfosFromConfig, HashSet<string> elementsSpdxIdList)
+    public async Task<GenerationResult> GenerateAsync(IEnumerable<ManifestInfo> manifestInfosFromConfig, ISet<string> elementsSpdxIdList)
     {
         using (recorder.TraceEvent(Events.ExternalDocumentReferenceGeneration))
         {

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/ExternalDocumentReferenceGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/ExternalDocumentReferenceGenerator.cs
@@ -96,6 +96,8 @@ public class ExternalDocumentReferenceGenerator : IJsonArrayGenerator<ExternalDo
                 serializationStrategy.WriteJsonObjectsToManifest(generationResult, elementsSpdxIdList);
             }
 
+            jsonDocumentCollection.DisposeAllJsonDocuments();
+
             return generationResult;
         }
     }

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/FileArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/FileArrayGenerator.cs
@@ -48,7 +48,7 @@ public class FileArrayGenerator : IJsonArrayGenerator<FileArrayGenerator>
     /// <param name="jsonSerializer">The serializer used to write the SBOM.</param>
     /// <param name="headerName">The header key for the file array object.</param>
     /// <returns></returns>
-    public async Task<GenerationResult> GenerateAsync(IList<ManifestInfo> manifestInfosFromConfig)
+    public async Task<GenerationResult> GenerateAsync(IList<ManifestInfo> manifestInfosFromConfig, HashSet<string> elementsSpdxIdList)
     {
         using (recorder.TraceEvent(Events.FilesGeneration))
         {
@@ -95,7 +95,7 @@ public class FileArrayGenerator : IJsonArrayGenerator<FileArrayGenerator>
             {
                 var config = sbomConfigs.Get(manifestInfo);
                 var serializationStrategy = JsonSerializationStrategyFactory.GetStrategy(config.ManifestInfo.Version);
-                serializationStrategy.WriteJsonObjectsToManifest(generationResult);
+                serializationStrategy.WriteJsonObjectsToManifest(generationResult, elementsSpdxIdList);
             }
 
             return generationResult;

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/FileArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/FileArrayGenerator.cs
@@ -48,7 +48,7 @@ public class FileArrayGenerator : IJsonArrayGenerator<FileArrayGenerator>
     /// <param name="jsonSerializer">The serializer used to write the SBOM.</param>
     /// <param name="headerName">The header key for the file array object.</param>
     /// <returns></returns>
-    public async Task<GenerationResult> GenerateAsync(IList<ManifestInfo> manifestInfosFromConfig, HashSet<string> elementsSpdxIdList)
+    public async Task<GenerationResult> GenerateAsync(IEnumerable<ManifestInfo> manifestInfosFromConfig, HashSet<string> elementsSpdxIdList)
     {
         using (recorder.TraceEvent(Events.FilesGeneration))
         {

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/FileArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/FileArrayGenerator.cs
@@ -48,7 +48,7 @@ public class FileArrayGenerator : IJsonArrayGenerator<FileArrayGenerator>
     /// <param name="jsonSerializer">The serializer used to write the SBOM.</param>
     /// <param name="headerName">The header key for the file array object.</param>
     /// <returns></returns>
-    public async Task<GenerationResult> GenerateAsync(IEnumerable<ManifestInfo> manifestInfosFromConfig, HashSet<string> elementsSpdxIdList)
+    public async Task<GenerationResult> GenerateAsync(IEnumerable<ManifestInfo> manifestInfosFromConfig, ISet<string> elementsSpdxIdList)
     {
         using (recorder.TraceEvent(Events.FilesGeneration))
         {

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/FileArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/FileArrayGenerator.cs
@@ -95,7 +95,7 @@ public class FileArrayGenerator : IJsonArrayGenerator<FileArrayGenerator>
             {
                 var config = sbomConfigs.Get(manifestInfo);
                 var serializationStrategy = JsonSerializationStrategyFactory.GetStrategy(config.ManifestInfo.Version);
-                serializationStrategy.WriteJsonObjectsToManifest(generationResult, elementsSpdxIdList);
+                serializationStrategy.WriteJsonObjectsToManifest(generationResult, config, elementsSpdxIdList);
             }
 
             jsonDocumentCollection.DisposeAllJsonDocuments();

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/FileArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/FileArrayGenerator.cs
@@ -98,6 +98,8 @@ public class FileArrayGenerator : IJsonArrayGenerator<FileArrayGenerator>
                 serializationStrategy.WriteJsonObjectsToManifest(generationResult, elementsSpdxIdList);
             }
 
+            jsonDocumentCollection.DisposeAllJsonDocuments();
+
             return generationResult;
         }
     }

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/IJsonArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/IJsonArrayGenerator.cs
@@ -17,5 +17,5 @@ public interface IJsonArrayGenerator<T>
     /// Generates all the JSON objects that need to be written to the SBOM.
     /// </summary>
     /// <returns>GenerationResult with objects to write to the SBOM and failures.</returns>
-    public Task<GenerationResult> GenerateAsync(IList<ManifestInfo> manifestInfosFromConfig);
+    public Task<GenerationResult> GenerateAsync(IList<ManifestInfo> manifestInfosFromConfig, HashSet<string> elementsSpdxIdList);
 }

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/IJsonArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/IJsonArrayGenerator.cs
@@ -1,25 +1,21 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Sbom.Extensions;
+using Microsoft.Sbom.Extensions.Entities;
 
 namespace Microsoft.Sbom.Api.Workflows.Helpers;
 
 /// <summary>
-/// Used to generate array objects in the JSON serializer.
+/// Used to generate array objects to be written to the JSON serializer.
 /// </summary>
 public interface IJsonArrayGenerator<T>
     where T : IJsonArrayGenerator<T>
 {
-    public ISbomConfig SbomConfig { get; set; }
-
-    public string SpdxManifestVersion { get; set; }
-
     /// <summary>
-    /// Generates an array in the json serializer with the headerName and writes all elements of the
-    /// specific type into the array.
+    /// Generates all the JSON objects that need to be written to the SBOM.
     /// </summary>
-    /// <returns>The list of failures.</returns>
-    public Task<GenerationResult> GenerateAsync();
+    /// <returns>GenerationResult with objects to write to the SBOM and failures.</returns>
+    public Task<GenerationResult> GenerateAsync(IList<ManifestInfo> manifestInfosFromConfig);
 }

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/IJsonArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/IJsonArrayGenerator.cs
@@ -3,7 +3,7 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Sbom.Extensions.Entities;
+using Microsoft.Sbom.Extensions;
 
 namespace Microsoft.Sbom.Api.Workflows.Helpers;
 
@@ -17,5 +17,5 @@ public interface IJsonArrayGenerator<T>
     /// Generates all the JSON objects that need to be written to the SBOM.
     /// </summary>
     /// <returns>GenerationResult with objects to write to the SBOM and failures.</returns>
-    public Task<GenerationResult> GenerateAsync(IEnumerable<ManifestInfo> manifestInfosFromConfig, ISet<string> elementsSpdxIdList);
+    public Task<GenerationResult> GenerateAsync(IEnumerable<ISbomConfig> targetConfigs, ISet<string> elementsSpdxIdList);
 }

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/IJsonArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/IJsonArrayGenerator.cs
@@ -17,5 +17,5 @@ public interface IJsonArrayGenerator<T>
     /// Generates all the JSON objects that need to be written to the SBOM.
     /// </summary>
     /// <returns>GenerationResult with objects to write to the SBOM and failures.</returns>
-    public Task<GenerationResult> GenerateAsync(IList<ManifestInfo> manifestInfosFromConfig, HashSet<string> elementsSpdxIdList);
+    public Task<GenerationResult> GenerateAsync(IEnumerable<ManifestInfo> manifestInfosFromConfig, HashSet<string> elementsSpdxIdList);
 }

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/IJsonArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/IJsonArrayGenerator.cs
@@ -17,5 +17,5 @@ public interface IJsonArrayGenerator<T>
     /// Generates all the JSON objects that need to be written to the SBOM.
     /// </summary>
     /// <returns>GenerationResult with objects to write to the SBOM and failures.</returns>
-    public Task<GenerationResult> GenerateAsync(IEnumerable<ManifestInfo> manifestInfosFromConfig, HashSet<string> elementsSpdxIdList);
+    public Task<GenerationResult> GenerateAsync(IEnumerable<ManifestInfo> manifestInfosFromConfig, ISet<string> elementsSpdxIdList);
 }

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/JsonDocumentCollection.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/JsonDocumentCollection.cs
@@ -33,7 +33,7 @@ public class JsonDocumentCollection<T>
         {
             foreach (var document in jsonDocuments)
             {
-                document.Dispose();
+                document?.Dispose();
             }
         }
 

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/JsonDocumentCollection.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/JsonDocumentCollection.cs
@@ -27,5 +27,16 @@ public class JsonDocumentCollection<T>
         }
     }
 
-    // TODO: cleanup doc
+    public void DisposeAllJsonDocuments()
+    {
+        foreach (var jsonDocuments in SerializersToJson.Values)
+        {
+            foreach (var document in jsonDocuments)
+            {
+                document.Dispose();
+            }
+        }
+
+        SerializersToJson.Clear();
+    }
 }

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/JsonDocumentCollection.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/JsonDocumentCollection.cs
@@ -26,4 +26,6 @@ public class JsonDocumentCollection<T>
             SerializersToJson.Add(key, new List<JsonDocument> { document });
         }
     }
+
+    // TODO: cleanup doc
 }

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/PackageArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/PackageArrayGenerator.cs
@@ -40,7 +40,7 @@ public class PackageArrayGenerator : IJsonArrayGenerator<PackageArrayGenerator>
         this.recorder = recorder ?? throw new ArgumentNullException(nameof(recorder));
     }
 
-    public async Task<GenerationResult> GenerateAsync(IEnumerable<ManifestInfo> manifestInfosFromConfig, HashSet<string> elementsSpdxIdList)
+    public async Task<GenerationResult> GenerateAsync(IEnumerable<ManifestInfo> manifestInfosFromConfig, ISet<string> elementsSpdxIdList)
     {
         using (recorder.TraceEvent(Events.PackagesGeneration))
         {

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/PackageArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/PackageArrayGenerator.cs
@@ -108,7 +108,7 @@ public class PackageArrayGenerator : IJsonArrayGenerator<PackageArrayGenerator>
             {
                 var config = sbomConfigs.Get(manifestInfo);
                 var serializationStrategy = JsonSerializationStrategyFactory.GetStrategy(config.ManifestInfo.Version);
-                serializationStrategy.WriteJsonObjectsToManifest(generationResult, elementsSpdxIdList);
+                serializationStrategy.WriteJsonObjectsToManifest(generationResult, config, elementsSpdxIdList);
             }
 
             jsonDocumentCollection.DisposeAllJsonDocuments();

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/PackageArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/PackageArrayGenerator.cs
@@ -40,7 +40,7 @@ public class PackageArrayGenerator : IJsonArrayGenerator<PackageArrayGenerator>
         this.recorder = recorder ?? throw new ArgumentNullException(nameof(recorder));
     }
 
-    public async Task<GenerationResult> GenerateAsync(IList<ManifestInfo> manifestInfosFromConfig)
+    public async Task<GenerationResult> GenerateAsync(IList<ManifestInfo> manifestInfosFromConfig, HashSet<string> elementsSpdxIdList)
     {
         using (recorder.TraceEvent(Events.PackagesGeneration))
         {
@@ -108,7 +108,7 @@ public class PackageArrayGenerator : IJsonArrayGenerator<PackageArrayGenerator>
             {
                 var config = sbomConfigs.Get(manifestInfo);
                 var serializationStrategy = JsonSerializationStrategyFactory.GetStrategy(config.ManifestInfo.Version);
-                serializationStrategy.WriteJsonObjectsToManifest(generationResult);
+                serializationStrategy.WriteJsonObjectsToManifest(generationResult, elementsSpdxIdList);
             }
 
             return generationResult;

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/PackageArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/PackageArrayGenerator.cs
@@ -111,6 +111,8 @@ public class PackageArrayGenerator : IJsonArrayGenerator<PackageArrayGenerator>
                 serializationStrategy.WriteJsonObjectsToManifest(generationResult, elementsSpdxIdList);
             }
 
+            jsonDocumentCollection.DisposeAllJsonDocuments();
+
             return generationResult;
         }
     }

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/PackageArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/PackageArrayGenerator.cs
@@ -40,7 +40,7 @@ public class PackageArrayGenerator : IJsonArrayGenerator<PackageArrayGenerator>
         this.recorder = recorder ?? throw new ArgumentNullException(nameof(recorder));
     }
 
-    public async Task<GenerationResult> GenerateAsync(IList<ManifestInfo> manifestInfosFromConfig, HashSet<string> elementsSpdxIdList)
+    public async Task<GenerationResult> GenerateAsync(IEnumerable<ManifestInfo> manifestInfosFromConfig, HashSet<string> elementsSpdxIdList)
     {
         using (recorder.TraceEvent(Events.PackagesGeneration))
         {

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/RelationshipsArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/RelationshipsArrayGenerator.cs
@@ -118,7 +118,7 @@ public class RelationshipsArrayGenerator : IJsonArrayGenerator<RelationshipsArra
             {
                 var config = sbomConfigs.Get(manifestInfo);
                 var serializationStrategy = JsonSerializationStrategyFactory.GetStrategy(config.ManifestInfo.Version);
-                serializationStrategy.WriteJsonObjectsToManifest(generationResult, elementsSpdxIdList);
+                serializationStrategy.WriteJsonObjectsToManifest(generationResult, config, elementsSpdxIdList);
             }
 
             jsonDocumentCollection.DisposeAllJsonDocuments();

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/RelationshipsArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/RelationshipsArrayGenerator.cs
@@ -121,6 +121,8 @@ public class RelationshipsArrayGenerator : IJsonArrayGenerator<RelationshipsArra
                 serializationStrategy.WriteJsonObjectsToManifest(generationResult, elementsSpdxIdList);
             }
 
+            jsonDocumentCollection.DisposeAllJsonDocuments();
+
             return generationResult;
         }
     }

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/RelationshipsArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/RelationshipsArrayGenerator.cs
@@ -44,7 +44,7 @@ public class RelationshipsArrayGenerator : IJsonArrayGenerator<RelationshipsArra
         this.recorder = recorder;
     }
 
-    public async Task<GenerationResult> GenerateAsync(IList<ManifestInfo> manifestInfosFromConfig, HashSet<string> elementsSpdxIdList)
+    public async Task<GenerationResult> GenerateAsync(IEnumerable<ManifestInfo> manifestInfosFromConfig, HashSet<string> elementsSpdxIdList)
     {
         using (recorder.TraceEvent(Events.RelationshipsGeneration))
         {

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/RelationshipsArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/RelationshipsArrayGenerator.cs
@@ -44,7 +44,7 @@ public class RelationshipsArrayGenerator : IJsonArrayGenerator<RelationshipsArra
         this.recorder = recorder;
     }
 
-    public async Task<GenerationResult> GenerateAsync(IEnumerable<ManifestInfo> manifestInfosFromConfig, HashSet<string> elementsSpdxIdList)
+    public async Task<GenerationResult> GenerateAsync(IEnumerable<ManifestInfo> manifestInfosFromConfig, ISet<string> elementsSpdxIdList)
     {
         using (recorder.TraceEvent(Events.RelationshipsGeneration))
         {

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/RelationshipsArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/RelationshipsArrayGenerator.cs
@@ -30,8 +30,6 @@ public class RelationshipsArrayGenerator : IJsonArrayGenerator<RelationshipsArra
 
     private readonly ISbomConfigProvider sbomConfigs;
 
-    public string SpdxManifestVersion { get; set; }
-
     public RelationshipsArrayGenerator(
         RelationshipGenerator generator,
         ChannelUtils channelUtils,
@@ -46,7 +44,7 @@ public class RelationshipsArrayGenerator : IJsonArrayGenerator<RelationshipsArra
         this.recorder = recorder;
     }
 
-    public async Task<GenerationResult> GenerateAsync(IList<ManifestInfo> manifestInfosFromConfig)
+    public async Task<GenerationResult> GenerateAsync(IList<ManifestInfo> manifestInfosFromConfig, HashSet<string> elementsSpdxIdList)
     {
         using (recorder.TraceEvent(Events.RelationshipsGeneration))
         {
@@ -120,7 +118,7 @@ public class RelationshipsArrayGenerator : IJsonArrayGenerator<RelationshipsArra
             {
                 var config = sbomConfigs.Get(manifestInfo);
                 var serializationStrategy = JsonSerializationStrategyFactory.GetStrategy(config.ManifestInfo.Version);
-                serializationStrategy.WriteJsonObjectsToManifest(generationResult);
+                serializationStrategy.WriteJsonObjectsToManifest(generationResult, elementsSpdxIdList);
             }
 
             return generationResult;

--- a/src/Microsoft.Sbom.Api/Workflows/SbomGenerationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SbomGenerationWorkflow.cs
@@ -198,8 +198,7 @@ public class SbomGenerationWorkflow : IWorkflow<SbomGenerationWorkflow>
     {
         foreach (var manifestInfo in manifestInfosFromConfig)
         {
-            var supportedManifestInfo = sbomConfigs.TryGet(manifestInfo, out var config);
-            if (supportedManifestInfo)
+            if (sbomConfigs.TryGet(manifestInfo, out var config))
             {
                 action(config);
             }

--- a/src/Microsoft.Sbom.Api/Workflows/SbomGenerationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SbomGenerationWorkflow.cs
@@ -106,7 +106,7 @@ public class SbomGenerationWorkflow : IWorkflow<SbomGenerationWorkflow>
                     ForEachManifestFromConfig(manifestInfosFromConfig, config =>
                     {
                         var strategy = JsonSerializationStrategyFactory.GetStrategy(config.ManifestInfo.Version);
-                        strategy.StartGraphArray(manifestInfosFromConfig, sbomConfigs);
+                        strategy.StartGraphArray(config);
                     });
 
                     // Write all the JSON documents from the generationResults to the manifest based on the manifestInfo.
@@ -134,7 +134,7 @@ public class SbomGenerationWorkflow : IWorkflow<SbomGenerationWorkflow>
                     ForEachManifestFromConfig(manifestInfosFromConfig, config =>
                     {
                         var strategy = JsonSerializationStrategyFactory.GetStrategy(config.ManifestInfo.Version);
-                        strategy.EndGraphArray(manifestInfosFromConfig, sbomConfigs);
+                        strategy.EndGraphArray(config);
                     });
 
                     // Finalize JSON

--- a/src/Microsoft.Sbom.Api/Workflows/SbomGenerationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SbomGenerationWorkflow.cs
@@ -75,6 +75,7 @@ public class SbomGenerationWorkflow : IWorkflow<SbomGenerationWorkflow>
     public virtual async Task<bool> RunAsync()
     {
         IEnumerable<FileValidationResult> validErrors = new List<FileValidationResult>();
+        var elementsSpdxIdList = new HashSet<string>();
         string sbomDir = null;
         var deleteSbomDir = false;
         using (recorder.TraceEvent(Events.SbomGenerationWorkflow))
@@ -109,13 +110,13 @@ public class SbomGenerationWorkflow : IWorkflow<SbomGenerationWorkflow>
                     });
 
                     // Write all the JSON documents from the generationResults to the manifest based on the manifestInfo.
-                    var fileGenerationResult = await fileArrayGenerator.GenerateAsync(manifestInfosFromConfig);
+                    var fileGenerationResult = await fileArrayGenerator.GenerateAsync(manifestInfosFromConfig, elementsSpdxIdList);
 
-                    var packageGenerationResult = await packageArrayGenerator.GenerateAsync(manifestInfosFromConfig);
+                    var packageGenerationResult = await packageArrayGenerator.GenerateAsync(manifestInfosFromConfig, elementsSpdxIdList);
 
-                    var externalDocumentReferenceGenerationResult = await externalDocumentReferenceGenerator.GenerateAsync(manifestInfosFromConfig);
+                    var externalDocumentReferenceGenerationResult = await externalDocumentReferenceGenerator.GenerateAsync(manifestInfosFromConfig, elementsSpdxIdList);
 
-                    var relationshipGenerationResult = await relationshipsArrayGenerator.GenerateAsync(manifestInfosFromConfig);
+                    var relationshipGenerationResult = await relationshipsArrayGenerator.GenerateAsync(manifestInfosFromConfig, elementsSpdxIdList);
 
                     // Concatenate all the errors from the generationResults.
                     validErrors = validErrors.Concat(fileGenerationResult.Errors);

--- a/src/Microsoft.Sbom.Api/Workflows/SbomGenerationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SbomGenerationWorkflow.cs
@@ -99,8 +99,7 @@ public class SbomGenerationWorkflow : IWorkflow<SbomGenerationWorkflow>
                 }
 
                 // Write manifests based on manifestInfo values in the configuration.
-                var manifestInfosFromConfiguration = configuration.ManifestInfo.Value;
-                var targetConfigs = GetTargetConfigs(manifestInfosFromConfiguration);
+                var targetConfigs = GetTargetConfigs(configuration.ManifestInfo.Value);
                 triedToGenerateAtLeastOneManifest = targetConfigs.Any();
 
                 await using (sbomConfigs.StartJsonSerializationAsync(targetConfigs))
@@ -193,7 +192,7 @@ public class SbomGenerationWorkflow : IWorkflow<SbomGenerationWorkflow>
         }
     }
 
-    public IEnumerable<ISbomConfig> GetTargetConfigs(IEnumerable<ManifestInfo> manifestInfosFromConfiguration)
+    private IEnumerable<ISbomConfig> GetTargetConfigs(IEnumerable<ManifestInfo> manifestInfosFromConfiguration)
     {
         var configs = new List<ISbomConfig>();
         foreach (var manifestInfo in manifestInfosFromConfiguration)
@@ -216,7 +215,7 @@ public class SbomGenerationWorkflow : IWorkflow<SbomGenerationWorkflow>
     /// </summary>
     /// <param name="targetConfigs">List of supported configs.</param>
     /// <param name="action">Action to perform on each config.</param>
-    public void ForEachConfig(IEnumerable<ISbomConfig> targetConfigs, Action<ISbomConfig> action)
+    private void ForEachConfig(IEnumerable<ISbomConfig> targetConfigs, Action<ISbomConfig> action)
     {
         foreach (var config in targetConfigs)
         {

--- a/src/Microsoft.Sbom.Extensions/IManifestToolJsonSerializer.cs
+++ b/src/Microsoft.Sbom.Extensions/IManifestToolJsonSerializer.cs
@@ -39,14 +39,14 @@ public interface IManifestToolJsonSerializer : IAsyncDisposable, IDisposable
 
     /// <summary>
     /// This writes a json document to the underlying stream.
-    /// We also call dispose on the JsonDocument once we finish writing.
+    /// Disposal is taken care of in implementations of IJsonArrayGenerator after writing.
     /// </summary>
     /// <param name="jsonDocument">The json document.</param>
     public void Write(JsonDocument jsonDocument);
 
     /// <summary>
     /// This writes a json element to the underlying stream.
-    /// We also call dispose on the JsonDocument once we finish writing.
+    /// Disposal is taken care of in implementations of IJsonArrayGenerator after writing.
     /// </summary>
     /// <param name="jsonDocument">The json document.</param>
     public void Write(JsonElement jsonElement);

--- a/src/Microsoft.Sbom.Extensions/IManifestToolJsonSerializer.cs
+++ b/src/Microsoft.Sbom.Extensions/IManifestToolJsonSerializer.cs
@@ -39,14 +39,14 @@ public interface IManifestToolJsonSerializer : IAsyncDisposable, IDisposable
 
     /// <summary>
     /// This writes a json document to the underlying stream.
-    /// Disposal is taken care of in implementations of IJsonArrayGenerator after writing.
+    /// Do not dispose jsonDocument in this method.
     /// </summary>
     /// <param name="jsonDocument">The json document.</param>
     public void Write(JsonDocument jsonDocument);
 
     /// <summary>
     /// This writes a json element to the underlying stream.
-    /// Disposal is taken care of in implementations of IJsonArrayGenerator after writing.
+    /// Do not dispose jsonDocument in this method.
     /// </summary>
     /// <param name="jsonDocument">The json document.</param>
     public void Write(JsonElement jsonElement);

--- a/src/Microsoft.Sbom.Extensions/ISbomConfigProvider.cs
+++ b/src/Microsoft.Sbom.Extensions/ISbomConfigProvider.cs
@@ -43,11 +43,11 @@ public interface ISbomConfigProvider : IDisposable, IAsyncDisposable, IInternalM
     public IDisposable StartJsonSerialization();
 
     /// <summary>
-    /// Starts the JSON serialization of all the included ISbomConfig objects asynchronously.
+    /// Starts the JSON serialization of target ISbomConfig objects asynchronously.
     /// This returns a <see cref="IAsyncDisposable"/> object that is used to clean up the JSON streams.
     /// </summary>
     /// <returns></returns>
-    public IAsyncDisposable StartJsonSerializationAsync(IEnumerable<ManifestInfo> manifestInfosFromConfig);
+    public IAsyncDisposable StartJsonSerializationAsync(IEnumerable<ISbomConfig> targetConfigs);
 
     /// <summary>
     /// Helper method to operate an action on each included configs.

--- a/src/Microsoft.Sbom.Extensions/ISbomConfigProvider.cs
+++ b/src/Microsoft.Sbom.Extensions/ISbomConfigProvider.cs
@@ -47,7 +47,7 @@ public interface ISbomConfigProvider : IDisposable, IAsyncDisposable, IInternalM
     /// This returns a <see cref="IAsyncDisposable"/> object that is used to clean up the JSON streams.
     /// </summary>
     /// <returns></returns>
-    public IAsyncDisposable StartJsonSerializationAsync(IList<ManifestInfo> manifestInfosFromConfig);
+    public IAsyncDisposable StartJsonSerializationAsync(IEnumerable<ManifestInfo> manifestInfosFromConfig);
 
     /// <summary>
     /// Helper method to operate an action on each included configs.

--- a/src/Microsoft.Sbom.Extensions/ISbomConfigProvider.cs
+++ b/src/Microsoft.Sbom.Extensions/ISbomConfigProvider.cs
@@ -47,14 +47,7 @@ public interface ISbomConfigProvider : IDisposable, IAsyncDisposable, IInternalM
     /// This returns a <see cref="IAsyncDisposable"/> object that is used to clean up the JSON streams.
     /// </summary>
     /// <returns></returns>
-    public IAsyncDisposable StartJsonSerializationAsync();
-
-    /// <summary>
-    /// Starts the JSON serialization of the specified ISbomConfig object asynchronously.
-    /// This returns a <see cref="IAsyncDisposable"/> object that is used to clean up the JSON streams.
-    /// </summary>
-    /// <returns></returns>
-    public IAsyncDisposable StartJsonSerializationAsync(ISbomConfig configuration);
+    public IAsyncDisposable StartJsonSerializationAsync(IList<ManifestInfo> manifestInfosFromConfig);
 
     /// <summary>
     /// Helper method to operate an action on each included configs.

--- a/test/Microsoft.Sbom.Api.Tests/Output/ManifestToolJsonSerializerTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Output/ManifestToolJsonSerializerTests.cs
@@ -38,18 +38,6 @@ public class ManifestToolJsonSerializerTests
 
         var expected = JsonSerializer.Serialize(JsonDocument.Parse("{\"Outputs\":[{\"hello\":\"world\"}],\"header\":\"value\"}"), new JsonSerializerOptions { WriteIndented = true });
         Assert.AreEqual(expected, result);
-
-        using var stream2 = new MemoryStream();
-        using var utfJsonWriter = new Utf8JsonWriter(stream2);
-        try
-        {
-            jsonDoc.WriteTo(utfJsonWriter);
-            Assert.Fail("Json document was not disposed by the serializer");
-        }
-        catch (Exception e)
-        {
-            Assert.AreEqual(typeof(ObjectDisposedException), e.GetType());
-        }
     }
 
     [TestMethod]
@@ -76,18 +64,6 @@ public class ManifestToolJsonSerializerTests
 
         var expected = JsonSerializer.Serialize(JsonDocument.Parse("{\"Outputs\":[{\"hello\":\"world\"}],\"header\":\"value\"}"), new JsonSerializerOptions { WriteIndented = true });
         Assert.AreEqual(expected, result);
-
-        using var stream2 = new MemoryStream();
-        using var utfJsonWriter = new Utf8JsonWriter(stream2);
-        try
-        {
-            jsonDoc.WriteTo(utfJsonWriter);
-            Assert.Fail("Json document was not disposed by the serializer");
-        }
-        catch (Exception e)
-        {
-            Assert.AreEqual(typeof(ObjectDisposedException), e.GetType());
-        }
     }
 
     [TestMethod]

--- a/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
@@ -190,11 +190,7 @@ public class InterfaceConcretionTests
 
     private class PinnedIJsonArrayGenerator : IJsonArrayGenerator<PinnedIJsonArrayGenerator>
     {
-        public ISbomConfig SbomConfig { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-        public string SpdxManifestVersion { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-
-        public Task<IList<FileValidationResult>> GenerateAsync() => throw new NotImplementedException();
-        Task<Api.Workflows.Helpers.GenerationResult> IJsonArrayGenerator<PinnedIJsonArrayGenerator>.GenerateAsync() => throw new NotImplementedException();
+        public Task<Api.Workflows.Helpers.GenerationResult> GenerateAsync(IList<ManifestInfo> manifestInfosFromConfig, HashSet<string> elementsSpdxIdList) => throw new NotImplementedException();
     }
 
     private class PinnedISbomRedactor : ISbomRedactor

--- a/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
@@ -190,7 +190,7 @@ public class InterfaceConcretionTests
 
     private class PinnedIJsonArrayGenerator : IJsonArrayGenerator<PinnedIJsonArrayGenerator>
     {
-        public Task<Api.Workflows.Helpers.GenerationResult> GenerateAsync(IList<ManifestInfo> manifestInfosFromConfig, HashSet<string> elementsSpdxIdList) => throw new NotImplementedException();
+        public Task<Api.Workflows.Helpers.GenerationResult> GenerateAsync(IEnumerable<ManifestInfo> manifestInfosFromConfig, HashSet<string> elementsSpdxIdList) => throw new NotImplementedException();
     }
 
     private class PinnedISbomRedactor : ISbomRedactor

--- a/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
@@ -190,7 +190,7 @@ public class InterfaceConcretionTests
 
     private class PinnedIJsonArrayGenerator : IJsonArrayGenerator<PinnedIJsonArrayGenerator>
     {
-        public Task<Api.Workflows.Helpers.GenerationResult> GenerateAsync(IEnumerable<ManifestInfo> manifestInfosFromConfig, HashSet<string> elementsSpdxIdList) => throw new NotImplementedException();
+        public Task<Api.Workflows.Helpers.GenerationResult> GenerateAsync(IEnumerable<ManifestInfo> manifestInfosFromConfig, ISet<string> elementsSpdxIdList) => throw new NotImplementedException();
     }
 
     private class PinnedISbomRedactor : ISbomRedactor

--- a/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
@@ -190,7 +190,7 @@ public class InterfaceConcretionTests
 
     private class PinnedIJsonArrayGenerator : IJsonArrayGenerator<PinnedIJsonArrayGenerator>
     {
-        public Task<Api.Workflows.Helpers.GenerationResult> GenerateAsync(IEnumerable<ManifestInfo> manifestInfosFromConfig, ISet<string> elementsSpdxIdList) => throw new NotImplementedException();
+        public Task<Api.Workflows.Helpers.GenerationResult> GenerateAsync(IEnumerable<ISbomConfig> targetConfigs, ISet<string> elementsSpdxIdList) => throw new NotImplementedException();
     }
 
     private class PinnedISbomRedactor : ISbomRedactor

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/Helpers/JsonDocumentCollectionTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/Helpers/JsonDocumentCollectionTests.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Text.Json;
+using Microsoft.Sbom.Api.Workflows.Helpers;
+using Microsoft.Sbom.Extensions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.Sbom.Api.Workflows.Tests;
+
+[TestClass]
+public class JsonDocumentCollectionTests
+{
+    [TestMethod]
+    public void JsonDocumentDisposalSucceeds()
+    {
+        var jsonDoc = JsonDocument.Parse("{\"hello\":\"world\"}");
+        var dummySerializer = new Mock<IManifestToolJsonSerializer>().Object;
+        var jsonDocumentCollection = new JsonDocumentCollection<IManifestToolJsonSerializer>();
+        jsonDocumentCollection.AddJsonDocument(dummySerializer, jsonDoc);
+
+        jsonDocumentCollection.DisposeAllJsonDocuments();
+
+        using var stream2 = new MemoryStream();
+        using var utfJsonWriter = new Utf8JsonWriter(stream2);
+        try
+        {
+            jsonDoc.WriteTo(utfJsonWriter);
+            Assert.Fail("Json document was not disposed by the serializer");
+        }
+        catch (Exception e)
+        {
+            Assert.AreEqual(typeof(ObjectDisposedException), e.GetType());
+        }
+    }
+}

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/Helpers/RelationshipsArrayGeneratorTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/Helpers/RelationshipsArrayGeneratorTest.cs
@@ -38,7 +38,7 @@ public class RelationshipsArrayGeneratorTest
     private IMetadataBuilder metadataBuilder;
     private ISbomConfig sbomConfig;
     private readonly ManifestInfo manifestInfo = Constants.TestManifestInfo;
-    private readonly IList<ManifestInfo> manifestInfos = new List<ManifestInfo> { Constants.TestManifestInfo };
+    private IList<ISbomConfig> targetConfigs;
     private HashSet<string> elementsSpdxIdList = new HashSet<string>();
 
     private const string DocumentId = "documentId";
@@ -70,6 +70,8 @@ public class RelationshipsArrayGeneratorTest
             Recorder = recorder,
         };
 
+        targetConfigs = new List<ISbomConfig> { sbomConfig };
+
         relationships = new List<Relationship>();
         relationshipGeneratorMock.Setup(r => r.Run(It.IsAny<IEnumerator<Relationship>>(), It.IsAny<ManifestInfo>()))
             .Callback<IEnumerator<Relationship>, ManifestInfo>((relationship, manifestInfo) =>
@@ -80,7 +82,7 @@ public class RelationshipsArrayGeneratorTest
                 }
             });
         relationshipGeneratorMock.CallBase = true;
-        relationshipsArrayGenerator = new RelationshipsArrayGenerator(relationshipGeneratorMock.Object, new ChannelUtils(), loggerMock.Object, sbomConfigsMock.Object, recorderMock.Object);
+        relationshipsArrayGenerator = new RelationshipsArrayGenerator(relationshipGeneratorMock.Object, new ChannelUtils(), loggerMock.Object, recorderMock.Object);
         manifestGeneratorProvider.Init();
 
         fileSystemUtilsMock.Setup(f => f.CreateDirectory(ManifestJsonDirPath));
@@ -98,7 +100,7 @@ public class RelationshipsArrayGeneratorTest
     {
         recorder.RecordDocumentId(DocumentId);
         recorder.RecordRootPackageId(RootPackageId);
-        var results = await relationshipsArrayGenerator.GenerateAsync(manifestInfos, elementsSpdxIdList);
+        var results = await relationshipsArrayGenerator.GenerateAsync(targetConfigs, elementsSpdxIdList);
 
         Assert.AreEqual(0, results.Errors.Count);
         Assert.AreEqual(1, relationships.Count);
@@ -118,7 +120,7 @@ public class RelationshipsArrayGeneratorTest
         recorder.RecordFileId(FileId1);
         recorder.RecordFileId(FileId2);
         recorder.RecordSPDXFileId(FileId1);
-        var results = await relationshipsArrayGenerator.GenerateAsync(manifestInfos, elementsSpdxIdList);
+        var results = await relationshipsArrayGenerator.GenerateAsync(targetConfigs, elementsSpdxIdList);
 
         Assert.AreEqual(0, results.Errors.Count);
         Assert.AreEqual(2, relationships.Count);
@@ -136,7 +138,7 @@ public class RelationshipsArrayGeneratorTest
         recorder.RecordDocumentId(DocumentId);
         recorder.RecordRootPackageId(RootPackageId);
         recorder.RecordExternalDocumentReferenceIdAndRootElement(ExternalDocRefId1, RootPackageId);
-        var results = await relationshipsArrayGenerator.GenerateAsync(manifestInfos, elementsSpdxIdList);
+        var results = await relationshipsArrayGenerator.GenerateAsync(targetConfigs, elementsSpdxIdList);
 
         Assert.AreEqual(0, results.Errors.Count);
         Assert.AreEqual(2, relationships.Count);
@@ -155,7 +157,7 @@ public class RelationshipsArrayGeneratorTest
         recorder.RecordDocumentId(DocumentId);
         recorder.RecordRootPackageId(RootPackageId);
         recorder.RecordPackageId(PackageId1, RootPackageId);
-        var results = await relationshipsArrayGenerator.GenerateAsync(manifestInfos, elementsSpdxIdList);
+        var results = await relationshipsArrayGenerator.GenerateAsync(targetConfigs, elementsSpdxIdList);
 
         Assert.AreEqual(0, results.Errors.Count);
         Assert.AreEqual(2, relationships.Count);
@@ -170,7 +172,7 @@ public class RelationshipsArrayGeneratorTest
     [TestMethod]
     public async Task When_NoGenerationDataExist_NoRelationshipsAreGenerated()
     {
-        var results = await relationshipsArrayGenerator.GenerateAsync(manifestInfos, elementsSpdxIdList);
+        var results = await relationshipsArrayGenerator.GenerateAsync(targetConfigs, elementsSpdxIdList);
 
         Assert.AreEqual(0, results.Errors.Count);
         Assert.AreEqual(0, relationships.Count);

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/Helpers/RelationshipsArrayGeneratorTest.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/Helpers/RelationshipsArrayGeneratorTest.cs
@@ -37,7 +37,9 @@ public class RelationshipsArrayGeneratorTest
     private ISbomPackageDetailsRecorder recorder;
     private IMetadataBuilder metadataBuilder;
     private ISbomConfig sbomConfig;
-    private readonly ManifestInfo manifestInfo = new ManifestInfo();
+    private readonly ManifestInfo manifestInfo = Constants.TestManifestInfo;
+    private readonly IList<ManifestInfo> manifestInfos = new List<ManifestInfo> { Constants.TestManifestInfo };
+    private HashSet<string> elementsSpdxIdList = new HashSet<string>();
 
     private const string DocumentId = "documentId";
     private const string RootPackageId = "rootPackageId";
@@ -78,10 +80,7 @@ public class RelationshipsArrayGeneratorTest
                 }
             });
         relationshipGeneratorMock.CallBase = true;
-        relationshipsArrayGenerator = new RelationshipsArrayGenerator(relationshipGeneratorMock.Object, new ChannelUtils(), loggerMock.Object, recorderMock.Object)
-        {
-            SbomConfig = sbomConfig
-        };
+        relationshipsArrayGenerator = new RelationshipsArrayGenerator(relationshipGeneratorMock.Object, new ChannelUtils(), loggerMock.Object, sbomConfigsMock.Object, recorderMock.Object);
         manifestGeneratorProvider.Init();
 
         fileSystemUtilsMock.Setup(f => f.CreateDirectory(ManifestJsonDirPath));
@@ -99,7 +98,7 @@ public class RelationshipsArrayGeneratorTest
     {
         recorder.RecordDocumentId(DocumentId);
         recorder.RecordRootPackageId(RootPackageId);
-        var results = await relationshipsArrayGenerator.GenerateAsync();
+        var results = await relationshipsArrayGenerator.GenerateAsync(manifestInfos, elementsSpdxIdList);
 
         Assert.AreEqual(0, results.Errors.Count);
         Assert.AreEqual(1, relationships.Count);
@@ -119,7 +118,7 @@ public class RelationshipsArrayGeneratorTest
         recorder.RecordFileId(FileId1);
         recorder.RecordFileId(FileId2);
         recorder.RecordSPDXFileId(FileId1);
-        var results = await relationshipsArrayGenerator.GenerateAsync();
+        var results = await relationshipsArrayGenerator.GenerateAsync(manifestInfos, elementsSpdxIdList);
 
         Assert.AreEqual(0, results.Errors.Count);
         Assert.AreEqual(2, relationships.Count);
@@ -137,7 +136,7 @@ public class RelationshipsArrayGeneratorTest
         recorder.RecordDocumentId(DocumentId);
         recorder.RecordRootPackageId(RootPackageId);
         recorder.RecordExternalDocumentReferenceIdAndRootElement(ExternalDocRefId1, RootPackageId);
-        var results = await relationshipsArrayGenerator.GenerateAsync();
+        var results = await relationshipsArrayGenerator.GenerateAsync(manifestInfos, elementsSpdxIdList);
 
         Assert.AreEqual(0, results.Errors.Count);
         Assert.AreEqual(2, relationships.Count);
@@ -156,7 +155,7 @@ public class RelationshipsArrayGeneratorTest
         recorder.RecordDocumentId(DocumentId);
         recorder.RecordRootPackageId(RootPackageId);
         recorder.RecordPackageId(PackageId1, RootPackageId);
-        var results = await relationshipsArrayGenerator.GenerateAsync();
+        var results = await relationshipsArrayGenerator.GenerateAsync(manifestInfos, elementsSpdxIdList);
 
         Assert.AreEqual(0, results.Errors.Count);
         Assert.AreEqual(2, relationships.Count);
@@ -171,7 +170,7 @@ public class RelationshipsArrayGeneratorTest
     [TestMethod]
     public async Task When_NoGenerationDataExist_NoRelationshipsAreGenerated()
     {
-        var results = await relationshipsArrayGenerator.GenerateAsync();
+        var results = await relationshipsArrayGenerator.GenerateAsync(manifestInfos, elementsSpdxIdList);
 
         Assert.AreEqual(0, results.Errors.Count);
         Assert.AreEqual(0, relationships.Count);

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/ManifestGenerationWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/ManifestGenerationWorkflowTests.cs
@@ -348,7 +348,7 @@ public class ManifestGenerationWorkflowTests
         var externalDocumentReferenceGenerator = new ExternalDocumentReferenceGenerator(mockLogger.Object, sbomConfigs, sourcesProvider, recorderMock.Object);
 
         var elementsSpdxIdList = new HashSet<string>();
-        var generationResult = new GenerationResult(new List<FileValidationResult>(), new Dictionary<IManifestToolJsonSerializer, List<System.Text.Json.JsonDocument>>(), new Dictionary<ISbomConfig, bool>());
+        var generationResult = new GenerationResult(new List<FileValidationResult>(), new Dictionary<IManifestToolJsonSerializer, List<JsonDocument>>(), new Dictionary<ISbomConfig, bool>());
         relationshipArrayGenerator
             .Setup(r => r.GenerateAsync(It.IsAny<IList<ManifestInfo>>(), It.IsAny<HashSet<string>>()))
             .ReturnsAsync(generationResult);

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/ManifestGenerationWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/ManifestGenerationWorkflowTests.cs
@@ -341,7 +341,7 @@ public class ManifestGenerationWorkflowTests
             { externalDocumentReferenceProvider }
         };
 
-        var fileArrayGenerator = new FileArrayGenerator(sbomConfigs, sourcesProvider, recorderMock.Object, mockLogger.Object);
+        var fileArrayGenerator = new FileArrayGenerator(sourcesProvider, recorderMock.Object, mockLogger.Object);
 
         var packageArrayGenerator = new PackageArrayGenerator(mockLogger.Object, sourcesProvider, recorderMock.Object, sbomConfigs);
 
@@ -350,7 +350,7 @@ public class ManifestGenerationWorkflowTests
         var elementsSpdxIdList = new HashSet<string>();
         var generationResult = new GenerationResult(new List<FileValidationResult>(), new Dictionary<IManifestToolJsonSerializer, List<JsonDocument>>(), new Dictionary<ISbomConfig, bool>());
         relationshipArrayGenerator
-            .Setup(r => r.GenerateAsync(It.IsAny<IList<ManifestInfo>>(), It.IsAny<HashSet<string>>()))
+            .Setup(r => r.GenerateAsync(It.IsAny<IList<ISbomConfig>>(), It.IsAny<HashSet<string>>()))
             .ReturnsAsync(generationResult);
 
         var workflow = new SbomGenerationWorkflow(

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/ManifestGenerationWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/ManifestGenerationWorkflowTests.cs
@@ -479,16 +479,12 @@ public class ManifestGenerationWorkflowTests
         var elementsSpdxIdList = new HashSet<string>();
 
         var fileArrayGeneratorMock = new Mock<IJsonArrayGenerator<FileArrayGenerator>>();
-        fileArrayGeneratorMock.Setup(f => f.GenerateAsync(new List<ManifestInfo> { Constants.TestManifestInfo }, elementsSpdxIdList)).ReturnsAsync(generationResultWithFailure);
 
         var packageArrayGeneratorMock = new Mock<IJsonArrayGenerator<PackageArrayGenerator>>();
-        packageArrayGeneratorMock.Setup(f => f.GenerateAsync(new List<ManifestInfo> { Constants.TestManifestInfo }, elementsSpdxIdList)).ReturnsAsync(generationResult);
 
         var relationshipsArrayGeneratorMock = new Mock<IJsonArrayGenerator<RelationshipsArrayGenerator>>();
-        relationshipsArrayGeneratorMock.Setup(f => f.GenerateAsync(new List<ManifestInfo> { Constants.TestManifestInfo }, elementsSpdxIdList)).ReturnsAsync(generationResult);
 
         var externalDocumentReferenceGeneratorMock = new Mock<IJsonArrayGenerator<ExternalDocumentReferenceGenerator>>();
-        externalDocumentReferenceGeneratorMock.Setup(f => f.GenerateAsync(new List<ManifestInfo> { Constants.TestManifestInfo }, elementsSpdxIdList)).ReturnsAsync(generationResult);
 
         var sbomConfigsMock = new Mock<ISbomConfigProvider>();
         sbomConfigsMock.Setup(f => f.TryGet(It.IsAny<ManifestInfo>(), out sbomConfig)).Returns(true);
@@ -525,6 +521,7 @@ public class ManifestGenerationWorkflowTests
         configurationMock.SetupGet(x => x.ManifestInfo).Returns(new ConfigurationSetting<IList<ManifestInfo>> { Value = testManifestInfo, Source = SettingSource.CommandLine });
         fileSystemMock.Setup(f => f.DirectoryExists(It.IsAny<string>())).Returns(true);
         fileSystemMock.Setup(f => f.DeleteDir(It.IsAny<string>(), true)).Verifiable();
+        fileSystemMock.Setup(f => f.IsDirectoryEmpty(It.IsAny<string>())).Returns(true);
 
         var warnings = new List<string>();
         mockLogger.Setup(l => l.Warning(It.IsAny<string>()))


### PR DESCRIPTION
Only iterate through sourcesProviders once and use that as a source of truth to generate all requested manifests. In previous code we were iterating through sourcesProviders once per manifest. This creates performance and data reliability issues.
For example, when we were trying to generate SPDX 2.2 and WdacCatalog manifest files through the drop validator task, which both use the SPDX 2.2 format, the WdacCatalog file was missing data. This data inconsistency was because we were asynchronously iterating through the sourcesProviders for each manifest. This is also a performance issue since we only need to iterate sourcesProviders and use that as a source of truth to generate all requested manifests.

Generate only manifests that are provided in the config rather than all supported configs. If the config is not supported log a warning instead of throwing an exception. This builds on the work that was already done in https://github.com/microsoft/sbom-tool/commit/6fdf28debb12e489b6a1fd995deb8dab326a8a33

Generation is updated to use target configs instead of target manifests. Rather than passing manifests and getting configs based on that, we get the target configs once during SbomGenerationWorkflow and then use that for all the GenerateAsync() method. 

Use generics like IEnumerable and ISet where applicable