### PR TITLE
remove this prefix requirement

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -81,10 +81,10 @@ dotnet_analyzer_diagnostic.severity = warning
 # https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules#net-style-rules
 [*.{cs,csx,cake,vb,vbx}]
 # "this." and "Me." qualifiers
-dotnet_style_qualification_for_field = true
-dotnet_style_qualification_for_property = true
-dotnet_style_qualification_for_method = true
-dotnet_style_qualification_for_event = true:warning
+dotnet_style_qualification_for_field = false
+dotnet_style_qualification_for_property = false
+dotnet_style_qualification_for_method = false
+dotnet_style_qualification_for_event = false
 # Language keywords instead of framework type names for type references
 dotnet_style_predefined_type_for_locals_parameters_members = true:warning
 dotnet_style_predefined_type_for_member_access = true:warning


### PR DESCRIPTION
seems the majority of the code does not use the `this.` qualifier

![image](https://github.com/user-attachments/assets/533e9fd4-2d38-4672-ba44-9f3246d14222)

using static analysis, 

 * 2218 without the use of `this.`
 * 2139 with the use of `this.`

I would like to settle on one and make it an error, or at least a warning. noting that this pr just makes it a suggestion.

