### PR TITLE
Bump component-detection from 5.2.13 to 5.2.19

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     </PackageVersion>
   </ItemDefinitionGroup>
   <PropertyGroup>
-    <ComponentDetectionPackageVersion>5.2.13</ComponentDetectionPackageVersion>
+    <ComponentDetectionPackageVersion>5.2.19</ComponentDetectionPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AutoMapper" Version="10.1.1" />


### PR DESCRIPTION
We need to bump our component-detection version to pick up some changes in the DotNetComponent code.