### PR TITLE
Tidy interfaces just a bit

### DIFF
--- a/src/Microsoft.Sbom.Api/Executors/ComponentDetectionBaseWalker.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ComponentDetectionBaseWalker.cs
@@ -141,7 +141,7 @@ public abstract class ComponentDetectionBaseWalker
                 {
                     licenseInformationRetrieved = true;
 
-                    List<string> apiResponses;
+                    IList<string> apiResponses;
 
                     apiResponses = await licenseInformationFetcher.FetchLicenseInformationAsync(listOfComponentsForApi, configuration.LicenseInformationTimeoutInSeconds.Value);
 

--- a/src/Microsoft.Sbom.Api/Executors/GenerationResult.cs
+++ b/src/Microsoft.Sbom.Api/Executors/GenerationResult.cs
@@ -13,9 +13,9 @@ namespace Microsoft.Sbom.Api.Workflows.Helpers;
 /// </summary>
 public class GenerationResult
 {
-    public List<FileValidationResult> Errors { get; }
+    public IList<FileValidationResult> Errors { get; }
 
-    public IReadOnlyDictionary<IManifestToolJsonSerializer, List<JsonDocument>> SerializerToJsonDocuments { get; }
+    public IReadOnlyDictionary<IManifestToolJsonSerializer, IList<JsonDocument>> SerializerToJsonDocuments { get; }
 
     public IReadOnlyDictionary<ISbomConfig, bool> JsonArrayStartedForConfig { get; }
 
@@ -25,7 +25,7 @@ public class GenerationResult
     /// <param name="errors">List of FileValidationResult errors.</param>
     /// <param name="serializerToJsonDocuments">Dictionary to map serializer to the JSON document that should be written to it.</param>
     /// <param name="jsonArrayStartedForConfig">This value determines whether a JSON array for a section is started for the specified config. This is only used for SPDX 2.2 SBOM generation.</param>
-    public GenerationResult(List<FileValidationResult> errors, IReadOnlyDictionary<IManifestToolJsonSerializer, List<JsonDocument>> serializerToJsonDocuments, IReadOnlyDictionary<ISbomConfig, bool> jsonArrayStartedForConfig)
+    public GenerationResult(IList<FileValidationResult> errors, IReadOnlyDictionary<IManifestToolJsonSerializer, IList<JsonDocument>> serializerToJsonDocuments, IReadOnlyDictionary<ISbomConfig, bool> jsonArrayStartedForConfig)
     {
         Errors = errors;
         SerializerToJsonDocuments = serializerToJsonDocuments;

--- a/src/Microsoft.Sbom.Api/Executors/GeneratorResult.cs
+++ b/src/Microsoft.Sbom.Api/Executors/GeneratorResult.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Sbom.Api.Workflows.Helpers;
 /// <summary>
 /// Result from GenerateAsync
 /// </summary>
-public class GenerationResult
+public class GeneratorResult
 {
     public IList<FileValidationResult> Errors { get; }
 
@@ -25,7 +25,7 @@ public class GenerationResult
     /// <param name="errors">List of FileValidationResult errors.</param>
     /// <param name="serializerToJsonDocuments">Dictionary to map serializer to the JSON document that should be written to it.</param>
     /// <param name="jsonArrayStartedForConfig">This value determines whether a JSON array for a section is started for the specified config. This is only used for SPDX 2.2 SBOM generation.</param>
-    public GenerationResult(IList<FileValidationResult> errors, IReadOnlyDictionary<IManifestToolJsonSerializer, IList<JsonDocument>> serializerToJsonDocuments, IReadOnlyDictionary<ISbomConfig, bool> jsonArrayStartedForConfig)
+    public GeneratorResult(IList<FileValidationResult> errors, IReadOnlyDictionary<IManifestToolJsonSerializer, IList<JsonDocument>> serializerToJsonDocuments, IReadOnlyDictionary<ISbomConfig, bool> jsonArrayStartedForConfig)
     {
         Errors = errors;
         SerializerToJsonDocuments = serializerToJsonDocuments;

--- a/src/Microsoft.Sbom.Api/Executors/IJsonSerializationStrategy.cs
+++ b/src/Microsoft.Sbom.Api/Executors/IJsonSerializationStrategy.cs
@@ -59,5 +59,5 @@ internal interface IJsonSerializationStrategy
     /// <param name="sbomConfig"></param>
     public void EndGraphArray(ISbomConfig sbomConfig);
 
-    public void WriteJsonObjectsToManifest(GenerationResult generationResult, ISbomConfig config, ISet<string> elementsSpdxIdList);
+    public void WriteJsonObjectsToManifest(GeneratorResult generatorResult, ISbomConfig config, ISet<string> elementsSpdxIdList);
 }

--- a/src/Microsoft.Sbom.Api/Executors/ILicenseInformationFetcher.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ILicenseInformationFetcher.cs
@@ -15,7 +15,7 @@ public interface ILicenseInformationFetcher
     /// </summary>
     /// <param name="scannedComponents"> An IEnumerable of ScannedComponents given by the Component Detection libraries after a scan is completed.</param>
     /// <returns></returns>
-    public List<string> ConvertComponentsToListForApi(IEnumerable<ScannedComponent> scannedComponents);
+    public IList<string> ConvertComponentsToListForApi(IEnumerable<ScannedComponent> scannedComponents);
 
     /// <summary>
     /// Calls the ClearlyDefined API to get the license information for the list of components.
@@ -23,7 +23,7 @@ public interface ILicenseInformationFetcher
     /// <param name="listOfComponentsForApi"> A list of strings formatted into a list of strings that can be used to call the batch ClearlyDefined API.</param>
     /// <param name="timeoutInSeconds">Timeout in seconds to use when making web requests. Caller owns sanitizing this value</param>
     /// <returns></returns>
-    public Task<List<string>> FetchLicenseInformationAsync(List<string> listOfComponentsForApi, int timeoutInSeconds);
+    public Task<IList<string>> FetchLicenseInformationAsync(IList<string> listOfComponentsForApi, int timeoutInSeconds);
 
     /// <summary>
     /// Gets the dictionary of licenses that were fetched from the ClearlyDefined API.

--- a/src/Microsoft.Sbom.Api/Executors/ILicenseInformationFetcher.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ILicenseInformationFetcher.cs
@@ -36,14 +36,14 @@ public interface ILicenseInformationFetcher
     /// </summary>
     /// <param name="httpResponse"> The response from a ClearlyDefined API request.</param>
     /// <returns></returns>
-    public Dictionary<string, string> ConvertClearlyDefinedApiResponseToList(string httpResponseContent);
+    public IDictionary<string, string> ConvertClearlyDefinedApiResponseToList(string httpResponseContent);
 
     /// <summary>
     /// Appends the licenses from the partialLicenseDictionary to the licenseDictionary.
     /// We only request license information for 400 components at a time so we can end up with multiple responses. This function is used to combine the responses into a single dictionary.
     /// </summary>
     /// <param name="partialLicenseDictionary"> A dictionary of licenses and component names in the {name@version, license} format</param>
-    public void AppendLicensesToDictionary(Dictionary<string, string> partialLicenseDictionary);
+    public void AppendLicensesToDictionary(IDictionary<string, string> partialLicenseDictionary);
 
     /// <summary>
     /// Gets the license from the licenseDictionary.

--- a/src/Microsoft.Sbom.Api/Executors/ILicenseInformationService.cs
+++ b/src/Microsoft.Sbom.Api/Executors/ILicenseInformationService.cs
@@ -8,5 +8,5 @@ namespace Microsoft.Sbom.Api.Executors;
 
 public interface ILicenseInformationService
 {
-    public Task<List<string>> FetchLicenseInformationFromAPI(List<string> listOfComponentsForApi, int timeoutInSeconds);
+    public Task<IList<string>> FetchLicenseInformationFromAPI(IList<string> listOfComponentsForApi, int timeoutInSeconds);
 }

--- a/src/Microsoft.Sbom.Api/Executors/LicenseInformationFetcher.cs
+++ b/src/Microsoft.Sbom.Api/Executors/LicenseInformationFetcher.cs
@@ -28,7 +28,7 @@ public class LicenseInformationFetcher : ILicenseInformationFetcher
         this.licenseInformationService = licenseInformationService ?? throw new ArgumentNullException(nameof(licenseInformationService));
     }
 
-    public List<string> ConvertComponentsToListForApi(IEnumerable<ScannedComponent> scannedComponents)
+    public IList<string> ConvertComponentsToListForApi(IEnumerable<ScannedComponent> scannedComponents)
     {
         var listOfComponentsForApi = new List<string>();
 
@@ -82,7 +82,7 @@ public class LicenseInformationFetcher : ILicenseInformationFetcher
         return listOfComponentsForApi;
     }
 
-    public async Task<List<string>> FetchLicenseInformationAsync(List<string> listOfComponentsForApi, int timeoutInSeconds)
+    public async Task<IList<string>> FetchLicenseInformationAsync(IList<string> listOfComponentsForApi, int timeoutInSeconds)
     {
         return await licenseInformationService.FetchLicenseInformationFromAPI(listOfComponentsForApi, timeoutInSeconds);
     }

--- a/src/Microsoft.Sbom.Api/Executors/LicenseInformationFetcher.cs
+++ b/src/Microsoft.Sbom.Api/Executors/LicenseInformationFetcher.cs
@@ -88,7 +88,7 @@ public class LicenseInformationFetcher : ILicenseInformationFetcher
     }
 
     // Will attempt to extract license information from a clearlyDefined batch API response. Will always return a dictionary which may be empty depending on the response.
-    public Dictionary<string, string> ConvertClearlyDefinedApiResponseToList(string httpResponseContent)
+    public IDictionary<string, string> ConvertClearlyDefinedApiResponseToList(string httpResponseContent)
     {
         var extractedLicenses = new Dictionary<string, string>();
 
@@ -142,7 +142,7 @@ public class LicenseInformationFetcher : ILicenseInformationFetcher
         return licenseDictionary;
     }
 
-    public void AppendLicensesToDictionary(Dictionary<string, string> partialLicenseDictionary)
+    public void AppendLicensesToDictionary(IDictionary<string, string> partialLicenseDictionary)
     {
         foreach (var kvp in partialLicenseDictionary)
         {

--- a/src/Microsoft.Sbom.Api/Executors/LicenseInformationService.cs
+++ b/src/Microsoft.Sbom.Api/Executors/LicenseInformationService.cs
@@ -28,7 +28,7 @@ public class LicenseInformationService : ILicenseInformationService
         this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
     }
 
-    public async Task<List<string>> FetchLicenseInformationFromAPI(List<string> listOfComponentsForApi, int timeoutInSeconds)
+    public async Task<IList<string>> FetchLicenseInformationFromAPI(IList<string> listOfComponentsForApi, int timeoutInSeconds)
     {
         var batchSize = 500;
         var responses = new List<HttpResponseMessage>();

--- a/src/Microsoft.Sbom.Api/Executors/Spdx22SerializationStrategy.cs
+++ b/src/Microsoft.Sbom.Api/Executors/Spdx22SerializationStrategy.cs
@@ -76,14 +76,14 @@ internal class Spdx22SerializationStrategy : IJsonSerializationStrategy
     /// <summary>
     /// Writes the json objects to the manifest in SPDX 2.2 format.
     /// </summary>
-    /// <param name="generationResult"></param>
+    /// <param name="generatorResult"></param>
     /// <param name="config"></param>
     /// <param name="elementsSpdxIdList">Not used for deduplication. Only used for >= SPDX 3.0.</param>
-    public void WriteJsonObjectsToManifest(GenerationResult generationResult, ISbomConfig config, ISet<string> elementsSpdxIdList)
+    public void WriteJsonObjectsToManifest(GeneratorResult generatorResult, ISbomConfig config, ISet<string> elementsSpdxIdList)
     {
         var serializer = config.JsonSerializer;
 
-        if (generationResult.SerializerToJsonDocuments.TryGetValue(serializer, out var jsonDocuments))
+        if (generatorResult.SerializerToJsonDocuments.TryGetValue(serializer, out var jsonDocuments))
         {
             if (jsonDocuments.Count > 0)
             {
@@ -94,7 +94,7 @@ internal class Spdx22SerializationStrategy : IJsonSerializationStrategy
             }
         }
 
-        var jsonArrayStarted = generationResult.JsonArrayStartedForConfig[config];
+        var jsonArrayStarted = generatorResult.JsonArrayStartedForConfig[config];
         if (jsonArrayStarted)
         {
             config.JsonSerializer.EndJsonArray();

--- a/src/Microsoft.Sbom.Api/Executors/Spdx30SerializationStrategy.cs
+++ b/src/Microsoft.Sbom.Api/Executors/Spdx30SerializationStrategy.cs
@@ -87,14 +87,14 @@ internal class Spdx30SerializationStrategy : IJsonSerializationStrategy
     /// <summary>
     /// Writes the JSON objects in SPDX 3.0 format.
     /// </summary>
-    /// <param name="generationResult"></param>
+    /// <param name="generatorResult"></param>
     /// <param name="config"></param>
     /// <param name="elementsSpdxIdList">Hashes for deduplication in SPDX 3.0.</param>
-    public void WriteJsonObjectsToManifest(GenerationResult generationResult, ISbomConfig config, ISet<string> elementsSpdxIdList)
+    public void WriteJsonObjectsToManifest(GeneratorResult generatorResult, ISbomConfig config, ISet<string> elementsSpdxIdList)
     {
         var serializer = config.JsonSerializer;
 
-        if (generationResult.SerializerToJsonDocuments.TryGetValue(serializer, out var jsonDocuments))
+        if (generatorResult.SerializerToJsonDocuments.TryGetValue(serializer, out var jsonDocuments))
         {
             foreach (var jsonDocument in jsonDocuments)
             {

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/ExternalDocumentReferenceGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/ExternalDocumentReferenceGenerator.cs
@@ -36,7 +36,7 @@ public class ExternalDocumentReferenceGenerator : IJsonArrayGenerator<ExternalDo
         this.recorder = recorder ?? throw new ArgumentNullException(nameof(recorder));
     }
 
-    public async Task<GenerationResult> GenerateAsync(IEnumerable<ISbomConfig> targetConfigs, ISet<string> elementsSpdxIdList)
+    public async Task<GeneratorResult> GenerateAsync(IEnumerable<ISbomConfig> targetConfigs, ISet<string> elementsSpdxIdList)
     {
         using (recorder.TraceEvent(Events.ExternalDocumentReferenceGeneration))
         {
@@ -50,7 +50,7 @@ public class ExternalDocumentReferenceGenerator : IJsonArrayGenerator<ExternalDo
             if (!externalDocumentReferenceSourcesProvider.Any())
             {
                 log.Debug($"No source providers found for {ProviderType.ExternalDocumentReference}");
-                return new GenerationResult(totalErrors, jsonDocumentCollection.SerializersToJson, jsonArrayStartedForConfig);
+                return new GeneratorResult(totalErrors, jsonDocumentCollection.SerializersToJson, jsonArrayStartedForConfig);
             }
 
             // Write the start of the array, if supported.
@@ -83,16 +83,16 @@ public class ExternalDocumentReferenceGenerator : IJsonArrayGenerator<ExternalDo
                 }
             }
 
-            var generationResult = new GenerationResult(totalErrors, jsonDocumentCollection.SerializersToJson, jsonArrayStartedForConfig);
+            var generatorResult = new GeneratorResult(totalErrors, jsonDocumentCollection.SerializersToJson, jsonArrayStartedForConfig);
             foreach (var config in targetConfigs)
             {
                 var serializationStrategy = JsonSerializationStrategyFactory.GetStrategy(config.ManifestInfo.Version);
-                serializationStrategy.WriteJsonObjectsToManifest(generationResult, config, elementsSpdxIdList);
+                serializationStrategy.WriteJsonObjectsToManifest(generatorResult, config, elementsSpdxIdList);
             }
 
             jsonDocumentCollection.DisposeAllJsonDocuments();
 
-            return generationResult;
+            return generatorResult;
         }
     }
 }

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/FileArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/FileArrayGenerator.cs
@@ -41,7 +41,7 @@ public class FileArrayGenerator : IJsonArrayGenerator<FileArrayGenerator>
     /// <see cref="GenerationResult"/> objects that can be used to trace the error.
     /// </summary>
     /// <returns></returns>
-    public async Task<GenerationResult> GenerateAsync(IEnumerable<ISbomConfig> targetConfigs, ISet<string> elementsSpdxIdList)
+    public async Task<GeneratorResult> GenerateAsync(IEnumerable<ISbomConfig> targetConfigs, ISet<string> elementsSpdxIdList)
     {
         using (recorder.TraceEvent(Events.FilesGeneration))
         {
@@ -81,17 +81,17 @@ public class FileArrayGenerator : IJsonArrayGenerator<FileArrayGenerator>
                 }
             }
 
-            var generationResult = new GenerationResult(totalErrors, jsonDocumentCollection.SerializersToJson, jsonArrayStartedForConfig);
+            var generatorResult = new GeneratorResult(totalErrors, jsonDocumentCollection.SerializersToJson, jsonArrayStartedForConfig);
 
             foreach (var config in targetConfigs)
             {
                 var serializationStrategy = JsonSerializationStrategyFactory.GetStrategy(config.ManifestInfo.Version);
-                serializationStrategy.WriteJsonObjectsToManifest(generationResult, config, elementsSpdxIdList);
+                serializationStrategy.WriteJsonObjectsToManifest(generatorResult, config, elementsSpdxIdList);
             }
 
             jsonDocumentCollection.DisposeAllJsonDocuments();
 
-            return generationResult;
+            return generatorResult;
         }
     }
 }

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/IJsonArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/IJsonArrayGenerator.cs
@@ -16,6 +16,6 @@ public interface IJsonArrayGenerator<T>
     /// <summary>
     /// Generates all the JSON objects that need to be written to the SBOM.
     /// </summary>
-    /// <returns>GenerationResult with objects to write to the SBOM and failures.</returns>
-    public Task<GenerationResult> GenerateAsync(IEnumerable<ISbomConfig> targetConfigs, ISet<string> elementsSpdxIdList);
+    /// <returns>GeneratorResult with objects to write to the SBOM and failures.</returns>
+    public Task<GeneratorResult> GenerateAsync(IEnumerable<ISbomConfig> targetConfigs, ISet<string> elementsSpdxIdList);
 }

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/JsonDocumentCollection.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/JsonDocumentCollection.cs
@@ -8,11 +8,11 @@ namespace Microsoft.Sbom.Api.Workflows.Helpers;
 
 public class JsonDocumentCollection<T>
 {
-    public Dictionary<T, List<JsonDocument>> SerializersToJson { get; }
+    public Dictionary<T, IList<JsonDocument>> SerializersToJson { get; }
 
     public JsonDocumentCollection()
     {
-        SerializersToJson = new Dictionary<T, List<JsonDocument>>();
+        SerializersToJson = new Dictionary<T, IList<JsonDocument>>();
     }
 
     public void AddJsonDocument(T key, JsonDocument document)

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/PackageArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/PackageArrayGenerator.cs
@@ -39,7 +39,7 @@ public class PackageArrayGenerator : IJsonArrayGenerator<PackageArrayGenerator>
         this.recorder = recorder ?? throw new ArgumentNullException(nameof(recorder));
     }
 
-    public async Task<GenerationResult> GenerateAsync(IEnumerable<ISbomConfig> targetConfigs, ISet<string> elementsSpdxIdList)
+    public async Task<GeneratorResult> GenerateAsync(IEnumerable<ISbomConfig> targetConfigs, ISet<string> elementsSpdxIdList)
     {
         using (recorder.TraceEvent(Events.PackagesGeneration))
         {
@@ -101,16 +101,16 @@ public class PackageArrayGenerator : IJsonArrayGenerator<PackageArrayGenerator>
                 }
             }
 
-            var generationResult = new GenerationResult(totalErrors, jsonDocumentCollection.SerializersToJson, jsonArrayStartedForConfig);
+            var generatorResult = new GeneratorResult(totalErrors, jsonDocumentCollection.SerializersToJson, jsonArrayStartedForConfig);
             foreach (var config in targetConfigs)
             {
                 var serializationStrategy = JsonSerializationStrategyFactory.GetStrategy(config.ManifestInfo.Version);
-                serializationStrategy.WriteJsonObjectsToManifest(generationResult, config, elementsSpdxIdList);
+                serializationStrategy.WriteJsonObjectsToManifest(generatorResult, config, elementsSpdxIdList);
             }
 
             jsonDocumentCollection.DisposeAllJsonDocuments();
 
-            return generationResult;
+            return generatorResult;
         }
     }
 }

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/RelationshipsArrayGenerator.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/RelationshipsArrayGenerator.cs
@@ -40,7 +40,7 @@ public class RelationshipsArrayGenerator : IJsonArrayGenerator<RelationshipsArra
         this.recorder = recorder;
     }
 
-    public async Task<GenerationResult> GenerateAsync(IEnumerable<ISbomConfig> targetConfigs, ISet<string> elementsSpdxIdList)
+    public async Task<GeneratorResult> GenerateAsync(IEnumerable<ISbomConfig> targetConfigs, ISet<string> elementsSpdxIdList)
     {
         using (recorder.TraceEvent(Events.RelationshipsGeneration))
         {
@@ -108,16 +108,16 @@ public class RelationshipsArrayGenerator : IJsonArrayGenerator<RelationshipsArra
                 }
             }
 
-            var generationResult = new GenerationResult(totalErrors, jsonDocumentCollection.SerializersToJson, jsonArrayStartedForConfig);
+            var generatorResult = new GeneratorResult(totalErrors, jsonDocumentCollection.SerializersToJson, jsonArrayStartedForConfig);
             foreach (var config in targetConfigs)
             {
                 var serializationStrategy = JsonSerializationStrategyFactory.GetStrategy(config.ManifestInfo.Version);
-                serializationStrategy.WriteJsonObjectsToManifest(generationResult, config, elementsSpdxIdList);
+                serializationStrategy.WriteJsonObjectsToManifest(generatorResult, config, elementsSpdxIdList);
             }
 
             jsonDocumentCollection.DisposeAllJsonDocuments();
 
-            return generationResult;
+            return generatorResult;
         }
     }
 

--- a/src/Microsoft.Sbom.Api/Workflows/SbomGenerationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SbomGenerationWorkflow.cs
@@ -113,19 +113,19 @@ public class SbomGenerationWorkflow : IWorkflow<SbomGenerationWorkflow>
                     });
 
                     // Write all the JSON documents from the generationResults to the manifest based on the manifestInfo.
-                    var fileGenerationResult = await fileArrayGenerator.GenerateAsync(targetConfigs, elementsSpdxIdList);
+                    var fileGeneratorResult = await fileArrayGenerator.GenerateAsync(targetConfigs, elementsSpdxIdList);
 
-                    var packageGenerationResult = await packageArrayGenerator.GenerateAsync(targetConfigs, elementsSpdxIdList);
+                    var packageGeneratorResult = await packageArrayGenerator.GenerateAsync(targetConfigs, elementsSpdxIdList);
 
-                    var externalDocumentReferenceGenerationResult = await externalDocumentReferenceGenerator.GenerateAsync(targetConfigs, elementsSpdxIdList);
+                    var externalDocumentReferenceGeneratorResult = await externalDocumentReferenceGenerator.GenerateAsync(targetConfigs, elementsSpdxIdList);
 
-                    var relationshipGenerationResult = await relationshipsArrayGenerator.GenerateAsync(targetConfigs, elementsSpdxIdList);
+                    var relationshipGeneratorResult = await relationshipsArrayGenerator.GenerateAsync(targetConfigs, elementsSpdxIdList);
 
                     // Concatenate all the errors from the generationResults.
-                    validErrors = validErrors.Concat(fileGenerationResult.Errors);
-                    validErrors = validErrors.Concat(packageGenerationResult.Errors);
-                    validErrors = validErrors.Concat(externalDocumentReferenceGenerationResult.Errors);
-                    validErrors = validErrors.Concat(relationshipGenerationResult.Errors);
+                    validErrors = validErrors.Concat(fileGeneratorResult.Errors);
+                    validErrors = validErrors.Concat(packageGeneratorResult.Errors);
+                    validErrors = validErrors.Concat(externalDocumentReferenceGeneratorResult.Errors);
+                    validErrors = validErrors.Concat(relationshipGeneratorResult.Errors);
 
                     // Write metadata dictionary to SBOM. This is a no-op for SPDX 3.0 and above.
                     ForEachConfig(targetConfigs, config =>

--- a/src/Microsoft.Sbom.Common/Conformance/Interfaces/IConformanceEnforcer.cs
+++ b/src/Microsoft.Sbom.Common/Conformance/Interfaces/IConformanceEnforcer.cs
@@ -16,7 +16,7 @@ public interface IConformanceEnforcer
 
     public string GetConformanceEntityType(string entityType);
 
-    public void AddInvalidElementsIfDeserializationFails(string jsonObjectAsString, JsonSerializerOptions jsonSerializerOptions, HashSet<InvalidElementInfo> invalidElements, Exception e);
+    public void AddInvalidElementsIfDeserializationFails(string jsonObjectAsString, JsonSerializerOptions jsonSerializerOptions, ISet<InvalidElementInfo> invalidElements, Exception e);
 
     public void AddInvalidElements(ElementsResult elementsResult);
 }

--- a/src/Microsoft.Sbom.Common/Conformance/NTIAMinConformanceEnforcer.cs
+++ b/src/Microsoft.Sbom.Common/Conformance/NTIAMinConformanceEnforcer.cs
@@ -36,7 +36,7 @@ public class NTIAMinConformanceEnforcer : IConformanceEnforcer
         }
     }
 
-    public void AddInvalidElementsIfDeserializationFails(string jsonObjectAsString, JsonSerializerOptions jsonSerializerOptions, HashSet<InvalidElementInfo> invalidElements, Exception e)
+    public void AddInvalidElementsIfDeserializationFails(string jsonObjectAsString, JsonSerializerOptions jsonSerializerOptions, ISet<InvalidElementInfo> invalidElements, Exception e)
     {
         try
         {

--- a/src/Microsoft.Sbom.Common/Conformance/NoneConformanceEnforcer.cs
+++ b/src/Microsoft.Sbom.Common/Conformance/NoneConformanceEnforcer.cs
@@ -19,7 +19,7 @@ public class NoneConformanceEnforcer : IConformanceEnforcer
         return entityType.GetCommonEntityType();
     }
 
-    public void AddInvalidElementsIfDeserializationFails(string jsonObjectAsString, JsonSerializerOptions jsonSerializerOptions, HashSet<InvalidElementInfo> invalidElements, Exception e)
+    public void AddInvalidElementsIfDeserializationFails(string jsonObjectAsString, JsonSerializerOptions jsonSerializerOptions, ISet<InvalidElementInfo> invalidElements, Exception e)
     {
         throw new ParserException(e.Message);
     }

--- a/test/Microsoft.Sbom.Api.Tests/Executors/LicenseInformationFetcherTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/LicenseInformationFetcherTests.cs
@@ -146,7 +146,8 @@ public class LicenseInformationFetcherTests
         var expectedValue = "MIT";
         var licenseInformationFetcher = new LicenseInformationFetcher(mockLogger.Object, mockRecorder.Object, mockLicenseInformationService.Object);
 
-        var licensesDictionary = licenseInformationFetcher.ConvertClearlyDefinedApiResponseToList(HttpRequestUtils.GoodClearlyDefinedAPIResponse);
+        var licensesDictionary = new Dictionary<string, string>(
+            licenseInformationFetcher.ConvertClearlyDefinedApiResponseToList(HttpRequestUtils.GoodClearlyDefinedAPIResponse));
 
         CollectionAssert.Contains(licensesDictionary, new KeyValuePair<string, string>(expectedKey, expectedValue));
     }

--- a/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
@@ -190,7 +190,7 @@ public class InterfaceConcretionTests
 
     private class PinnedIJsonArrayGenerator : IJsonArrayGenerator<PinnedIJsonArrayGenerator>
     {
-        public Task<Api.Workflows.Helpers.GenerationResult> GenerateAsync(IEnumerable<ISbomConfig> targetConfigs, ISet<string> elementsSpdxIdList) => throw new NotImplementedException();
+        public Task<GeneratorResult> GenerateAsync(IEnumerable<ISbomConfig> targetConfigs, ISet<string> elementsSpdxIdList) => throw new NotImplementedException();
     }
 
     private class PinnedISbomRedactor : ISbomRedactor
@@ -234,12 +234,12 @@ public class InterfaceConcretionTests
     private class PinnedIMetadataBuilder : IMetadataBuilder
     {
         public string GetHeaderJsonString(IInternalMetadataProvider internalMetadataProvider) => throw new NotImplementedException();
-        public bool TryGetCreationInfoJson(IInternalMetadataProvider internalMetadataProvider, out Extensions.Entities.GenerationResult generationResult) => throw new NotImplementedException();
+        public bool TryGetCreationInfoJson(IInternalMetadataProvider internalMetadataProvider, out GenerationResult generationResult) => throw new NotImplementedException();
         public bool TryGetExternalRefArrayHeaderName(out string headerName) => throw new NotImplementedException();
         public bool TryGetFilesArrayHeaderName(out string headerName) => throw new NotImplementedException();
         public bool TryGetPackageArrayHeaderName(out string headerName) => throw new NotImplementedException();
         public bool TryGetRelationshipsHeaderName(out string headerName) => throw new NotImplementedException();
-        public bool TryGetRootPackageJson(IInternalMetadataProvider internalMetadataProvider, out Extensions.Entities.GenerationResult generationResult) => throw new NotImplementedException();
+        public bool TryGetRootPackageJson(IInternalMetadataProvider internalMetadataProvider, out GenerationResult generationResult) => throw new NotImplementedException();
     }
 
     private class PinnedIManifestToolJsonSerializer : IManifestToolJsonSerializer
@@ -353,7 +353,7 @@ public class InterfaceConcretionTests
     // FormatEnforcedSPDX2
     // FormatValidationResults
     // GenerationData
-    // GenerationResult
+    // GeneratorResult
     // InputConfiguration
     // JsonDocument
     // JsonDocWithSerializer

--- a/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
@@ -74,15 +74,15 @@ public class InterfaceConcretionTests
     {
         public void AppendLicensesToDictionary(Dictionary<string, string> partialLicenseDictionary) => throw new NotImplementedException();
         public Dictionary<string, string> ConvertClearlyDefinedApiResponseToList(string httpResponseContent) => throw new NotImplementedException();
-        public List<string> ConvertComponentsToListForApi(IEnumerable<ScannedComponent> scannedComponents) => throw new NotImplementedException();
-        public Task<List<string>> FetchLicenseInformationAsync(List<string> listOfComponentsForApi, int timeoutInSeconds) => throw new NotImplementedException();
+        public IList<string> ConvertComponentsToListForApi(IEnumerable<ScannedComponent> scannedComponents) => throw new NotImplementedException();
+        public Task<IList<string>> FetchLicenseInformationAsync(IList<string> listOfComponentsForApi, int timeoutInSeconds) => throw new NotImplementedException();
         public string GetFromLicenseDictionary(string key) => throw new NotImplementedException();
         public ConcurrentDictionary<string, string> GetLicenseDictionary() => throw new NotImplementedException();
     }
 
     private class PinnedILicenstInformationService : ILicenseInformationService
     {
-        public Task<List<string>> FetchLicenseInformationFromAPI(List<string> listOfComponentsForApi, int timeoutInSeconds) => throw new NotImplementedException();
+        public Task<IList<string>> FetchLicenseInformationFromAPI(IList<string> listOfComponentsForApi, int timeoutInSeconds) => throw new NotImplementedException();
     }
 
     private class Pinned_SBOMReaderForExternalDocumentReference : ISbomReaderForExternalDocumentReference

--- a/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
@@ -72,8 +72,8 @@ public class InterfaceConcretionTests
 
     private class PinnedILicenseInformationFetcher : ILicenseInformationFetcher
     {
-        public void AppendLicensesToDictionary(Dictionary<string, string> partialLicenseDictionary) => throw new NotImplementedException();
-        public Dictionary<string, string> ConvertClearlyDefinedApiResponseToList(string httpResponseContent) => throw new NotImplementedException();
+        public void AppendLicensesToDictionary(IDictionary<string, string> partialLicenseDictionary) => throw new NotImplementedException();
+        public IDictionary<string, string> ConvertClearlyDefinedApiResponseToList(string httpResponseContent) => throw new NotImplementedException();
         public IList<string> ConvertComponentsToListForApi(IEnumerable<ScannedComponent> scannedComponents) => throw new NotImplementedException();
         public Task<IList<string>> FetchLicenseInformationAsync(IList<string> listOfComponentsForApi, int timeoutInSeconds) => throw new NotImplementedException();
         public string GetFromLicenseDictionary(string key) => throw new NotImplementedException();

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/ManifestGenerationWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/ManifestGenerationWorkflowTests.cs
@@ -44,7 +44,6 @@ using Moq;
 using Newtonsoft.Json.Linq;
 using Checksum = Microsoft.Sbom.Contracts.Checksum;
 using Constants = Microsoft.Sbom.Api.Utils.Constants;
-using GenerationResult = Microsoft.Sbom.Api.Workflows.Helpers.GenerationResult;
 using Generator30 = Microsoft.Sbom.Parsers.Spdx30SbomParser.Generator;
 using IComponentDetector = Microsoft.Sbom.Api.Utils.IComponentDetector;
 using ILogger = Serilog.ILogger;
@@ -348,10 +347,10 @@ public class ManifestGenerationWorkflowTests
         var externalDocumentReferenceGenerator = new ExternalDocumentReferenceGenerator(mockLogger.Object, sbomConfigs, sourcesProvider, recorderMock.Object);
 
         var elementsSpdxIdList = new HashSet<string>();
-        var generationResult = new GenerationResult(new List<FileValidationResult>(), new Dictionary<IManifestToolJsonSerializer, IList<JsonDocument>>(), new Dictionary<ISbomConfig, bool>());
+        var generatorResult = new GeneratorResult(new List<FileValidationResult>(), new Dictionary<IManifestToolJsonSerializer, IList<JsonDocument>>(), new Dictionary<ISbomConfig, bool>());
         relationshipArrayGenerator
             .Setup(r => r.GenerateAsync(It.IsAny<IList<ISbomConfig>>(), It.IsAny<HashSet<string>>()))
-            .ReturnsAsync(generationResult);
+            .ReturnsAsync(generatorResult);
 
         var workflow = new SbomGenerationWorkflow(
             configurationMock.Object,
@@ -469,8 +468,8 @@ public class ManifestGenerationWorkflowTests
         fileSystemMock.Setup(f => f.DirectoryExists(It.IsAny<string>())).Returns(true);
         fileSystemMock.Setup(f => f.DeleteDir(It.IsAny<string>(), true)).Verifiable();
 
-        var generationResult = new GenerationResult(new List<FileValidationResult>(), new Dictionary<IManifestToolJsonSerializer, IList<JsonDocument>>(), new Dictionary<ISbomConfig, bool>());
-        var generationResultWithFailure = new GenerationResult(new List<FileValidationResult> { new FileValidationResult() }, new Dictionary<IManifestToolJsonSerializer, IList<JsonDocument>>(), new Dictionary<ISbomConfig, bool>());
+        var generatorResult = new GeneratorResult(new List<FileValidationResult>(), new Dictionary<IManifestToolJsonSerializer, IList<JsonDocument>>(), new Dictionary<ISbomConfig, bool>());
+        var generatorResultWithFailure = new GeneratorResult(new List<FileValidationResult> { new FileValidationResult() }, new Dictionary<IManifestToolJsonSerializer, IList<JsonDocument>>(), new Dictionary<ISbomConfig, bool>());
 
         var sourcesProviders = new List<ISourcesProvider>
         {

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/ManifestGenerationWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/ManifestGenerationWorkflowTests.cs
@@ -348,7 +348,7 @@ public class ManifestGenerationWorkflowTests
         var externalDocumentReferenceGenerator = new ExternalDocumentReferenceGenerator(mockLogger.Object, sbomConfigs, sourcesProvider, recorderMock.Object);
 
         var elementsSpdxIdList = new HashSet<string>();
-        var generationResult = new GenerationResult(new List<FileValidationResult>(), new Dictionary<IManifestToolJsonSerializer, List<JsonDocument>>(), new Dictionary<ISbomConfig, bool>());
+        var generationResult = new GenerationResult(new List<FileValidationResult>(), new Dictionary<IManifestToolJsonSerializer, IList<JsonDocument>>(), new Dictionary<ISbomConfig, bool>());
         relationshipArrayGenerator
             .Setup(r => r.GenerateAsync(It.IsAny<IList<ISbomConfig>>(), It.IsAny<HashSet<string>>()))
             .ReturnsAsync(generationResult);
@@ -469,8 +469,8 @@ public class ManifestGenerationWorkflowTests
         fileSystemMock.Setup(f => f.DirectoryExists(It.IsAny<string>())).Returns(true);
         fileSystemMock.Setup(f => f.DeleteDir(It.IsAny<string>(), true)).Verifiable();
 
-        var generationResult = new GenerationResult(new List<FileValidationResult>(), new Dictionary<IManifestToolJsonSerializer, List<JsonDocument>>(), new Dictionary<ISbomConfig, bool>());
-        var generationResultWithFailure = new GenerationResult(new List<FileValidationResult> { new FileValidationResult() }, new Dictionary<IManifestToolJsonSerializer, List<JsonDocument>>(), new Dictionary<ISbomConfig, bool>());
+        var generationResult = new GenerationResult(new List<FileValidationResult>(), new Dictionary<IManifestToolJsonSerializer, IList<JsonDocument>>(), new Dictionary<ISbomConfig, bool>());
+        var generationResultWithFailure = new GenerationResult(new List<FileValidationResult> { new FileValidationResult() }, new Dictionary<IManifestToolJsonSerializer, IList<JsonDocument>>(), new Dictionary<ISbomConfig, bool>());
 
         var sourcesProviders = new List<ISourcesProvider>
         {


### PR DESCRIPTION
This PR makes 4 changes to tidy up the 4.0 API surface. Each commit does one thing:

1. [Use ISet instead of HashSet in IConformanceEnforcer](https://github.com/microsoft/sbom-tool/commit/69b520488c85dcc70654ce2467f47edd32c68226)
2. [Use IList instead of List in interfaces](https://github.com/microsoft/sbom-tool/commit/03336a278fc5c7e8d194f786676a16b2787ab7b3)
3. [Use IDictionary instead of Dictionary in ILicenseInformationFetcher](https://github.com/microsoft/sbom-tool/commit/6d6bc8c983168db1e2f78c0a905637c5c6ecbb3c)
4. [Rename GenerationResult back to GeneratorResult](https://github.com/microsoft/sbom-tool/commit/a314b434f8fc38b8d2ea772f842426e48817d82b)