### PR TITLE
Add config file for Consolidate action

### DIFF
--- a/src/Microsoft.Sbom.Api/Config/ConfigFile.cs
+++ b/src/Microsoft.Sbom.Api/Config/ConfigFile.cs
@@ -186,4 +186,10 @@ public class ConfigFile
     /// The conformance to validate against
     /// </summary>
     public ConformanceType Conformance { get; set; }
+
+    /// <summary>
+    /// Describes the artifacts used for consolidation, as well information specific to each artifact.
+    /// The Key is the location of the artifact, and the value is an <see cref="ArtifactInfo"/> object.
+    /// </summary>
+    public Dictionary<string, ArtifactInfo> ArtifactInfoMap { get; set; }
 }

--- a/src/Microsoft.Sbom.Api/Config/ConfigSanitizer.cs
+++ b/src/Microsoft.Sbom.Api/Config/ConfigSanitizer.cs
@@ -56,8 +56,8 @@ public class ConfigSanitizer
         if ((configuration.ManifestToolAction == ManifestToolActions.Validate || configuration.ManifestToolAction == ManifestToolActions.Generate) &&
             (configuration.BuildDropPath?.Value == null || (configuration.DockerImagesToScan?.Value != null && configuration.BuildComponentPath?.Value == null)))
         {
-                ValidateBuildDropPathConfiguration(configuration);
-                configuration.BuildDropPath = GetTempBuildDropPath(configuration);
+            ValidateBuildDropPathConfiguration(configuration);
+            configuration.BuildDropPath = GetTempBuildDropPath(configuration);
         }
 
         CheckValidateFormatConfig(configuration);
@@ -68,7 +68,7 @@ public class ConfigSanitizer
         configuration.ManifestDirPath = GetManifestDirPath(configuration.ManifestDirPath, configuration.BuildDropPath?.Value, configuration.ManifestToolAction);
 
         // Set namespace value, this handles default values and user provided values.
-        if (configuration.ManifestToolAction == ManifestToolActions.Generate)
+        if (configuration.ManifestToolAction == ManifestToolActions.Generate || configuration.ManifestToolAction == ManifestToolActions.Consolidate)
         {
             configuration.NamespaceUriBase = GetNamespaceBaseUri(configuration, logger);
         }
@@ -111,6 +111,8 @@ public class ConfigSanitizer
         // Replace backslashes in directory paths with the OS-sepcific directory separator character.
         PathUtils.ConvertToOSSpecificPathSeparators(configuration);
 
+        CheckConsolidationConfig(configuration);
+
         logger.Dispose();
 
         return configuration;
@@ -126,6 +128,19 @@ public class ConfigSanitizer
         if (config.SbomPath?.Value == null)
         {
             throw new ValidationArgException($"Please provide a value for the SbomPath (-sp) parameter to validate the SBOM.");
+        }
+    }
+
+    private void CheckConsolidationConfig(IConfiguration config)
+    {
+        if (config.ManifestToolAction != ManifestToolActions.Consolidate)
+        {
+            return;
+        }
+
+        if (config.ArtifactInfoMap?.Value == null || !config.ArtifactInfoMap.Value.Any())
+        {
+            throw new ValidationArgException($"Please provide a value for the ArtifactInfoMap to consolidate the SBOMs.");
         }
     }
 

--- a/src/Microsoft.Sbom.Api/Config/ValueConverters/ArtifactInfoMapSettingAddingConverter.cs
+++ b/src/Microsoft.Sbom.Api/Config/ValueConverters/ArtifactInfoMapSettingAddingConverter.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using AutoMapper;
+using Microsoft.Sbom.Common.Config;
+
+namespace Microsoft.Sbom.Api.Config.ValueConverters;
+
+internal class ArtifactInfoMapSettingAddingConverter : IValueConverter<Dictionary<string, ArtifactInfo>, ConfigurationSetting<Dictionary<string, ArtifactInfo>>>
+{
+    private readonly SettingSource settingSource;
+
+    public ArtifactInfoMapSettingAddingConverter(SettingSource settingSource)
+    {
+        this.settingSource = settingSource;
+    }
+
+    public ConfigurationSetting<Dictionary<string, ArtifactInfo>> Convert(Dictionary<string, ArtifactInfo> sourceMember, ResolutionContext context)
+    {
+        if (sourceMember == null || !sourceMember.Any())
+        {
+            return null;
+        }
+
+        return new ConfigurationSetting<Dictionary<string, ArtifactInfo>>
+        {
+            Source = settingSource,
+            Value = sourceMember
+        };
+    }
+}

--- a/src/Microsoft.Sbom.Api/ConfigurationProfile.cs
+++ b/src/Microsoft.Sbom.Api/ConfigurationProfile.cs
@@ -112,6 +112,7 @@ public class ConfigurationProfile : Profile
             .ForMember(c => c.DeleteManifestDirIfPresent, o => o.Ignore())
             .ForMember(c => c.PackageSupplier, o => o.Ignore());
 
+        // See Issue #1107 for details on why this map doesn't have a bunch of .ForMember calls to ignore properties.
         CreateMap<ConsolidationArgs, InputConfiguration>();
 
         // Create config for the config json file to configuration.
@@ -172,6 +173,9 @@ public class ConfigurationProfile : Profile
         ForAllPropertyMaps(
             p => p.SourceType == typeof(ConformanceType),
             (c, memberOptions) => memberOptions.ConvertUsing(new ConformanceConfigurationSettingAddingConverter(GetSettingSourceFor(c.SourceMember.ReflectedType))));
+        ForAllPropertyMaps(
+            p => p.SourceType == typeof(Dictionary<string, ArtifactInfo>),
+            (c, memberOptions) => memberOptions.ConvertUsing(new ArtifactInfoMapSettingAddingConverter(GetSettingSourceFor(c.SourceMember.ReflectedType))));
     }
 
     // Based on the type of source, return the settings type.

--- a/src/Microsoft.Sbom.Api/Workflows/SbomConsolidationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SbomConsolidationWorkflow.cs
@@ -1,30 +1,48 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.Sbom.Api.Workflows;
-
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.Sbom.Common.Config;
 using Serilog;
+
+namespace Microsoft.Sbom.Api.Workflows;
 
 public class SbomConsolidationWorkflow : IWorkflow<SbomConsolidationWorkflow>
 {
     private readonly ILogger logger;
+    private readonly IConfiguration configuration;
 
-    public SbomConsolidationWorkflow(ILogger logger)
+#pragma warning disable IDE0051 // We'll use this soon.
+    private IReadOnlyDictionary<string, ArtifactInfo> ArtifactInfoMap => configuration.ArtifactInfoMap.Value;
+#pragma warning restore IDE0051 // We'll use this soon.
+
+    public SbomConsolidationWorkflow(ILogger logger, IConfiguration configuration)
     {
         this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        this.configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
     }
 
     /// <inheritdoc/>
 #pragma warning disable CS1998 // Placeholder, will use async in the future.
     public virtual async Task<bool> RunAsync()
     {
-        // Placeholder for the actual implementation of the SBOM consolidation workflow.
-        // This method should contain the logic to consolidate SBOMs as per the requirements.
-        // For now, it logs and returns true to indicate success.
         logger.Information("Placeholder SBOM consolidation workflow executed.");
-        return true;
+
+        return ValidateSourceSboms() && GeneratedConsolidatedSbom();
     }
 #pragma warning restore CS1998 // Placeholder, will use async in the future.
+
+    private bool ValidateSourceSboms()
+    {
+        // TODO : Implement the source SBOMs.
+        return true;
+    }
+
+    private bool GeneratedConsolidatedSbom()
+    {
+        // TODO : Generate the consolidated SBOM.
+        return true;
+    }
 }

--- a/src/Microsoft.Sbom.Common/Config/ArtifactInfo.cs
+++ b/src/Microsoft.Sbom.Common/Config/ArtifactInfo.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Sbom.Common.Config;
+
+/// <summary>
+/// Describes a single artifact that is an input to the consolidation workflow.
+/// </summary>
+public class ArtifactInfo
+{
+    /// <summary>
+    /// If the manifest folder is external to the artifact, this tells us where to find it.
+    /// </summary>
+    public string? ExternalManifestDir { get; set; }
+
+    /// <summary>
+    /// If true, files missing from the artifact will not cause an error.
+    /// </summary>
+    public bool? IgnoreMissingFiles { get; set; }
+
+    /// <summary>
+    /// If true, we will skip the signing check for this artifact. NOT RECOMMENDED for production use.
+    /// </summary>
+    public bool? SkipSigningCheck { get; set; }
+}

--- a/src/Microsoft.Sbom.Common/Config/Configuration.cs
+++ b/src/Microsoft.Sbom.Common/Config/Configuration.cs
@@ -55,6 +55,7 @@ public class Configuration : IConfiguration
     private static readonly AsyncLocal<ConfigurationSetting<string>> sbomPath = new();
     private static readonly AsyncLocal<ConfigurationSetting<string>> sbomDir = new();
     private static readonly AsyncLocal<ConfigurationSetting<ConformanceType>> conformance = new();
+    private static readonly AsyncLocal<ConfigurationSetting<Dictionary<string, ArtifactInfo>>> artifactInfoMap = new();
 
     /// <inheritdoc cref="IConfiguration.BuildDropPath" />
     [DirectoryExists]
@@ -347,5 +348,12 @@ public class Configuration : IConfiguration
     {
         get => conformance.Value;
         set => conformance.Value = value;
+    }
+
+    /// <inheritdoc cref="IConfiguration.ArtifactInfoMap" />
+    public ConfigurationSetting<Dictionary<string, ArtifactInfo>> ArtifactInfoMap
+    {
+        get => artifactInfoMap.Value;
+        set => artifactInfoMap.Value = value;
     }
 }

--- a/src/Microsoft.Sbom.Common/Config/IConfiguration.cs
+++ b/src/Microsoft.Sbom.Common/Config/IConfiguration.cs
@@ -218,4 +218,10 @@ public interface IConfiguration
     /// maximum are truncated to <see cref="Constants.MaxLicenseFetchTimeoutInSeconds"/>
     /// </summary>
     public ConfigurationSetting<int> LicenseInformationTimeoutInSeconds { get; set; }
+
+    /// <summary>
+    /// Describes the artifacts used for consolidation, as well information specific to each artifact.
+    /// The Key is the location of the artifact, and the value is an <see cref="ArtifactInfo"/> object.
+    /// </summary>
+    public ConfigurationSetting<Dictionary<string, ArtifactInfo>> ArtifactInfoMap { get; set; }
 }

--- a/src/Microsoft.Sbom.Common/Config/InputConfiguration.cs
+++ b/src/Microsoft.Sbom.Common/Config/InputConfiguration.cs
@@ -160,4 +160,7 @@ public class InputConfiguration : IConfiguration
 
     /// <inheritdoc cref="IConfiguration.Conformance" />
     public ConfigurationSetting<ConformanceType> Conformance { get; set; }
+
+    /// <inheritdoc cref="IConfiguration.ArtifactInfoMap" />
+    public ConfigurationSetting<Dictionary<string, ArtifactInfo>> ArtifactInfoMap { get; set; }
 }

--- a/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
@@ -329,6 +329,7 @@ public class InterfaceConcretionTests
         public ConfigurationSetting<string> SbomDir { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public ConfigurationSetting<ConformanceType> Conformance { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public ConfigurationSetting<int> LicenseInformationTimeoutInSeconds { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public ConfigurationSetting<Dictionary<string, ArtifactInfo>> ArtifactInfoMap { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
     }
 
     private class PinnedISettingSourceable : ISettingSourceable


### PR DESCRIPTION
This Adds the config file for the Consolidate verb. The key new element is the ArtifactInfoMap, which `ConfigSanitizer` will now reject for the `consolidate` action if it's malformed.

This touches `IConfiguration` so it's technically an API breaking change, but I'm not sure we need to worry about that one. It'll be a minor version bump either way when we release the `consolidate` action (and we'll also need to add it to the API, but we have a separate story for that and won't merge it until after we have a better idea of the shape of the data.