### PR TITLE
simplify HashAlgorithmProvider

### DIFF
--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsBase.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigurationBuilderTestsBase.cs
@@ -44,7 +44,6 @@ public class ConfigurationBuilderTestsBase
         };
 
         var hashAlgorithmProvider = new HashAlgorithmProvider(new IAlgorithmNames[] { new AlgorithmNames() });
-        hashAlgorithmProvider.Init();
 
         var configSanitizer = new ConfigSanitizer(hashAlgorithmProvider, fileSystemUtilsMock.Object, mockAssemblyConfig.Object);
         object Ctor(Type type)


### PR DESCRIPTION
 * use linq for building the dictionary. in this scenario i like this for readability. but let me know if u prefer the loop style
 * make the dictionary keyed on InvariantCultureIgnoreCase
 * remove redundant init
 * avoid keeping the algorithmNamesList enumerable in memory