### PR TITLE
Complete the stubbed plumbing for Consolidate action

### DIFF
--- a/src/Microsoft.Sbom.Api/Config/ConfigurationBuilder.cs
+++ b/src/Microsoft.Sbom.Api/Config/ConfigurationBuilder.cs
@@ -45,6 +45,10 @@ public class ConfigurationBuilder<T> : IConfigurationBuilder<T>
                 formatValidationArgs.ManifestToolAction = ManifestToolActions.ValidateFormat;
                 commandLineArgs = mapper.Map<InputConfiguration>(formatValidationArgs);
                 break;
+            case ConsolidationArgs consolidationArgs:
+                consolidationArgs.ManifestToolAction = ManifestToolActions.Consolidate;
+                commandLineArgs = mapper.Map<InputConfiguration>(consolidationArgs);
+                break;
             default:
                 throw new ValidationArgException($"Unsupported configuration type found {typeof(T)}");
         }

--- a/src/Microsoft.Sbom.Api/ConfigurationProfile.cs
+++ b/src/Microsoft.Sbom.Api/ConfigurationProfile.cs
@@ -112,6 +112,8 @@ public class ConfigurationProfile : Profile
             .ForMember(c => c.DeleteManifestDirIfPresent, o => o.Ignore())
             .ForMember(c => c.PackageSupplier, o => o.Ignore());
 
+        CreateMap<ConsolidationArgs, InputConfiguration>();
+
         // Create config for the config json file to configuration.
         CreateMap<ConfigFile, InputConfiguration>()
             .ForMember(c => c.PackagesList, o => o.Ignore())

--- a/src/Microsoft.Sbom.Api/Workflows/SbomConsolidationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SbomConsolidationWorkflow.cs
@@ -3,12 +3,28 @@
 
 namespace Microsoft.Sbom.Api.Workflows;
 
+using System;
 using System.Threading.Tasks;
+using Serilog;
 
 public class SbomConsolidationWorkflow : IWorkflow<SbomConsolidationWorkflow>
 {
+    private readonly ILogger logger;
+
+    public SbomConsolidationWorkflow(ILogger logger)
+    {
+        this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
     /// <inheritdoc/>
 #pragma warning disable CS1998 // Placeholder, will use async in the future.
-    public virtual async Task<bool> RunAsync() => true;
+    public virtual async Task<bool> RunAsync()
+    {
+        // Placeholder for the actual implementation of the SBOM consolidation workflow.
+        // This method should contain the logic to consolidate SBOMs as per the requirements.
+        // For now, it logs and returns true to indicate success.
+        logger.Information("Placeholder SBOM consolidation workflow executed.");
+        return true;
+    }
 #pragma warning restore CS1998 // Placeholder, will use async in the future.
 }

--- a/src/Microsoft.Sbom.Common/Config/ManifestToolActions.cs
+++ b/src/Microsoft.Sbom.Common/Config/ManifestToolActions.cs
@@ -13,5 +13,6 @@ public enum ManifestToolActions
     Generate = 2,
     Redact = 4,
     ValidateFormat = 8,
-    All = Validate | Generate | Redact | ValidateFormat
+    Consolidate = 16,
+    All = Validate | Generate | Redact | ValidateFormat | Consolidate
 }

--- a/src/Microsoft.Sbom.DotNetTool/ConsolidationService.cs
+++ b/src/Microsoft.Sbom.DotNetTool/ConsolidationService.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Sbom.Api;
+using Microsoft.Sbom.Api.Exceptions;
+using Microsoft.Sbom.Api.Output.Telemetry;
+using Microsoft.Sbom.Api.Workflows;
+
+namespace Microsoft.Sbom.Tool;
+
+public class ConsolidationService : IHostedService
+{
+    private readonly IWorkflow<SbomConsolidationWorkflow> consolidationWorkflow;
+    private readonly IRecorder recorder;
+    private readonly IHostApplicationLifetime hostApplicationLifetime;
+
+    public ConsolidationService(
+        IWorkflow<SbomConsolidationWorkflow> consolidationWorkflow,
+        IRecorder recorder,
+        IHostApplicationLifetime hostApplicationLifetime)
+    {
+        this.consolidationWorkflow = consolidationWorkflow;
+        this.recorder = recorder;
+        this.hostApplicationLifetime = hostApplicationLifetime;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await consolidationWorkflow.RunAsync();
+            await recorder.FinalizeAndLogTelemetryAsync();
+            Environment.ExitCode = result ? (int)ExitCode.Success : (int)ExitCode.GeneralError;
+        }
+        catch (AccessDeniedValidationArgException e)
+        {
+            var message = e.InnerException != null ? e.InnerException.Message : e.Message;
+            Console.WriteLine($"Encountered error while running ManifestTool consolidation workflow. Error: {message}");
+            Environment.ExitCode = (int)ExitCode.WriteAccessError;
+        }
+        catch (Exception e)
+        {
+            var message = e.InnerException != null ? e.InnerException.Message : e.Message;
+            Console.WriteLine($"Encountered error while running ManifestTool consolidation workflow. Error: {message}");
+            Environment.ExitCode = (int)ExitCode.GeneralError;
+        }
+
+        hostApplicationLifetime.StopApplication();
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/src/Microsoft.Sbom.Tool/Program.cs
+++ b/src/Microsoft.Sbom.Tool/Program.cs
@@ -35,6 +35,7 @@ internal class Program
                     {
                         ValidationArgs => services.AddHostedService<ValidationService>(),
                         GenerationArgs => services.AddHostedService<GenerationService>(),
+                        ConsolidationArgs => services.AddHostedService<ConsolidationService>(),
                         RedactArgs => services.AddHostedService<RedactService>(),
                         FormatValidationArgs => services.AddHostedService<FormatValidationService>(),
                         _ => services


### PR DESCRIPTION
PR #1104 compiled and passed all E2E tests, but was unable to get code into the `SbomConsolidationWorkflow` class. This adds more plumbing so that when we execute `sbomtool.exe consolidate`, we get into the correct workflow. I'll add the config mapping in a subsequent PR.

I discovered with this PR that we have separate implementations of *Service.cs in the `Microsoft.Sbom.Tool` and `DotNetTool` projects. Most of the existing duplicated classes are _mostly_ in sync, with some larger differences in ValidationService.cs. This feels like a significant violation of the DRY principle, but untangling it right is out of scope. The same `Program.cs` file gets used in both projects, so maybe that's a potential future pattern to sort things out.