### PR TITLE
remove build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # SBOM Tool
 
-[![Build](https://github.com/microsoft/sbom-tool/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/microsoft/sbom-tool/actions/workflows/build.yml)
 ![GitHub all releases](https://img.shields.io/github/downloads/microsoft/sbom-tool/total)
 ![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/microsoft/sbom-tool?include_prereleases)
 


### PR DESCRIPTION
seems the build was moved to a non public devops instance.

fixes #1057