### PR TITLE
Remove lazy reflection

### DIFF
--- a/src/Microsoft.Sbom.Api/Config/ConfigSanitizer.cs
+++ b/src/Microsoft.Sbom.Api/Config/ConfigSanitizer.cs
@@ -28,9 +28,7 @@ public class ConfigSanitizer
     private readonly IFileSystemUtils fileSystemUtils;
     private readonly IAssemblyConfig assemblyConfig;
 
-    internal static string SbomToolVersion => VersionValue.Value;
-
-    private static readonly Lazy<string> VersionValue = new Lazy<string>(() => typeof(SbomToolCmdRunner).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? string.Empty);
+    internal static string SbomToolVersion { get; } = typeof(SbomToolCmdRunner).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? string.Empty;
 
     public ConfigSanitizer(IHashAlgorithmProvider hashAlgorithmProvider, IFileSystemUtils fileSystemUtils, IAssemblyConfig assemblyConfig)
     {

--- a/src/Microsoft.Sbom.Api/Config/SbomToolCmdRunner.cs
+++ b/src/Microsoft.Sbom.Api/Config/SbomToolCmdRunner.cs
@@ -14,12 +14,7 @@ namespace Microsoft.Sbom.Api.Config;
 [ArgProductName("sbom-tool")]
 public class SbomToolCmdRunner
 {
-    internal static string SbomToolVersion => VersionValue.Value;
-
-    private static readonly Lazy<string> VersionValue = new Lazy<string>(() =>
-    {
-        return typeof(SbomToolCmdRunner).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? string.Empty;
-    });
+    internal static string SbomToolVersion { get; } = typeof(SbomToolCmdRunner).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? string.Empty;
 
     /// <summary>
     /// Gets or sets a value indicating whether displays help info.

--- a/src/Microsoft.Sbom.Api/MetaData/LocalMetadataProvider.cs
+++ b/src/Microsoft.Sbom.Api/MetaData/LocalMetadataProvider.cs
@@ -20,10 +20,7 @@ public class LocalMetadataProvider : IMetadataProvider, IDefaultMetadataProvider
     private const string ProductName = "Microsoft.SBOMTool";
     private const string BuildEnvironmentNameValue = "local";
 
-    private static readonly Lazy<string> Version = new Lazy<string>(() =>
-    {
-        return typeof(LocalMetadataProvider).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? string.Empty;
-    });
+    private static readonly string Version = typeof(LocalMetadataProvider).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? string.Empty;
 
     public string BuildEnvironmentName => BuildEnvironmentNameValue;
 

--- a/src/Microsoft.Sbom.Api/MetaData/LocalMetadataProvider.cs
+++ b/src/Microsoft.Sbom.Api/MetaData/LocalMetadataProvider.cs
@@ -45,7 +45,7 @@ public class LocalMetadataProvider : IMetadataProvider, IDefaultMetadataProvider
                 { MetadataKey.SbomToolName, ProductName },
 
                 // TODO get tool version from dll manifest.
-                { MetadataKey.SbomToolVersion, Version.Value }
+                { MetadataKey.SbomToolVersion, Version }
             };
 
             // Add the package name if available.


### PR DESCRIPTION
so the several uses of this pattern surprised me
```
private static readonly Lazy<string> VersionValue = new Lazy<string>(() => typeof(SbomToolCmdRunner).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? string.Empty);
```

given the reflection perf, i did not think Lazy would speed anything up. given the slight overhead of Lazy compared to the cost of reflection. so i did some simplistic timings
# Raw

## Init

```
var watch = Stopwatch.StartNew();
var value = typeof(SbomToolCmdRunner).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? string.Empty;
Console.WriteLine(watch.Elapsed);
```

00:00:00.0000279 (.0279 ms)


## Subsequent

this is putting a static pointer the stack. so single digit nanoseconds


# Lazy


## Init

```
var watch = Stopwatch.StartNew();
var lazy = new Lazy<string>(() => typeof(SbomToolCmdRunner).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? string.Empty);
Console.WriteLine(watch.Elapsed);
```

00:00:00.0000036 (.0036 ms)


## Subsequent

```
var lazy = new Lazy<string>(() => typeof(SbomToolCmdRunner).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? string.Empty);
var value1 = lazy.Value;
var watch = Stopwatch.StartNew();
var value2 = lazy.Value;
Console.WriteLine(watch.Elapsed);
```

00:00:00.0000024 (.0024 ms)


# Outcome

So it seems we are saving ~.0243ms at startup for an additional cost of ~.002 ms per subsequent call.

IMO this is not a good tradeoff.

But given the above numbers above are so small, i dont think this is really a performance conversation, IMO use of Lazy to defer a single static reflection call is a premature optimization
