### PR TITLE
fix some incorrect as usages in GetDocumentNamespaceUri

### DIFF
--- a/src/Microsoft.Sbom.Api/MetaData/SbomApiMetadataProvider.cs
+++ b/src/Microsoft.Sbom.Api/MetaData/SbomApiMetadataProvider.cs
@@ -48,8 +48,8 @@ public class SbomApiMetadataProvider : IMetadataProvider
     public string GetDocumentNamespaceUri()
     {
         var nsUniquePart = Uri.EscapeDataString(configuration.NamespaceUriUniquePart?.Value ?? IdentifierUtils.GetShortGuid(Guid.NewGuid()));
-        var packageName = Uri.EscapeDataString(MetadataDictionary[MetadataKey.PackageName] as string);
-        var packageVersion = Uri.EscapeDataString(MetadataDictionary[MetadataKey.PackageVersion] as string);
+        var packageName = Uri.EscapeDataString((string)MetadataDictionary[MetadataKey.PackageName]);
+        var packageVersion = Uri.EscapeDataString((string)MetadataDictionary[MetadataKey.PackageVersion]);
 
         return string.Join("/", configuration.NamespaceUriBase.Value, packageName, packageVersion, nsUniquePart);
     }


### PR DESCRIPTION
the assumption seems to be that these values must be non nullable strings. since if they are null or not strings, it would result in a null ref inside EscapeDataString.

so it is better to do a cast. and if the assumption is ever incorrect, the exception will occur earlier and be more accurate