### PR TITLE
Update MSTest and use Combinatorial.MSTest

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -12,9 +12,8 @@
   </PropertyGroup>
   
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
-    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
     <PackageReference Include="MSTest" />
+    <PackageReference Include="Combinatorial.MSTest" />
     <PackageReference Include="Moq" />
   </ItemGroup>
 

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -10,9 +10,8 @@
     </PackageVersion>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.13.1" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="1.6.3" />
-    <PackageVersion Include="MSTest" Version="3.7.3" />
+    <PackageVersion Include="MSTest" Version="3.8.3" />
+    <PackageVersion Include="Combinatorial.MSTest" Version="1.0.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
   </ItemGroup>
 </Project>

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/ManifestGenerationWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/ManifestGenerationWorkflowTests.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading.Channels;
 using System.Threading.Tasks;
+using Combinatorial.MSTest;
 using Microsoft.ComponentDetection.Contracts;
 using Microsoft.ComponentDetection.Contracts.BcdeModels;
 using Microsoft.ComponentDetection.Contracts.TypedComponent;
@@ -79,15 +80,11 @@ public class ManifestGenerationWorkflowTests
     }
 
     [TestMethod]
-    [DataRow("test", true, true)]
-    [DataRow("test", false, false)]
-    [DataRow("test", true, false)]
-    [DataRow("test", false, true)]
-    [DataRow("3.0", true, true)]
-    [DataRow("3.0", false, false)]
-    [DataRow("3.0", true, false)]
-    [DataRow("3.0", false, true)]
-    public async Task ManifestGenerationWorkflowTests_Succeeds(string spdxVersionForGenerator, bool deleteExistingManifestDir, bool isDefaultSourceManifestDirPath)
+    [CombinatorialData]
+    public async Task ManifestGenerationWorkflowTests_Succeeds(
+        [CombinatorialValues("test", "3.0")] string spdxVersionForGenerator,
+        bool deleteExistingManifestDir,
+        bool isDefaultSourceManifestDirPath)
     {
         var manifestInfoPerSpdxVersion = new Dictionary<string, ManifestInfo>
         {


### PR DESCRIPTION
This PR updates MSTest to current latest stable, simplifes TrxReport and CC references which are now transitive dependency of MSTest metapackage, and also uses https://github.com/Youssef1313/Combinatorial.MSTest (**NOTE:** *The package is **not** maintained by Microsoft*) to simplify `ManifestGenerationWorkflowTests_Succeeds`