### PR TITLE
move to sdk 9

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "9.0.300",
     "rollForward": "latestMajor"
   }
 }


### PR DESCRIPTION
to avoid using an sdk with a cve
https://github.com/dotnet/announcements/issues/329

