### PR TITLE
Add IsPackable to target condition

### DIFF
--- a/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.targets
+++ b/src/Microsoft.Sbom.Targets/Microsoft.Sbom.Targets.targets
@@ -35,7 +35,7 @@
   </PropertyGroup>
 
   <!-- After the Nuget Package is generated, we will unzip, scan, generate the SBOM and zip again. -->
-  <Target Name="GenerateSbomTarget" AfterTargets="Pack" Condition=" '$(GenerateSBOM)' ==  'true'" >
+  <Target Name="GenerateSbomTarget" AfterTargets="Pack" Condition="'$(IsPackable)' == 'true' AND '$(GenerateSBOM)' ==  'true'" >
     <!-- Unzip Nuget package, so it can be scanned by the SBOM Task. -->
     <PropertyGroup>
       <PackageOutputFullPath>$([System.IO.Path]::GetFullPath('$(PackageOutputPath)'))</PackageOutputFullPath>


### PR DESCRIPTION
This PR adds `'$(IsPackable)' == 'true'` to the condition that controls if `GenerateSbomTarget` will run.

Fixes #1074 