### PR TITLE
explicitly reference Serilog

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,6 +38,7 @@
     <PackageVersion Include="packageurl-dotnet" Version="1.1.0" />
     <PackageVersion Include="PowerArgs" Version="3.6.0" />
     <PackageVersion Include="Scrutor" Version="6.0.1" />
+    <PackageVersion Include="Serilog" Version="4.3.0" />
     <PackageVersion Include="Serilog.Extensions.Hosting" Version="8.0.0" />
     <PackageVersion Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />

--- a/src/Microsoft.Sbom.Api/Microsoft.Sbom.Api.csproj
+++ b/src/Microsoft.Sbom.Api/Microsoft.Sbom.Api.csproj
@@ -21,6 +21,7 @@
         <PackageReference Include="NuGet.Configuration" />
         <PackageReference Include="packageurl-dotnet" />
         <PackageReference Include="PowerArgs" />
+        <PackageReference Include="Serilog" />
         <PackageReference Include="Serilog.Extensions.Hosting" />
         <PackageReference Include="Serilog.Sinks.Console" />
         <PackageReference Include="Spectre.Console.Cli" />

--- a/src/Microsoft.Sbom.Common/Microsoft.Sbom.Common.csproj
+++ b/src/Microsoft.Sbom.Common/Microsoft.Sbom.Common.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Serilog" />
     <PackageReference Include="Serilog.Sinks.Console" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" />
     <PackageReference Include="System.Private.Uri" />

--- a/src/Microsoft.Sbom.Extensions.DependencyInjection/Microsoft.Sbom.Extensions.DependencyInjection.csproj
+++ b/src/Microsoft.Sbom.Extensions.DependencyInjection/Microsoft.Sbom.Extensions.DependencyInjection.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Scrutor" />
+    <PackageReference Include="Serilog" />
     <PackageReference Include="Serilog.Sinks.Async" />
     <PackageReference Include="Serilog.Sinks.Console" />
     <PackageReference Include="Serilog.Sinks.File" />

--- a/test/Microsoft.Sbom.Extensions.DependencyInjection.Tests/Microsoft.Sbom.Extensions.DependencyInjection.Tests.csproj
+++ b/test/Microsoft.Sbom.Extensions.DependencyInjection.Tests/Microsoft.Sbom.Extensions.DependencyInjection.Tests.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Serilog" />
     <PackageReference Include="Serilog.Sinks.Console" />
   </ItemGroup>
 


### PR DESCRIPTION
given downstream extensions to Serilog do not deploy when a new version of Serilog is deployed, it is better to explicitly reference Serilog so we get the current stable version