### PR TITLE
Add SPDXFormatDetector for SPDX version detection

### DIFF
--- a/src/Microsoft.Sbom.Api/Utils/ISPDXFormatDetector.cs
+++ b/src/Microsoft.Sbom.Api/Utils/ISPDXFormatDetector.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using Microsoft.Sbom.Extensions.Entities;
+
+namespace Microsoft.Sbom.Api.Utils;
+
+public interface ISPDXFormatDetector
+{
+    public bool TryDetectFormat(string filePath, out ManifestInfo detectedManifestInfo);
+
+    public bool TryDetectFormat(Stream stream, out ManifestInfo detectedManifestInfo);
+}

--- a/src/Microsoft.Sbom.Api/Utils/SPDXFormatDetector.cs
+++ b/src/Microsoft.Sbom.Api/Utils/SPDXFormatDetector.cs
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Sbom.Api.Manifest;
+using Microsoft.Sbom.Common;
+using Microsoft.Sbom.Extensions.Entities;
+using Microsoft.Sbom.JsonAsynchronousNodeKit;
+using Microsoft.Sbom.Parser;
+
+namespace Microsoft.Sbom.Api.Utils;
+
+public class SPDXFormatDetector : ISPDXFormatDetector
+{
+    private readonly IFileSystemUtils fileSystemUtils;
+    private readonly IManifestParserProvider manifestParserProvider;
+    private readonly IDictionary<ManifestInfo, Func<ISbomParser, Stream, bool>> supportedManifestInfos;
+
+    public SPDXFormatDetector(
+        IFileSystemUtils fileSystemUtils,
+        IManifestParserProvider manifestParserProvider)
+    {
+        this.fileSystemUtils = fileSystemUtils;
+        this.manifestParserProvider = manifestParserProvider;
+        supportedManifestInfos = new Dictionary<ManifestInfo, Func<ISbomParser, Stream, bool>>()
+        {
+            { ManifestInfo.Parse("SPDX:2.2"), TryParse22 },
+            { ManifestInfo.Parse("SPDX:3.0"), TryParse30 }
+        };
+    }
+
+    public bool TryDetectFormat(string filePath, out ManifestInfo detectedManifestInfo)
+    {
+        using var stream = fileSystemUtils.OpenRead(filePath);
+        return TryDetectFormat(stream, out detectedManifestInfo);
+    }
+
+    public bool TryDetectFormat(Stream stream, out ManifestInfo detectedManifestInfo)
+    {
+        foreach (var (mi, tryParse) in supportedManifestInfos)
+        {
+            var manifestInterface = manifestParserProvider.Get(mi);
+            var sbomParser = manifestInterface.CreateParser(stream);
+
+            if (tryParse(sbomParser, stream))
+            {
+                detectedManifestInfo = mi;
+                return true;
+            }
+        }
+
+        detectedManifestInfo = null;
+        return false;
+    }
+
+    private bool TryParse22(ISbomParser parser, Stream stream)
+    {
+        try
+        {
+            ParserStateResult? result = null;
+            var requiredFieldsFound = 0;
+            do
+            {
+                result = parser.Next();
+                if (result is not null)
+                {
+                    switch (result.FieldName)
+                    {
+                        case SPDXParser.FilesProperty:
+                        case SPDXParser.PackagesProperty:
+                        case SPDXParser.ReferenceProperty:
+                        case SPDXParser.RelationshipsProperty:
+                            requiredFieldsFound++;
+                            break;
+                        default:
+                            break;
+                    }
+                }
+            }
+            while (result is not null && requiredFieldsFound < 4);
+
+            return requiredFieldsFound == 4;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private bool TryParse30(ISbomParser parser, Stream stream)
+    {
+        try
+        {
+            ParserStateResult? result = null;
+            var requiredFieldsFound = 0;
+            do
+            {
+                result = parser.Next();
+
+                if (result is not null && result.Result is not null)
+                {
+                    switch (result.FieldName)
+                    {
+                        case Constants.SPDXContextHeaderName:
+                        case Constants.SPDXGraphHeaderName:
+                            requiredFieldsFound++;
+                            break;
+                        default:
+                            break;
+                    }
+                }
+            }
+            while (result is not null && requiredFieldsFound < 2);
+
+            return requiredFieldsFound == 2;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/test/Microsoft.Sbom.Api.Tests/Utils/SPDXFormatDetectorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Utils/SPDXFormatDetectorTests.cs
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using Microsoft.Sbom.Api.Manifest;
+using Microsoft.Sbom.Api.Utils;
+using Microsoft.Sbom.Common;
+using Microsoft.Sbom.Extensions;
+using Microsoft.Sbom.Extensions.Entities;
+using Microsoft.Sbom.Parser;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.Sbom.Api.Tests.Utils;
+
+[TestClass]
+public class SPDXFormatDetectorTests
+{
+    private Mock<IFileSystemUtils> mockFileSystemUtils;
+    private Mock<IManifestParserProvider> mockManifestParserProvider;
+    private Mock<IManifestInterface> mock22ManifestInterface;
+    private Mock<IManifestInterface> mock30ManifestInterface;
+    private SPDXFormatDetector testSubject;
+
+    private const string FilePathStub = "file-path";
+    private const string Spdx22VersionStub = "SPDX:2.2";
+    private const string Spdx30VersionStub = "SPDX:3.0";
+    private const string Spdx22ContentStub = @"{""files"":[],""packages"":[],""relationships"":[],""externalDocumentRefs"":[]}";
+    private const string Spdx30ContentStub = @"{""@context"": [""https://Spdx.org/rdf/3.0.1/Spdx-context.jsonld""],""@graph"": []}";
+    private const string InvalidContentStub = "invalid-content";
+
+    [TestInitialize]
+    public void SetUp()
+    {
+        mockFileSystemUtils = new Mock<IFileSystemUtils>(MockBehavior.Strict);
+        mockManifestParserProvider = new Mock<IManifestParserProvider>(MockBehavior.Strict);
+        mock22ManifestInterface = new Mock<IManifestInterface>(MockBehavior.Strict);
+        mock30ManifestInterface = new Mock<IManifestInterface>(MockBehavior.Strict);
+
+        mockManifestParserProvider.Setup(m => m.Get(ManifestInfo.Parse(Spdx22VersionStub))).Returns(mock22ManifestInterface.Object);
+        mockManifestParserProvider.Setup(m => m.Get(ManifestInfo.Parse(Spdx30VersionStub))).Returns(mock30ManifestInterface.Object);
+        mock22ManifestInterface.Setup(m => m.CreateParser(It.IsAny<Stream>())).Returns((Stream stream) => new SPDXParser(stream));
+        mock30ManifestInterface.Setup(m => m.CreateParser(It.IsAny<Stream>())).Returns((Stream stream) => new SPDX30Parser(stream));
+
+        testSubject = new SPDXFormatDetector(mockFileSystemUtils.Object, mockManifestParserProvider.Object);
+    }
+
+    [TestCleanup]
+    public void Verify()
+    {
+        mockFileSystemUtils.VerifyAll();
+    }
+
+    [TestMethod]
+    [DataRow(Spdx22ContentStub, Spdx22VersionStub)]
+    [DataRow(Spdx30ContentStub, Spdx30VersionStub)]
+    public void TryDetectFormat_FilePath_Success(string testContent, string expectedVersion)
+    {
+        mockFileSystemUtils
+            .Setup(m => m.OpenRead(FilePathStub))
+            .Returns(TestUtils.GenerateStreamFromString(testContent))
+            .Verifiable();
+
+        var result = testSubject.TryDetectFormat(FilePathStub, out var manifestInfo);
+        Assert.IsTrue(result);
+        Assert.IsNotNull(manifestInfo);
+        Assert.AreEqual(expectedVersion, manifestInfo.ToString());
+    }
+
+    [TestMethod]
+    [DataRow(Spdx22ContentStub, Spdx22VersionStub)]
+    [DataRow(Spdx30ContentStub, Spdx30VersionStub)]
+    public void TryDetectFormat_Stream_Success(string testContent, string expectedVersion)
+    {
+        var result = testSubject.TryDetectFormat(TestUtils.GenerateStreamFromString(testContent), out var manifestInfo);
+        Assert.IsTrue(result);
+        Assert.IsNotNull(manifestInfo);
+        Assert.AreEqual(ManifestInfo.Parse(expectedVersion), manifestInfo);
+    }
+
+    [TestMethod]
+    public void TryDetectFormat_FilePath_InvalidVersion()
+    {
+        mockFileSystemUtils
+            .Setup(m => m.OpenRead(FilePathStub))
+            .Returns(TestUtils.GenerateStreamFromString(InvalidContentStub))
+            .Verifiable();
+
+        var result = testSubject.TryDetectFormat(FilePathStub, out var manifestInfo);
+        Assert.IsFalse(result);
+        Assert.IsNull(manifestInfo);
+    }
+
+    [TestMethod]
+    public void TryDetectFormat_Stream_InvalidVersion()
+    {
+        var result = testSubject.TryDetectFormat(TestUtils.GenerateStreamFromString(InvalidContentStub), out var manifestInfo);
+        Assert.IsFalse(result);
+        Assert.IsNull(manifestInfo);
+    }
+}


### PR DESCRIPTION
This PR adds a SPDXFormatDetector class which can be used to determine which version of SPDX a given SBOM uses. This class is not currently leveraged anywhere but it will be used in the new consolidate verb. 