### PR TITLE
Create GitHub-targeted artifacts

### DIFF
--- a/pipelines/sbom-tool-main-build.yaml
+++ b/pipelines/sbom-tool-main-build.yaml
@@ -43,6 +43,9 @@ extends:
           templateContext:
             outputs:
             - output: pipelineArtifact
+              targetPath: $(Build.ArtifactStagingDirectory)\GitHub
+              artifactName: '$(OutputArtifactName)-GitHub'
+            - output: pipelineArtifact
               targetPath: $(Build.ArtifactStagingDirectory)
               artifactName: '$(OutputArtifactName)'
           pool:
@@ -200,10 +203,18 @@ extends:
               Remove-Item $(Build.ArtifactStagingDirectory)\win -Recurse
             displayName: 'Restructure Artifact'
 
+          - powershell: |
+              New-Item $(Build.ArtifactStagingDirectory)\GitHub -ItemType Directory
+              Copy-Item -Path $(Build.ArtifactStagingDirectory)\bin\$(BinaryNameWindows) -Destination $(Build.ArtifactStagingDirectory)\GitHub\$(BinaryNameWindows)
+            displayName: 'Copy Artifact for GitHub release'
+
         - job: Job_2
           displayName: 'Build (Linux)'
           templateContext:
             outputs:
+            - output: pipelineArtifact
+              targetPath: $(Build.ArtifactStagingDirectory)/GitHub
+              artifactName: '$(OutputArtifactName)-GitHub-linux'
             - output: pipelineArtifact
               targetPath: $(Build.ArtifactStagingDirectory)
               artifactName: '$(OutputArtifactName)-linux'
@@ -233,10 +244,18 @@ extends:
               Remove-Item $(Build.ArtifactStagingDirectory)/linux -Recurse
             displayName: 'Restructure Artifact'
 
+          - powershell: |
+              New-Item $(Build.ArtifactStagingDirectory)/GitHub -ItemType Directory
+              Copy-Item -Path $(Build.ArtifactStagingDirectory)/bin/$(BinaryNameLinux) -Destination $(Build.ArtifactStagingDirectory)/GitHub/$(BinaryNameLinux)
+            displayName: 'Copy Artifact for GitHub release'
+
         - job: Job_3
           displayName: 'Build (macOS)'
           templateContext:
             outputs:
+            - output: pipelineArtifact
+              targetPath: $(Build.ArtifactStagingDirectory)/GitHub
+              artifactName: '$(OutputArtifactName)-GitHub-macOS'
             - output: pipelineArtifact
               targetPath: $(Build.ArtifactStagingDirectory)
               artifactName: '$(OutputArtifactName)-macOS'
@@ -267,10 +286,18 @@ extends:
               Remove-Item $(Build.ArtifactStagingDirectory)/osx -Recurse
             displayName: 'Restructure Artifact'
 
+          - powershell: |
+              New-Item $(Build.ArtifactStagingDirectory)/GitHub -ItemType Directory
+              Copy-Item -Path $(Build.ArtifactStagingDirectory)/bin/$(BinaryNameMacOS) -Destination $(Build.ArtifactStagingDirectory)/GitHub/$(BinaryNameMacOS)
+            displayName: 'Copy Artifact for GitHub release'
+
         - job: Job_4
           displayName: 'Build (macOS-arm64)'
           templateContext:
             outputs:
+            - output: pipelineArtifact
+              targetPath: $(Build.ArtifactStagingDirectory)/GitHub
+              artifactName: '$(OutputArtifactName)-GitHub-macOS-arm64'
             - output: pipelineArtifact
               targetPath: $(Build.ArtifactStagingDirectory)
               artifactName: '$(OutputArtifactName)-macOS-arm64'
@@ -300,3 +327,8 @@ extends:
               Move-Item -Path $(Build.ArtifactStagingDirectory)/osx-arm64/$(BinaryNameMacOSArm64) -Destination $(Build.ArtifactStagingDirectory)/bin/$(BinaryNameMacOSArm64)
               Remove-Item $(Build.ArtifactStagingDirectory)/osx-arm64 -Recurse
             displayName: 'Restructure Artifact'
+
+          - powershell: |
+              New-Item $(Build.ArtifactStagingDirectory)/GitHub -ItemType Directory
+              Copy-Item -Path $(Build.ArtifactStagingDirectory)/bin/$(BinaryNameMacOSArm64) -Destination $(Build.ArtifactStagingDirectory)/GitHub/$(BinaryNameMacOSArm64)
+            displayName: 'Copy Artifact for GitHub release'


### PR DESCRIPTION
The SBOMs that we release to GitHub is based on the root of the artifacts tree. Its file list includes the NuPkgs folder and some miscellaneous build artifacts from Component Governance. Anyone wanting to validate our drop files needs to set the flag to ignore missing files.

This PR creates separate artifacts for each of the binaries that we ship via GitHub releases. Each artifact has an SBOM, so they're much more effectively scoped. Ideally they would have just 1 entry in the files section, but they have 2 because a sample SBOM is being listed in the files section instead of just in the eternaldocref section. This unwanted duplication is tracked at #956. Once that is also fixed, the resulting SBOMs will have just 1 entry in the files section.

Test build from this branch can be found at https://dev.azure.com/mseng/AzureDevOps/_build/results?buildId=30006697&view=artifacts&pathAsName=false&type=publishedArtifacts. Here is a screenshot of the new artifacts, each containing just the shipping file and the associated manifest folder:

<img width="456" alt="image" src="https://github.com/user-attachments/assets/07f1570f-dcbf-4319-abe0-eae936e6442c" />


