### PR TITLE
Add simple unit tests for SbomConsolidationWorkflow

### DIFF
--- a/src/Microsoft.Sbom.Api/Workflows/SbomConsolidationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SbomConsolidationWorkflow.cs
@@ -13,36 +13,36 @@ public class SbomConsolidationWorkflow : IWorkflow<SbomConsolidationWorkflow>
 {
     private readonly ILogger logger;
     private readonly IConfiguration configuration;
+    private readonly IWorkflow<SbomGenerationWorkflow> sbomGenerationWorkflow;
 
 #pragma warning disable IDE0051 // We'll use this soon.
     private IReadOnlyDictionary<string, ArtifactInfo> ArtifactInfoMap => configuration.ArtifactInfoMap.Value;
 #pragma warning restore IDE0051 // We'll use this soon.
 
-    public SbomConsolidationWorkflow(ILogger logger, IConfiguration configuration)
+    public SbomConsolidationWorkflow(ILogger logger, IConfiguration configuration, IWorkflow<SbomGenerationWorkflow> sbomGenerationWorkflow)
     {
         this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
         this.configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        this.sbomGenerationWorkflow = sbomGenerationWorkflow ?? throw new ArgumentNullException(nameof(sbomGenerationWorkflow));
     }
 
     /// <inheritdoc/>
-#pragma warning disable CS1998 // Placeholder, will use async in the future.
     public virtual async Task<bool> RunAsync()
     {
         logger.Information("Placeholder SBOM consolidation workflow executed.");
 
-        return ValidateSourceSboms() && GeneratedConsolidatedSbom();
+        return ValidateSourceSboms() && await GeneratedConsolidatedSbom();
     }
-#pragma warning restore CS1998 // Placeholder, will use async in the future.
 
     private bool ValidateSourceSboms()
     {
-        // TODO : Implement the source SBOMs.
+        // TODO : Implement the source SBOMs.`
         return true;
     }
 
-    private bool GeneratedConsolidatedSbom()
+    private async Task<bool> GeneratedConsolidatedSbom()
     {
-        // TODO : Generate the consolidated SBOM.
-        return true;
+        // TODO : Incorporate the source SBOMs in the consolidated SBOM generation workflow.
+        return await sbomGenerationWorkflow.RunAsync().ConfigureAwait(false);
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/SbomConsolidationWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/SbomConsolidationWorkflowTests.cs
@@ -20,7 +20,7 @@ public class SbomConsolidationWorkflowTests
     [TestInitialize]
     public void BeforeEachTest()
     {
-        loggerMock = new Mock<ILogger>();  // Intentionally not useing Strict to streamline setup
+        loggerMock = new Mock<ILogger>();  // Intentionally not using Strict to streamline setup
         configurationMock = new Mock<IConfiguration>(MockBehavior.Strict);
         sbomGenerationWorkflowMock = new Mock<IWorkflow<SbomGenerationWorkflow>>(MockBehavior.Strict);
 

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/SbomConsolidationWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/SbomConsolidationWorkflowTests.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+using Microsoft.Sbom.Common.Config;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Serilog;
+
+namespace Microsoft.Sbom.Api.Workflows.Tests;
+
+[TestClass]
+public class SbomConsolidationWorkflowTests
+{
+    private Mock<ILogger> loggerMock;
+    private Mock<IConfiguration> configurationMock;
+    private Mock<IWorkflow<SbomGenerationWorkflow>> sbomGenerationWorkflowMock;
+    private SbomConsolidationWorkflow testSubject;
+
+    [TestInitialize]
+    public void BeforeEachTest()
+    {
+        loggerMock = new Mock<ILogger>();  // Intentionally not useing Strict to streamline setup
+        configurationMock = new Mock<IConfiguration>(MockBehavior.Strict);
+        sbomGenerationWorkflowMock = new Mock<IWorkflow<SbomGenerationWorkflow>>(MockBehavior.Strict);
+
+        testSubject = new SbomConsolidationWorkflow(
+            loggerMock.Object,
+            configurationMock.Object,
+            sbomGenerationWorkflowMock.Object);
+    }
+
+    [TestCleanup]
+    public void AfterEachTest()
+    {
+        loggerMock.VerifyAll();
+        configurationMock.VerifyAll();
+        sbomGenerationWorkflowMock.VerifyAll();
+    }
+
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
+    public async Task RunAsync_MinimalHappyPath_CallsGenerationWorkflow(bool expectedResult)
+    {
+        sbomGenerationWorkflowMock.Setup(x => x.RunAsync())
+            .ReturnsAsync(expectedResult);
+
+        var result = await testSubject.RunAsync();
+
+        Assert.AreEqual(expectedResult, result);
+    }
+}


### PR DESCRIPTION
Add minimal unit tests for SbomConsolidationWorkflow, including calling the generation workflow. Note that the generation workflow is not yet correctly implemented, so the action is not yet meaningful.