### PR TITLE
Ensure that SBOM creation time is represented in Gregorian calendar format

### DIFF
--- a/src/Microsoft.Sbom.Common/InternalMetadataProviderIdentityExtensions.cs
+++ b/src/Microsoft.Sbom.Common/InternalMetadataProviderIdentityExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Microsoft.Sbom.Extensions;
 using Microsoft.Sbom.Extensions.Entities;
@@ -157,6 +158,7 @@ public static class InternalMetadataProviderIdentityExtensions
             return generationTimestamp as string;
         }
 
-        return DateTimeOffset.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ");
+        // Use InvariantCulture to ensure Gregorian calendar is always used
+        return DateTimeOffset.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
     }
 }

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Utils/InternalMetadataProviderIdentityExtensionsTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Utils/InternalMetadataProviderIdentityExtensionsTests.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.ComponentModel;
+using System.Globalization;
 using System.Text.RegularExpressions;
+using System.Threading;
 using Microsoft.Sbom.Common;
 using Microsoft.Sbom.Extensions;
 using Microsoft.Sbom.Extensions.Entities;
@@ -184,5 +186,47 @@ public class InternalMetadataProviderIdentityExtensionsTests
         var actualSwidPurl = mdProviderMock.Object.GetSwidTagId();
 
         Assert.IsTrue(Regex.IsMatch(actualSwidPurl, expectedSwidPurlPattern));
+    }
+
+    [TestMethod]
+    public void GetGenerationTimestamp_NonGregorianCalendar()
+    {
+        // Save the current culture
+        var originalCulture = Thread.CurrentThread.CurrentCulture;
+        var originalUICulture = Thread.CurrentThread.CurrentUICulture;
+        try
+        {
+            // Set culture to one that uses a non-Gregorian calendar (e.g., UmAlQuraCalendar)
+            var nonGregorianCulture = new CultureInfo("ar-SA");
+            nonGregorianCulture.DateTimeFormat.Calendar = new UmAlQuraCalendar();
+            Thread.CurrentThread.CurrentCulture = nonGregorianCulture;
+            Thread.CurrentThread.CurrentUICulture = nonGregorianCulture;
+
+            var mdProviderMock = new Mock<IInternalMetadataProvider>();
+            object time = null;
+            mdProviderMock.Setup(m => m.TryGetMetadata(MetadataKey.GenerationTimestamp, out time))
+                .Returns(false);
+
+            var timestamp = mdProviderMock.Object.GetGenerationTimestamp();
+            Assert.IsNotNull(timestamp);
+            try
+            {
+                // Parse the timestamp as UTC using invariant culture
+                var parsedDate = DateTimeOffset.ParseExact(timestamp, "yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
+                var now = DateTimeOffset.UtcNow;
+                // Assert that the generated timestamp year matches UtcNow year
+                Assert.AreEqual(now.Year, parsedDate.Year, $"Timestamp year does not match UtcNow year. Timestamp: {parsedDate}, Now: {now}");
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail($"Exception occurred while parsing or comparing timestamp: {ex.Message}");
+            }
+        }
+        finally
+        {
+            // Restore the original culture
+            Thread.CurrentThread.CurrentCulture = originalCulture;
+            Thread.CurrentThread.CurrentUICulture = originalUICulture;
+        }
     }
 }


### PR DESCRIPTION
The issue was that the string conversion of the datetime needs to specify InvariantCulture so that the year will be represented in Gregorian even if the tool is running on a system using a non-Gregorian calendar. 

#989 