### PR TITLE
JSON encode env var values before config file insertion

### DIFF
--- a/src/Microsoft.Sbom.Api/Config/ConfigFileParser.cs
+++ b/src/Microsoft.Sbom.Api/Config/ConfigFileParser.cs
@@ -45,8 +45,9 @@ public class ConfigFileParser
         {
             var envVarName = match.Groups[1].Value;
             var envVarValue = Environment.GetEnvironmentVariable(envVarName);
+            var encodedEnvVarValue = string.IsNullOrEmpty(envVarValue) ? envVarValue : JsonEncodedText.Encode(envVarValue).ToString();
 
-            return envVarValue;
+            return encodedEnvVarValue;
         });
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/Config/ConfigFileParserTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Config/ConfigFileParserTests.cs
@@ -17,7 +17,7 @@ public class ConfigFileParserTests
     private readonly string filePathStub = "test-path";
     private readonly string contentStub = "{\"PackageSupplier\": \"TestSupplier\",\"BuildDropPath\": \"$(BuildDropPathEnvVar)\"}";
     private readonly string envVarName = "BuildDropPathEnvVar";
-    private readonly string envVarValue = "TestPath";
+    private readonly string envVarValue = @"test\path";
 
     [TestInitialize]
     public void Initialize()


### PR DESCRIPTION
Fixing a bug in https://github.com/microsoft/sbom-tool/pull/1105 in which env var values were not being inserted into config files properly. The unit test coverage has been updated to cover this case. 