### PR TITLE
Adding validate plumbing to consolidate verb

### DIFF
--- a/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfigFactory.cs
+++ b/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfigFactory.cs
@@ -2,9 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using Microsoft.Sbom.Api.Recorder;
 using Microsoft.Sbom.Common;
 using Microsoft.Sbom.Extensions;
 using Microsoft.Sbom.Extensions.Entities;
+using Constants = Microsoft.Sbom.Api.Utils.Constants;
 
 namespace Microsoft.Sbom.Api.Manifest.Configuration;
 
@@ -39,4 +41,29 @@ public class SbomConfigFactory : ISbomConfigFactory
             Recorder = recorder
         };
     }
+
+    public ISbomConfig Get(
+        ManifestInfo manifestInfo,
+        string manifestPath,
+        IMetadataBuilderFactory metadataBuilderFactory)
+    {
+        var sbomDirPath = GetSbomDirPath(manifestPath, manifestInfo);
+        var sbomFilePath = GetSbomFilePath(manifestPath, manifestInfo);
+        return Get(manifestInfo,
+            manifestPath,
+            sbomFilePath,
+            $"{sbomFilePath}.sha256",
+            fileSystemUtils.JoinPaths(sbomDirPath, Constants.CatalogFileName),
+            fileSystemUtils.JoinPaths(sbomDirPath, Constants.BsiFileName),
+            new SbomPackageDetailsRecorder(),
+            metadataBuilderFactory.Get(manifestInfo));
+    }
+
+    public string GetSbomDirPath(string manifestDirPath, ManifestInfo manifestInfo) => fileSystemUtils.JoinPaths(
+        manifestDirPath,
+        $"{manifestInfo.Name.ToLower()}_{manifestInfo.Version.ToLower()}");
+
+    public string GetSbomFilePath(string manifestDirPath, ManifestInfo manifestInfo) => fileSystemUtils.JoinPaths(
+        GetSbomDirPath(manifestDirPath, manifestInfo),
+        $"manifest.{manifestInfo.Name.ToLower()}.json");
 }

--- a/src/Microsoft.Sbom.Api/Utils/ISPDXFormatDetector.cs
+++ b/src/Microsoft.Sbom.Api/Utils/ISPDXFormatDetector.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.IO;
 using Microsoft.Sbom.Extensions.Entities;
 
@@ -11,4 +12,6 @@ public interface ISPDXFormatDetector
     public bool TryDetectFormat(string filePath, out ManifestInfo detectedManifestInfo);
 
     public bool TryDetectFormat(Stream stream, out ManifestInfo detectedManifestInfo);
+
+    public bool TryGetSbomsWithVersion(string manifestDirPath, out IDictionary<string, ManifestInfo> detectedSboms);
 }

--- a/src/Microsoft.Sbom.Api/Utils/ISPDXFormatDetector.cs
+++ b/src/Microsoft.Sbom.Api/Utils/ISPDXFormatDetector.cs
@@ -13,5 +13,5 @@ public interface ISPDXFormatDetector
 
     public bool TryDetectFormat(Stream stream, out ManifestInfo detectedManifestInfo);
 
-    public bool TryGetSbomsWithVersion(string manifestDirPath, out IDictionary<string, ManifestInfo> detectedSboms);
+    public bool TryGetSbomsWithVersion(string manifestDirPath, out IList<(string sbomFilePath, ManifestInfo manifestInfo)> detectedSboms);
 }

--- a/src/Microsoft.Sbom.Api/Utils/SPDXFormatDetector.cs
+++ b/src/Microsoft.Sbom.Api/Utils/SPDXFormatDetector.cs
@@ -17,10 +17,12 @@ public class SPDXFormatDetector : ISPDXFormatDetector
 {
     private readonly IFileSystemUtils fileSystemUtils;
     private readonly IDictionary<ManifestInfo, Func<Stream, bool>> supportedManifestInfos;
+    private readonly ISbomConfigFactory sbomConfigFactory;
 
     public SPDXFormatDetector(
         IFileSystemUtils fileSystemUtils,
-        IManifestParserProvider manifestParserProvider)
+        IManifestParserProvider manifestParserProvider,
+        ISbomConfigFactory sbomConfigFactory)
     {
         this.fileSystemUtils = fileSystemUtils;
         supportedManifestInfos = new Dictionary<ManifestInfo, Func<Stream, bool>>()
@@ -28,6 +30,25 @@ public class SPDXFormatDetector : ISPDXFormatDetector
             { Constants.SPDX22ManifestInfo, TryParse22 },
             { Constants.SPDX30ManifestInfo, TryParse30 }
         };
+        this.sbomConfigFactory = sbomConfigFactory;
+    }
+
+    public bool TryGetSbomsWithVersion(string manifestDirPath, out IDictionary<string, ManifestInfo> detectedSboms)
+    {
+        detectedSboms = new Dictionary<string, ManifestInfo>();
+        foreach (var mi in supportedManifestInfos.Keys) {
+            var filePath = sbomConfigFactory.GetSbomFilePath(manifestDirPath, mi);
+            if (fileSystemUtils.FileExists(filePath))
+            {
+                var result = TryDetectFormat(filePath, out var detectedManifestInfo);
+                if (result && mi.Equals(detectedManifestInfo))
+                {
+                    detectedSboms.Add(filePath, detectedManifestInfo);
+                }
+            }
+        }
+
+        return detectedSboms.Any();
     }
 
     public bool TryDetectFormat(string filePath, out ManifestInfo detectedManifestInfo)

--- a/src/Microsoft.Sbom.Api/Utils/SPDXFormatDetector.cs
+++ b/src/Microsoft.Sbom.Api/Utils/SPDXFormatDetector.cs
@@ -33,9 +33,9 @@ public class SPDXFormatDetector : ISPDXFormatDetector
         this.sbomConfigFactory = sbomConfigFactory;
     }
 
-    public bool TryGetSbomsWithVersion(string manifestDirPath, out IDictionary<string, ManifestInfo> detectedSboms)
+    public bool TryGetSbomsWithVersion(string manifestDirPath, out IList<(string sbomFilePath, ManifestInfo manifestInfo)> detectedSboms)
     {
-        detectedSboms = new Dictionary<string, ManifestInfo>();
+        detectedSboms = new List<(string, ManifestInfo)>();
         foreach (var mi in supportedManifestInfos.Keys) {
             var filePath = sbomConfigFactory.GetSbomFilePath(manifestDirPath, mi);
             if (fileSystemUtils.FileExists(filePath))
@@ -43,7 +43,7 @@ public class SPDXFormatDetector : ISPDXFormatDetector
                 var result = TryDetectFormat(filePath, out var detectedManifestInfo);
                 if (result && mi.Equals(detectedManifestInfo))
                 {
-                    detectedSboms.Add(filePath, detectedManifestInfo);
+                    detectedSboms.Add((filePath, detectedManifestInfo));
                 }
             }
         }

--- a/src/Microsoft.Sbom.Api/Utils/SPDXFormatDetector.cs
+++ b/src/Microsoft.Sbom.Api/Utils/SPDXFormatDetector.cs
@@ -38,7 +38,7 @@ public class SPDXFormatDetector : ISPDXFormatDetector
         detectedSboms = new List<(string, ManifestInfo)>();
         foreach (var mi in supportedManifestInfos.Keys) {
             var filePath = sbomConfigFactory.GetSbomFilePath(manifestDirPath, mi);
-            if (fileSystemUtils.FileExists(filePath))
+            if (fileSystemUtils.FileExists(filePath) && fileSystemUtils.GetFileSize(filePath) > 0)
             {
                 var result = TryDetectFormat(filePath, out var detectedManifestInfo);
                 if (result && mi.Equals(detectedManifestInfo))

--- a/src/Microsoft.Sbom.Api/Workflows/SbomConsolidationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SbomConsolidationWorkflow.cs
@@ -3,9 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Sbom.Api.Utils;
+using Microsoft.Sbom.Common;
 using Microsoft.Sbom.Common.Config;
+using Microsoft.Sbom.Extensions;
 using Serilog;
+using Constants = Microsoft.Sbom.Api.Utils.Constants;
 
 namespace Microsoft.Sbom.Api.Workflows;
 
@@ -13,31 +18,66 @@ public class SbomConsolidationWorkflow : IWorkflow<SbomConsolidationWorkflow>
 {
     private readonly ILogger logger;
     private readonly IConfiguration configuration;
+    private readonly ISbomConfigFactory sbomConfigFactory;
+    private readonly ISPDXFormatDetector sPDXFormatDetector;
+    private readonly IFileSystemUtils fileSystemUtils;
+    protected readonly IMetadataBuilderFactory metadataBuilderFactory;
 
 #pragma warning disable IDE0051 // We'll use this soon.
     private IReadOnlyDictionary<string, ArtifactInfo> ArtifactInfoMap => configuration.ArtifactInfoMap.Value;
 #pragma warning restore IDE0051 // We'll use this soon.
 
-    public SbomConsolidationWorkflow(ILogger logger, IConfiguration configuration)
+    public SbomConsolidationWorkflow(ILogger logger, IConfiguration configuration, ISbomConfigFactory sbomConfigFactory, ISPDXFormatDetector sPDXFormatDetector, IFileSystemUtils fileSystemUtils, IMetadataBuilderFactory metadataBuilderFactory)
     {
         this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
         this.configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        this.sbomConfigFactory = sbomConfigFactory ?? throw new ArgumentNullException(nameof(sbomConfigFactory));
+        this.sPDXFormatDetector = sPDXFormatDetector ?? throw new ArgumentNullException(nameof(sPDXFormatDetector));
+        this.fileSystemUtils = fileSystemUtils ?? throw new ArgumentNullException(nameof(fileSystemUtils));
+        this.metadataBuilderFactory = metadataBuilderFactory ?? throw new ArgumentNullException(nameof(metadataBuilderFactory));
     }
 
     /// <inheritdoc/>
-#pragma warning disable CS1998 // Placeholder, will use async in the future.
     public virtual async Task<bool> RunAsync()
     {
         logger.Information("Placeholder SBOM consolidation workflow executed.");
 
-        return ValidateSourceSboms() && GeneratedConsolidatedSbom();
+        return await ValidateSourceSbomsAsync() && GeneratedConsolidatedSbom();
     }
-#pragma warning restore CS1998 // Placeholder, will use async in the future.
 
-    private bool ValidateSourceSboms()
+    private async Task<bool> ValidateSourceSbomsAsync()
     {
-        // TODO : Implement the source SBOMs.
-        return true;
+        var sbomsToValidate = ArtifactInfoMap.Select(artifact => GetSbomsToValidate(artifact.Key, artifact.Value))
+            .Where(l => l != null)
+            .SelectMany(l => l);
+        if (!sbomsToValidate.Any())
+        {
+            logger.Information($"No valid SBOMs detected.");
+            return false;
+        }
+
+        var validationWorkflows = sbomsToValidate
+            .Select(sbom => ValidateSourceSbomAsync(sbom.config, sbom.info));
+        var results = await Task.WhenAll(validationWorkflows);
+        return results.All(b => b);
+    }
+
+    private IEnumerable<(ISbomConfig config, ArtifactInfo info)> GetSbomsToValidate(string artifactPath, ArtifactInfo info)
+    {
+        var manifestDirPath = info?.ExternalManifestDir ?? fileSystemUtils.JoinPaths(artifactPath, Constants.ManifestFolder);
+        var isValidSpdxFormat = sPDXFormatDetector.TryGetSbomsWithVersion(manifestDirPath, out var detectedSboms);
+        if (!isValidSpdxFormat)
+        {
+            logger.Information($"No SBOMs located in {manifestDirPath} of a recognized SPDX format.");
+            return null;
+        }
+
+        return detectedSboms.Select((sbom) => (sbomConfigFactory.Get(sbom.Value, manifestDirPath, metadataBuilderFactory), info));
+    }
+
+    private async Task<bool> ValidateSourceSbomAsync(ISbomConfig sbomConfig, ArtifactInfo info)
+    {
+        return await Task.FromResult(true); // TODO: Run validation workflow
     }
 
     private bool GeneratedConsolidatedSbom()

--- a/src/Microsoft.Sbom.Common/FileSystemUtils.cs
+++ b/src/Microsoft.Sbom.Common/FileSystemUtils.cs
@@ -112,4 +112,7 @@ public abstract class FileSystemUtils : IFileSystemUtils
 
     /// <inheritdoc />
     public byte[] ReadAllBytes(string path) => File.ReadAllBytes(path);
+
+    /// <inheritdoc />
+    public long GetFileSize(string path) => new FileInfo(path).Length;
 }

--- a/src/Microsoft.Sbom.Common/IFileSystemUtils.cs
+++ b/src/Microsoft.Sbom.Common/IFileSystemUtils.cs
@@ -192,4 +192,11 @@ public interface IFileSystemUtils
     /// <param name="path">The absolute relative path of a file.</param>
     /// <returns>Byte array content of the file.</returns>
     public byte[] ReadAllBytes(string path);
+
+    /// <summary>
+    /// Returns the size of the given file
+    /// </summary>
+    /// <param name="path">The absolute relative path of a file.</param>
+    /// <returns>Size of file in bytes.</returns>
+    public long GetFileSize(string path);
 }

--- a/src/Microsoft.Sbom.Common/ISbomConfigFactory.cs
+++ b/src/Microsoft.Sbom.Common/ISbomConfigFactory.cs
@@ -29,7 +29,7 @@ public interface ISbomConfigFactory
         string manifestPath,
         IMetadataBuilderFactory metadataBuilderFactory);
 
-    public string GetSbomDirPath(string manifestDirPath, ManifestInfo manifestInfo);
+    public string GetSpdxDirPath(string manifestDirPath, ManifestInfo manifestInfo);
 
     public string GetSbomFilePath(string manifestDirPath, ManifestInfo manifestInfo);
 }

--- a/src/Microsoft.Sbom.Common/ISbomConfigFactory.cs
+++ b/src/Microsoft.Sbom.Common/ISbomConfigFactory.cs
@@ -23,4 +23,13 @@ public interface ISbomConfigFactory
         string bsiFilePath,
         ISbomPackageDetailsRecorder recorder,
         IMetadataBuilder metadataBuilder);
+
+    public ISbomConfig Get(
+        ManifestInfo manifestInfo,
+        string manifestPath,
+        IMetadataBuilderFactory metadataBuilderFactory);
+
+    public string GetSbomDirPath(string manifestDirPath, ManifestInfo manifestInfo);
+
+    public string GetSbomFilePath(string manifestDirPath, ManifestInfo manifestInfo);
 }

--- a/src/Microsoft.Sbom.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Sbom.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -73,6 +73,8 @@ public static class ServiceCollectionExtensions
             .AddTransient<IWorkflow<SbomGenerationWorkflow>, SbomGenerationWorkflow>()
             .AddTransient<IWorkflow<SbomConsolidationWorkflow>, SbomConsolidationWorkflow>()
             .AddTransient<IWorkflow<SbomRedactionWorkflow>, SbomRedactionWorkflow>()
+            .AddTransient<ISbomConfigFactory, SbomConfigFactory>()
+            .AddTransient<ISPDXFormatDetector, SPDXFormatDetector>()
             .AddTransient<ISbomRedactor, SbomRedactor>()
             .AddTransient<ValidatedSbomFactory>()
             .AddTransient<DirectoryWalker>()

--- a/test/Microsoft.Sbom.Api.Tests/Manifest/Configuration/SbomConfigFactoryTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Manifest/Configuration/SbomConfigFactoryTests.cs
@@ -50,8 +50,7 @@ public class SbomConfigFactoryTests
     {
         fileSystemUtilsMock
             .Setup(m => m.JoinPaths(manifestDirPathStub, manifestInfoStringStub))
-            .Returns(spdxDirPathStub)
-            .Verifiable();
+            .Returns(spdxDirPathStub);
 
         var result = testSubject.GetSpdxDirPath(manifestDirPathStub, manifestInfoStub);
         Assert.AreEqual(spdxDirPathStub, result);
@@ -62,12 +61,10 @@ public class SbomConfigFactoryTests
     {
         fileSystemUtilsMock
             .Setup(m => m.JoinPaths(manifestDirPathStub, manifestInfoStringStub))
-            .Returns(spdxDirPathStub)
-            .Verifiable();
+            .Returns(spdxDirPathStub);
         fileSystemUtilsMock
             .Setup(m => m.JoinPaths(spdxDirPathStub, manifestFileNameStub))
-            .Returns(sbomFilePathStub)
-            .Verifiable();
+            .Returns(sbomFilePathStub);
 
         var result = testSubject.GetSbomFilePath(manifestDirPathStub, manifestInfoStub);
         Assert.AreEqual(sbomFilePathStub, result);
@@ -78,25 +75,20 @@ public class SbomConfigFactoryTests
     {
         fileSystemUtilsMock
             .Setup(m => m.JoinPaths(manifestDirPathStub, manifestInfoStringStub))
-            .Returns(spdxDirPathStub)
-            .Verifiable();
+            .Returns(spdxDirPathStub);
         fileSystemUtilsMock
             .Setup(m => m.JoinPaths(spdxDirPathStub, manifestFileNameStub))
-            .Returns(sbomFilePathStub)
-            .Verifiable();
+            .Returns(sbomFilePathStub);
         fileSystemUtilsMock
             .Setup(m => m.JoinPaths(spdxDirPathStub, Api.Utils.Constants.CatalogFileName))
-            .Returns(catFilePathStub)
-            .Verifiable();
+            .Returns(catFilePathStub);
         fileSystemUtilsMock
             .Setup(m => m.JoinPaths(spdxDirPathStub, Api.Utils.Constants.BsiFileName))
-            .Returns(bsiFilePathStub)
-            .Verifiable();
+            .Returns(bsiFilePathStub);
         fileSystemUtilsMock
             .Setup(m => m.FileExists($"{sbomFilePathStub}.sha256"))
-            .Returns(true)
-            .Verifiable();
-        metadataBuilderFactoryMock.Setup(m => m.Get(manifestInfoStub)).Returns(metadataBuilderStub).Verifiable();
+            .Returns(true);
+        metadataBuilderFactoryMock.Setup(m => m.Get(manifestInfoStub)).Returns(metadataBuilderStub);
 
         var result = testSubject.Get(manifestInfoStub, manifestDirPathStub, metadataBuilderFactoryMock.Object);
         Assert.AreEqual(manifestInfoStub, result.ManifestInfo);
@@ -112,41 +104,32 @@ public class SbomConfigFactoryTests
     {
         fileSystemUtilsMock
             .Setup(m => m.JoinPaths(manifestDirPathStub, manifestInfoStringStub))
-            .Returns(spdxDirPathStub)
-            .Verifiable();
+            .Returns(spdxDirPathStub);
         fileSystemUtilsMock
             .Setup(m => m.JoinPaths(spdxDirPathStub, manifestFileNameStub))
-            .Returns(sbomFilePathStub)
-            .Verifiable();
+            .Returns(sbomFilePathStub);
         fileSystemUtilsMock
             .Setup(m => m.JoinPaths(spdxDirPathStub, Api.Utils.Constants.CatalogFileName))
-            .Returns(catFilePathStub)
-            .Verifiable();
+            .Returns(catFilePathStub);
         fileSystemUtilsMock
             .Setup(m => m.JoinPaths(spdxDirPathStub, Api.Utils.Constants.BsiFileName))
-            .Returns(bsiFilePathStub)
-            .Verifiable();
+            .Returns(bsiFilePathStub);
         fileSystemUtilsMock
             .Setup(m => m.FileExists($"{sbomFilePathStub}.sha256"))
-            .Returns(false)
-            .Verifiable();
+            .Returns(false);
         fileSystemUtilsMock
             .Setup(m => m.FileExists(catFilePathStub))
-            .Returns(false)
-            .Verifiable();
+            .Returns(false);
         fileSystemUtilsMock
             .Setup(m => m.FileExists(bsiFilePathStub))
-            .Returns(false)
-            .Verifiable();
+            .Returns(false);
         fileSystemUtilsMock
             .Setup(m => m.JoinPaths(manifestDirPathStub, Api.Utils.Constants.CatalogFileName))
-            .Returns(cbCatFilePathStub)
-            .Verifiable();
+            .Returns(cbCatFilePathStub);
         fileSystemUtilsMock
             .Setup(m => m.JoinPaths(manifestDirPathStub, Api.Utils.Constants.BsiFileName))
-            .Returns(cbBsiFilePathStub)
-            .Verifiable();
-        metadataBuilderFactoryMock.Setup(m => m.Get(manifestInfoStub)).Returns(metadataBuilderStub).Verifiable();
+            .Returns(cbBsiFilePathStub);
+        metadataBuilderFactoryMock.Setup(m => m.Get(manifestInfoStub)).Returns(metadataBuilderStub);
 
         var result = testSubject.Get(manifestInfoStub, manifestDirPathStub, metadataBuilderFactoryMock.Object);
         Assert.AreEqual(manifestInfoStub, result.ManifestInfo);

--- a/test/Microsoft.Sbom.Api.Tests/Manifest/Configuration/SbomConfigFactoryTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Manifest/Configuration/SbomConfigFactoryTests.cs
@@ -1,0 +1,159 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Sbom.Api.Manifest.Configuration;
+using Microsoft.Sbom.Common;
+using Microsoft.Sbom.Extensions;
+using Microsoft.Sbom.Extensions.Entities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.Sbom.Api.Tests.Manifest.Configuration;
+
+[TestClass]
+public class SbomConfigFactoryTests
+{
+    private Mock<IFileSystemUtils> fileSystemUtilsMock;
+    private Mock<IMetadataBuilderFactory> metadataBuilderFactoryMock;
+    private SbomConfigFactory testSubject;
+
+    private string manifestDirPathStub = "manifest-dir-path";
+    private string spdxDirPathStub = "spdx-dir-path";
+    private string sbomFilePathStub = "sbom-file-path";
+    private string catFilePathStub = "cat-file-path";
+    private string cbCatFilePathStub = "cloud-build-cat-file-path";
+    private string bsiFilePathStub = "bsi-file-path";
+    private string cbBsiFilePathStub = "cloud-build-bsi-file-path";
+    private ManifestInfo manifestInfoStub = Api.Utils.Constants.SPDX30ManifestInfo;
+    private string manifestInfoStringStub = "spdx_3.0";
+    private string manifestFileNameStub = "manifest.spdx.json";
+    private IMetadataBuilder metadataBuilderStub = new Mock<IMetadataBuilder>().Object;
+
+    [TestInitialize]
+    public void BeforeEachTest()
+    {
+        fileSystemUtilsMock = new Mock<IFileSystemUtils>(MockBehavior.Strict);
+        metadataBuilderFactoryMock = new Mock<IMetadataBuilderFactory>(MockBehavior.Strict);
+
+        testSubject = new SbomConfigFactory(fileSystemUtilsMock.Object);
+    }
+
+    [TestCleanup]
+    public void AfterEachTest()
+    {
+        fileSystemUtilsMock.VerifyAll();
+        metadataBuilderFactoryMock.VerifyAll();
+    }
+
+    [TestMethod]
+    public void GetSpdxDirPath_ReturnsValidPath()
+    {
+        fileSystemUtilsMock
+            .Setup(m => m.JoinPaths(manifestDirPathStub, manifestInfoStringStub))
+            .Returns(spdxDirPathStub)
+            .Verifiable();
+
+        var result = testSubject.GetSpdxDirPath(manifestDirPathStub, manifestInfoStub);
+        Assert.AreEqual(spdxDirPathStub, result);
+    }
+
+    [TestMethod]
+    public void GetSbomFilePath_ReturnsValidPath()
+    {
+        fileSystemUtilsMock
+            .Setup(m => m.JoinPaths(manifestDirPathStub, manifestInfoStringStub))
+            .Returns(spdxDirPathStub)
+            .Verifiable();
+        fileSystemUtilsMock
+            .Setup(m => m.JoinPaths(spdxDirPathStub, manifestFileNameStub))
+            .Returns(sbomFilePathStub)
+            .Verifiable();
+
+        var result = testSubject.GetSbomFilePath(manifestDirPathStub, manifestInfoStub);
+        Assert.AreEqual(sbomFilePathStub, result);
+    }
+
+    [TestMethod]
+    public void Get_ReturnsCorrectConfig_AdoStyleSbom()
+    {
+        fileSystemUtilsMock
+            .Setup(m => m.JoinPaths(manifestDirPathStub, manifestInfoStringStub))
+            .Returns(spdxDirPathStub)
+            .Verifiable();
+        fileSystemUtilsMock
+            .Setup(m => m.JoinPaths(spdxDirPathStub, manifestFileNameStub))
+            .Returns(sbomFilePathStub)
+            .Verifiable();
+        fileSystemUtilsMock
+            .Setup(m => m.JoinPaths(spdxDirPathStub, Api.Utils.Constants.CatalogFileName))
+            .Returns(catFilePathStub)
+            .Verifiable();
+        fileSystemUtilsMock
+            .Setup(m => m.JoinPaths(spdxDirPathStub, Api.Utils.Constants.BsiFileName))
+            .Returns(bsiFilePathStub)
+            .Verifiable();
+        fileSystemUtilsMock
+            .Setup(m => m.FileExists($"{sbomFilePathStub}.sha256"))
+            .Returns(true)
+            .Verifiable();
+        metadataBuilderFactoryMock.Setup(m => m.Get(manifestInfoStub)).Returns(metadataBuilderStub).Verifiable();
+
+        var result = testSubject.Get(manifestInfoStub, manifestDirPathStub, metadataBuilderFactoryMock.Object);
+        Assert.AreEqual(manifestInfoStub, result.ManifestInfo);
+        Assert.AreEqual(sbomFilePathStub, result.ManifestJsonFilePath);
+        Assert.AreEqual(manifestDirPathStub, result.ManifestJsonDirPath);
+        Assert.AreEqual($"{sbomFilePathStub}.sha256", result.ManifestJsonFileSha256FilePath);
+        Assert.AreEqual(catFilePathStub, result.CatalogFilePath);
+        Assert.AreEqual(bsiFilePathStub, result.BsiFilePath);
+    }
+
+    [TestMethod]
+    public void Get_ReturnsCorrectConfig_CloudBuildStyleSbom()
+    {
+        fileSystemUtilsMock
+            .Setup(m => m.JoinPaths(manifestDirPathStub, manifestInfoStringStub))
+            .Returns(spdxDirPathStub)
+            .Verifiable();
+        fileSystemUtilsMock
+            .Setup(m => m.JoinPaths(spdxDirPathStub, manifestFileNameStub))
+            .Returns(sbomFilePathStub)
+            .Verifiable();
+        fileSystemUtilsMock
+            .Setup(m => m.JoinPaths(spdxDirPathStub, Api.Utils.Constants.CatalogFileName))
+            .Returns(catFilePathStub)
+            .Verifiable();
+        fileSystemUtilsMock
+            .Setup(m => m.JoinPaths(spdxDirPathStub, Api.Utils.Constants.BsiFileName))
+            .Returns(bsiFilePathStub)
+            .Verifiable();
+        fileSystemUtilsMock
+            .Setup(m => m.FileExists($"{sbomFilePathStub}.sha256"))
+            .Returns(false)
+            .Verifiable();
+        fileSystemUtilsMock
+            .Setup(m => m.FileExists(catFilePathStub))
+            .Returns(false)
+            .Verifiable();
+        fileSystemUtilsMock
+            .Setup(m => m.FileExists(bsiFilePathStub))
+            .Returns(false)
+            .Verifiable();
+        fileSystemUtilsMock
+            .Setup(m => m.JoinPaths(manifestDirPathStub, Api.Utils.Constants.CatalogFileName))
+            .Returns(cbCatFilePathStub)
+            .Verifiable();
+        fileSystemUtilsMock
+            .Setup(m => m.JoinPaths(manifestDirPathStub, Api.Utils.Constants.BsiFileName))
+            .Returns(cbBsiFilePathStub)
+            .Verifiable();
+        metadataBuilderFactoryMock.Setup(m => m.Get(manifestInfoStub)).Returns(metadataBuilderStub).Verifiable();
+
+        var result = testSubject.Get(manifestInfoStub, manifestDirPathStub, metadataBuilderFactoryMock.Object);
+        Assert.AreEqual(manifestInfoStub, result.ManifestInfo);
+        Assert.AreEqual(sbomFilePathStub, result.ManifestJsonFilePath);
+        Assert.AreEqual(manifestDirPathStub, result.ManifestJsonDirPath);
+        Assert.IsNull(result.ManifestJsonFileSha256FilePath);
+        Assert.AreEqual(cbCatFilePathStub, result.CatalogFilePath);
+        Assert.AreEqual(cbBsiFilePathStub, result.BsiFilePath);
+    }
+}

--- a/test/Microsoft.Sbom.Api.Tests/Utils/SPDXFormatDetectorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Utils/SPDXFormatDetectorTests.cs
@@ -76,6 +76,9 @@ public class SPDXFormatDetectorTests
             .Setup(m => m.FileExists(FilePathStub + expectedVersion))
             .Returns(true);
         mockFileSystemUtils
+            .Setup(m => m.GetFileSize(FilePathStub + expectedVersion))
+            .Returns(1);
+        mockFileSystemUtils
             .Setup(m => m.OpenRead(FilePathStub + expectedVersion))
             .Returns(TestUtils.GenerateStreamFromString(testContent));
 
@@ -103,6 +106,12 @@ public class SPDXFormatDetectorTests
         mockFileSystemUtils
             .Setup(m => m.FileExists(FilePathStub + Spdx30VersionStub))
             .Returns(true);
+        mockFileSystemUtils
+            .Setup(m => m.GetFileSize(FilePathStub + Spdx22VersionStub))
+            .Returns(1);
+        mockFileSystemUtils
+            .Setup(m => m.GetFileSize(FilePathStub + Spdx30VersionStub))
+            .Returns(1);
         mockFileSystemUtils
             .Setup(m => m.OpenRead(FilePathStub + Spdx22VersionStub))
             .Returns(TestUtils.GenerateStreamFromString(Spdx22ContentStub));
@@ -135,6 +144,36 @@ public class SPDXFormatDetectorTests
         mockFileSystemUtils
             .Setup(m => m.FileExists(FilePathStub + Spdx30VersionStub))
             .Returns(false);
+
+        var result = testSubject.TryGetSbomsWithVersion(DirPathStub, out var detectedSboms);
+        Assert.IsFalse(result);
+        Assert.IsNotNull(detectedSboms);
+        Assert.IsFalse(detectedSboms.Any());
+    }
+
+    [TestMethod]
+    public void TryGetSbomsWithVersion_FilesAreEmpty()
+    {
+        var spdx22FilePathStub = FilePathStub + Spdx22VersionStub;
+        var spdx30FilePathStub = FilePathStub + Spdx30VersionStub;
+        mockSbomConfigFactory
+            .Setup(m => m.GetSbomFilePath(DirPathStub, Api.Utils.Constants.SPDX22ManifestInfo))
+            .Returns(spdx22FilePathStub);
+        mockSbomConfigFactory
+            .Setup(m => m.GetSbomFilePath(DirPathStub, Api.Utils.Constants.SPDX30ManifestInfo))
+            .Returns(spdx30FilePathStub);
+        mockFileSystemUtils
+            .Setup(m => m.FileExists(FilePathStub + Spdx22VersionStub))
+            .Returns(true);
+        mockFileSystemUtils
+            .Setup(m => m.FileExists(FilePathStub + Spdx30VersionStub))
+            .Returns(true);
+        mockFileSystemUtils
+            .Setup(m => m.GetFileSize(FilePathStub + Spdx22VersionStub))
+            .Returns(0);
+        mockFileSystemUtils
+            .Setup(m => m.GetFileSize(FilePathStub + Spdx30VersionStub))
+            .Returns(0);
 
         var result = testSubject.TryGetSbomsWithVersion(DirPathStub, out var detectedSboms);
         Assert.IsFalse(result);

--- a/test/Microsoft.Sbom.Api.Tests/Utils/SPDXFormatDetectorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Utils/SPDXFormatDetectorTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;
+using System.Linq;
 using Microsoft.Sbom.Api.Manifest;
 using Microsoft.Sbom.Api.Utils;
 using Microsoft.Sbom.Common;
@@ -20,8 +21,10 @@ public class SPDXFormatDetectorTests
     private Mock<IManifestParserProvider> mockManifestParserProvider;
     private Mock<IManifestInterface> mock22ManifestInterface;
     private Mock<IManifestInterface> mock30ManifestInterface;
+    private Mock<ISbomConfigFactory> mockSbomConfigFactory;
     private SPDXFormatDetector testSubject;
 
+    private const string DirPathStub = "dir-path";
     private const string FilePathStub = "file-path";
     private const string Spdx22VersionStub = "SPDX:2.2";
     private const string Spdx30VersionStub = "SPDX:3.0";
@@ -36,19 +39,124 @@ public class SPDXFormatDetectorTests
         mockManifestParserProvider = new Mock<IManifestParserProvider>(MockBehavior.Strict);
         mock22ManifestInterface = new Mock<IManifestInterface>(MockBehavior.Strict);
         mock30ManifestInterface = new Mock<IManifestInterface>(MockBehavior.Strict);
+        mockSbomConfigFactory = new Mock<ISbomConfigFactory>(MockBehavior.Strict);
 
         mockManifestParserProvider.Setup(m => m.Get(ManifestInfo.Parse(Spdx22VersionStub))).Returns(mock22ManifestInterface.Object);
         mockManifestParserProvider.Setup(m => m.Get(ManifestInfo.Parse(Spdx30VersionStub))).Returns(mock30ManifestInterface.Object);
         mock22ManifestInterface.Setup(m => m.CreateParser(It.IsAny<Stream>())).Returns((Stream stream) => new SPDXParser(stream));
         mock30ManifestInterface.Setup(m => m.CreateParser(It.IsAny<Stream>())).Returns((Stream stream) => new SPDX30Parser(stream));
 
-        testSubject = new SPDXFormatDetector(mockFileSystemUtils.Object, mockManifestParserProvider.Object);
+        testSubject = new SPDXFormatDetector(mockFileSystemUtils.Object, mockManifestParserProvider.Object, mockSbomConfigFactory.Object);
     }
 
     [TestCleanup]
     public void Verify()
     {
         mockFileSystemUtils.VerifyAll();
+        mockSbomConfigFactory.VerifyAll();
+    }
+
+    [TestMethod]
+    [DataRow(Spdx22ContentStub, Spdx22VersionStub)]
+    [DataRow(Spdx30ContentStub, Spdx30VersionStub)]
+    public void TryGetSbomsWithVersion_SingleResult_Success(string testContent, string expectedVersion)
+    {
+        var spdx22FilePathStub = FilePathStub + Spdx22VersionStub;
+        var spdx30FilePathStub = FilePathStub + Spdx30VersionStub;
+        mockSbomConfigFactory
+            .Setup(m => m.GetSbomFilePath(DirPathStub, Api.Utils.Constants.SPDX22ManifestInfo))
+            .Returns(spdx22FilePathStub)
+            .Verifiable();
+        mockSbomConfigFactory
+            .Setup(m => m.GetSbomFilePath(DirPathStub, Api.Utils.Constants.SPDX30ManifestInfo))
+            .Returns(spdx30FilePathStub)
+            .Verifiable();
+        mockFileSystemUtils
+            .Setup(m => m.FileExists(It.IsAny<string>()))
+            .Returns(false);
+        mockFileSystemUtils
+            .Setup(m => m.FileExists(FilePathStub + expectedVersion))
+            .Returns(true)
+            .Verifiable();
+        mockFileSystemUtils
+            .Setup(m => m.OpenRead(FilePathStub + expectedVersion))
+            .Returns(TestUtils.GenerateStreamFromString(testContent))
+            .Verifiable();
+
+        var result = testSubject.TryGetSbomsWithVersion(DirPathStub, out var detectedSboms);
+        Assert.IsTrue(result);
+        Assert.IsNotNull(detectedSboms);
+        Assert.AreEqual(1, detectedSboms.Count);
+        Assert.AreEqual(FilePathStub + expectedVersion, detectedSboms.First().Key);
+        Assert.AreEqual(expectedVersion, detectedSboms.First().Value.ToString());
+    }
+
+    [TestMethod]
+    public void TryGetSbomsWithVersion_MultipleResults_Success()
+    {
+        var spdx22FilePathStub = FilePathStub + Spdx22VersionStub;
+        var spdx30FilePathStub = FilePathStub + Spdx30VersionStub;
+        mockSbomConfigFactory
+            .Setup(m => m.GetSbomFilePath(DirPathStub, Api.Utils.Constants.SPDX22ManifestInfo))
+            .Returns(spdx22FilePathStub)
+            .Verifiable();
+        mockSbomConfigFactory
+            .Setup(m => m.GetSbomFilePath(DirPathStub, Api.Utils.Constants.SPDX30ManifestInfo))
+            .Returns(spdx30FilePathStub)
+            .Verifiable();
+        mockFileSystemUtils
+            .Setup(m => m.FileExists(FilePathStub + Spdx22VersionStub))
+            .Returns(true)
+            .Verifiable();
+        mockFileSystemUtils
+            .Setup(m => m.FileExists(FilePathStub + Spdx30VersionStub))
+            .Returns(true)
+            .Verifiable();
+        mockFileSystemUtils
+            .Setup(m => m.OpenRead(FilePathStub + Spdx22VersionStub))
+            .Returns(TestUtils.GenerateStreamFromString(Spdx22ContentStub))
+            .Verifiable();
+        mockFileSystemUtils
+            .Setup(m => m.OpenRead(FilePathStub + Spdx30VersionStub))
+            .Returns(TestUtils.GenerateStreamFromString(Spdx30ContentStub))
+            .Verifiable();
+
+        var result = testSubject.TryGetSbomsWithVersion(DirPathStub, out var detectedSboms);
+        Assert.IsTrue(result);
+        Assert.IsNotNull(detectedSboms);
+        Assert.AreEqual(2, detectedSboms.Count);
+        Assert.IsTrue(detectedSboms.ContainsKey(FilePathStub + Spdx22VersionStub));
+        Assert.IsTrue(detectedSboms.ContainsKey(FilePathStub + Spdx30VersionStub));
+        Assert.AreEqual(Spdx22VersionStub, detectedSboms[FilePathStub + Spdx22VersionStub].ToString());
+        Assert.AreEqual(Spdx30VersionStub, detectedSboms[FilePathStub + Spdx30VersionStub].ToString());
+    }
+
+    [TestMethod]
+    public void TryGetSbomsWithVersion_NoResults()
+    {
+        var spdx22FilePathStub = FilePathStub + Spdx22VersionStub;
+        var spdx30FilePathStub = FilePathStub + Spdx30VersionStub;
+        mockSbomConfigFactory
+            .Setup(m => m.GetSbomFilePath(DirPathStub, Api.Utils.Constants.SPDX22ManifestInfo))
+            .Returns(spdx22FilePathStub)
+            .Verifiable();
+        mockSbomConfigFactory
+            .Setup(m => m.GetSbomFilePath(DirPathStub, Api.Utils.Constants.SPDX30ManifestInfo))
+            .Returns(spdx30FilePathStub)
+            .Verifiable();
+        mockFileSystemUtils
+            .Setup(m => m.FileExists(FilePathStub + Spdx22VersionStub))
+            .Returns(false)
+            .Verifiable();
+        mockFileSystemUtils
+            .Setup(m => m.FileExists(FilePathStub + Spdx30VersionStub))
+            .Returns(false)
+            .Verifiable();
+
+        var result = testSubject.TryGetSbomsWithVersion(DirPathStub, out var detectedSboms);
+        Assert.IsFalse(result);
+        Assert.IsNotNull(detectedSboms);
+        Assert.IsFalse(detectedSboms.Any());
     }
 
     [TestMethod]

--- a/test/Microsoft.Sbom.Api.Tests/Utils/SPDXFormatDetectorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Utils/SPDXFormatDetectorTests.cs
@@ -86,9 +86,8 @@ public class SPDXFormatDetectorTests
         var result = testSubject.TryGetSbomsWithVersion(DirPathStub, out var detectedSboms);
         Assert.IsTrue(result);
         Assert.IsNotNull(detectedSboms);
-        Assert.AreEqual(1, detectedSboms.Count);
-        Assert.AreEqual(FilePathStub + expectedVersion, detectedSboms.First().Key);
-        Assert.AreEqual(expectedVersion, detectedSboms.First().Value.ToString());
+        Assert.AreEqual(1, detectedSboms.Count());
+        Assert.IsTrue(detectedSboms.Any(value => value.manifestInfo.ToString().Equals(expectedVersion) && value.sbomFilePath.Equals(FilePathStub + expectedVersion)));
     }
 
     [TestMethod]
@@ -124,11 +123,9 @@ public class SPDXFormatDetectorTests
         var result = testSubject.TryGetSbomsWithVersion(DirPathStub, out var detectedSboms);
         Assert.IsTrue(result);
         Assert.IsNotNull(detectedSboms);
-        Assert.AreEqual(2, detectedSboms.Count);
-        Assert.IsTrue(detectedSboms.ContainsKey(FilePathStub + Spdx22VersionStub));
-        Assert.IsTrue(detectedSboms.ContainsKey(FilePathStub + Spdx30VersionStub));
-        Assert.AreEqual(Spdx22VersionStub, detectedSboms[FilePathStub + Spdx22VersionStub].ToString());
-        Assert.AreEqual(Spdx30VersionStub, detectedSboms[FilePathStub + Spdx30VersionStub].ToString());
+        Assert.AreEqual(2, detectedSboms.Count());
+        Assert.IsTrue(detectedSboms.Any(value => value.manifestInfo.ToString().Equals(Spdx22VersionStub) && value.sbomFilePath.Equals(FilePathStub + Spdx22VersionStub)));
+        Assert.IsTrue(detectedSboms.Any(value => value.manifestInfo.ToString().Equals(Spdx30VersionStub) && value.sbomFilePath.Equals(FilePathStub + Spdx30VersionStub)));
     }
 
     [TestMethod]

--- a/test/Microsoft.Sbom.Api.Tests/Utils/SPDXFormatDetectorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Utils/SPDXFormatDetectorTests.cs
@@ -65,29 +65,25 @@ public class SPDXFormatDetectorTests
         var spdx30FilePathStub = FilePathStub + Spdx30VersionStub;
         mockSbomConfigFactory
             .Setup(m => m.GetSbomFilePath(DirPathStub, Api.Utils.Constants.SPDX22ManifestInfo))
-            .Returns(spdx22FilePathStub)
-            .Verifiable();
+            .Returns(spdx22FilePathStub);
         mockSbomConfigFactory
             .Setup(m => m.GetSbomFilePath(DirPathStub, Api.Utils.Constants.SPDX30ManifestInfo))
-            .Returns(spdx30FilePathStub)
-            .Verifiable();
+            .Returns(spdx30FilePathStub);
         mockFileSystemUtils
             .Setup(m => m.FileExists(It.IsAny<string>()))
             .Returns(false);
         mockFileSystemUtils
             .Setup(m => m.FileExists(FilePathStub + expectedVersion))
-            .Returns(true)
-            .Verifiable();
+            .Returns(true);
         mockFileSystemUtils
             .Setup(m => m.OpenRead(FilePathStub + expectedVersion))
-            .Returns(TestUtils.GenerateStreamFromString(testContent))
-            .Verifiable();
+            .Returns(TestUtils.GenerateStreamFromString(testContent));
 
         var result = testSubject.TryGetSbomsWithVersion(DirPathStub, out var detectedSboms);
         Assert.IsTrue(result);
         Assert.IsNotNull(detectedSboms);
         Assert.AreEqual(1, detectedSboms.Count());
-        Assert.IsTrue(detectedSboms.Any(value => value.manifestInfo.ToString().Equals(expectedVersion) && value.sbomFilePath.Equals(FilePathStub + expectedVersion)));
+        Assert.IsTrue(detectedSboms.Any(value => value.manifestInfo.ToString().Equals(expectedVersion) && value.sbomFilePath.Equals(FilePathStub + expectedVersion)), $"Files of format {expectedVersion} should have been detected");
     }
 
     [TestMethod]
@@ -97,35 +93,29 @@ public class SPDXFormatDetectorTests
         var spdx30FilePathStub = FilePathStub + Spdx30VersionStub;
         mockSbomConfigFactory
             .Setup(m => m.GetSbomFilePath(DirPathStub, Api.Utils.Constants.SPDX22ManifestInfo))
-            .Returns(spdx22FilePathStub)
-            .Verifiable();
+            .Returns(spdx22FilePathStub);
         mockSbomConfigFactory
             .Setup(m => m.GetSbomFilePath(DirPathStub, Api.Utils.Constants.SPDX30ManifestInfo))
-            .Returns(spdx30FilePathStub)
-            .Verifiable();
+            .Returns(spdx30FilePathStub);
         mockFileSystemUtils
             .Setup(m => m.FileExists(FilePathStub + Spdx22VersionStub))
-            .Returns(true)
-            .Verifiable();
+            .Returns(true);
         mockFileSystemUtils
             .Setup(m => m.FileExists(FilePathStub + Spdx30VersionStub))
-            .Returns(true)
-            .Verifiable();
+            .Returns(true);
         mockFileSystemUtils
             .Setup(m => m.OpenRead(FilePathStub + Spdx22VersionStub))
-            .Returns(TestUtils.GenerateStreamFromString(Spdx22ContentStub))
-            .Verifiable();
+            .Returns(TestUtils.GenerateStreamFromString(Spdx22ContentStub));
         mockFileSystemUtils
             .Setup(m => m.OpenRead(FilePathStub + Spdx30VersionStub))
-            .Returns(TestUtils.GenerateStreamFromString(Spdx30ContentStub))
-            .Verifiable();
+            .Returns(TestUtils.GenerateStreamFromString(Spdx30ContentStub));
 
         var result = testSubject.TryGetSbomsWithVersion(DirPathStub, out var detectedSboms);
         Assert.IsTrue(result);
         Assert.IsNotNull(detectedSboms);
         Assert.AreEqual(2, detectedSboms.Count());
-        Assert.IsTrue(detectedSboms.Any(value => value.manifestInfo.ToString().Equals(Spdx22VersionStub) && value.sbomFilePath.Equals(FilePathStub + Spdx22VersionStub)));
-        Assert.IsTrue(detectedSboms.Any(value => value.manifestInfo.ToString().Equals(Spdx30VersionStub) && value.sbomFilePath.Equals(FilePathStub + Spdx30VersionStub)));
+        Assert.IsTrue(detectedSboms.Any(value => value.manifestInfo.ToString().Equals(Spdx22VersionStub) && value.sbomFilePath.Equals(FilePathStub + Spdx22VersionStub)), "SPDX 2.2 files should have been detected");
+        Assert.IsTrue(detectedSboms.Any(value => value.manifestInfo.ToString().Equals(Spdx30VersionStub) && value.sbomFilePath.Equals(FilePathStub + Spdx30VersionStub)), "SPDX 3.0 files should have been detected");
     }
 
     [TestMethod]
@@ -135,20 +125,16 @@ public class SPDXFormatDetectorTests
         var spdx30FilePathStub = FilePathStub + Spdx30VersionStub;
         mockSbomConfigFactory
             .Setup(m => m.GetSbomFilePath(DirPathStub, Api.Utils.Constants.SPDX22ManifestInfo))
-            .Returns(spdx22FilePathStub)
-            .Verifiable();
+            .Returns(spdx22FilePathStub);
         mockSbomConfigFactory
             .Setup(m => m.GetSbomFilePath(DirPathStub, Api.Utils.Constants.SPDX30ManifestInfo))
-            .Returns(spdx30FilePathStub)
-            .Verifiable();
+            .Returns(spdx30FilePathStub);
         mockFileSystemUtils
             .Setup(m => m.FileExists(FilePathStub + Spdx22VersionStub))
-            .Returns(false)
-            .Verifiable();
+            .Returns(false);
         mockFileSystemUtils
             .Setup(m => m.FileExists(FilePathStub + Spdx30VersionStub))
-            .Returns(false)
-            .Verifiable();
+            .Returns(false);
 
         var result = testSubject.TryGetSbomsWithVersion(DirPathStub, out var detectedSboms);
         Assert.IsFalse(result);
@@ -163,8 +149,7 @@ public class SPDXFormatDetectorTests
     {
         mockFileSystemUtils
             .Setup(m => m.OpenRead(FilePathStub))
-            .Returns(TestUtils.GenerateStreamFromString(testContent))
-            .Verifiable();
+            .Returns(TestUtils.GenerateStreamFromString(testContent));
 
         var result = testSubject.TryDetectFormat(FilePathStub, out var manifestInfo);
         Assert.IsTrue(result);
@@ -188,8 +173,7 @@ public class SPDXFormatDetectorTests
     {
         mockFileSystemUtils
             .Setup(m => m.OpenRead(FilePathStub))
-            .Returns(TestUtils.GenerateStreamFromString(InvalidContentStub))
-            .Verifiable();
+            .Returns(TestUtils.GenerateStreamFromString(InvalidContentStub));
 
         var result = testSubject.TryDetectFormat(FilePathStub, out var manifestInfo);
         Assert.IsFalse(result);

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/SbomConsolidationWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/SbomConsolidationWorkflowTests.cs
@@ -70,8 +70,7 @@ public class SbomConsolidationWorkflowTests
     {
         configurationMock
             .Setup(m => m.ArtifactInfoMap)
-            .Returns(new ConfigurationSetting<Dictionary<string, ArtifactInfo>>(new Dictionary<string, ArtifactInfo>()))
-            .Verifiable();
+            .Returns(new ConfigurationSetting<Dictionary<string, ArtifactInfo>>(new Dictionary<string, ArtifactInfo>()));
 
         var result = await testSubject.RunAsync();
         Assert.IsFalse(result);
@@ -82,23 +81,21 @@ public class SbomConsolidationWorkflowTests
     {
         configurationMock
             .Setup(m => m.ArtifactInfoMap)
-            .Returns(new ConfigurationSetting<Dictionary<string, ArtifactInfo>>(artifactInfoMapStub))
-            .Verifiable();
+            .Returns(new ConfigurationSetting<Dictionary<string, ArtifactInfo>>(artifactInfoMapStub));
+
         foreach (var (key, artifactInfo) in artifactInfoMapStub)
         {
             if (artifactInfo.ExternalManifestDir == null)
             {
                 fileSystemUtilsMock
                     .Setup(m => m.JoinPaths(key, Api.Utils.Constants.ManifestFolder))
-                    .Returns(key)
-                    .Verifiable();
+                    .Returns(key);
             }
 
             IList<(string, ManifestInfo)> detectedSboms;
             sPDXFormatDetectorMock
                 .Setup(m => m.TryGetSbomsWithVersion(artifactInfo.ExternalManifestDir ?? key, out detectedSboms))
-                .Returns(false)
-                .Verifiable();
+                .Returns(false);
         }
 
         var result = await testSubject.RunAsync();
@@ -111,12 +108,9 @@ public class SbomConsolidationWorkflowTests
     public async Task RunAsync_MinimalHappyPath_CallsGenerationWorkflow(bool expectedResult)
     {
         SetUpSbomsToValidate();
-
         sbomGenerationWorkflowMock.Setup(x => x.RunAsync())
             .ReturnsAsync(expectedResult);
-
         var result = await testSubject.RunAsync();
-
         Assert.AreEqual(expectedResult, result);
     }
 
@@ -124,16 +118,15 @@ public class SbomConsolidationWorkflowTests
     {
         configurationMock
             .Setup(m => m.ArtifactInfoMap)
-            .Returns(new ConfigurationSetting<Dictionary<string, ArtifactInfo>>(artifactInfoMapStub))
-            .Verifiable();
+            .Returns(new ConfigurationSetting<Dictionary<string, ArtifactInfo>>(artifactInfoMapStub));
+
         foreach (var (key, artifactInfo) in artifactInfoMapStub)
         {
             if (artifactInfo.ExternalManifestDir == null)
             {
                 fileSystemUtilsMock
                     .Setup(m => m.JoinPaths(key, Api.Utils.Constants.ManifestFolder))
-                    .Returns(key)
-                    .Verifiable();
+                    .Returns(key);
             }
 
             var manifestDirPath = artifactInfo.ExternalManifestDir ?? key;
@@ -144,16 +137,13 @@ public class SbomConsolidationWorkflowTests
             };
             sPDXFormatDetectorMock
                 .Setup(m => m.TryGetSbomsWithVersion(manifestDirPath, out res))
-                .Returns(true)
-                .Verifiable();
+                .Returns(true);
             sbomConfigFactoryMock
                 .Setup(m => m.Get(Api.Utils.Constants.SPDX22ManifestInfo, manifestDirPath, metadataBuilderFactoryMock.Object))
-                .Returns(new SbomConfig(fileSystemUtilsMock.Object) { ManifestInfo = Api.Utils.Constants.SPDX22ManifestInfo, ManifestJsonDirPath = manifestDirPath })
-                .Verifiable();
+                .Returns(new SbomConfig(fileSystemUtilsMock.Object) { ManifestInfo = Api.Utils.Constants.SPDX22ManifestInfo, ManifestJsonDirPath = manifestDirPath });
             sbomConfigFactoryMock
                 .Setup(m => m.Get(Api.Utils.Constants.SPDX30ManifestInfo, manifestDirPath, metadataBuilderFactoryMock.Object))
-                .Returns(new SbomConfig(fileSystemUtilsMock.Object) { ManifestInfo = Api.Utils.Constants.SPDX30ManifestInfo, ManifestJsonDirPath = manifestDirPath })
-                .Verifiable();
+                .Returns(new SbomConfig(fileSystemUtilsMock.Object) { ManifestInfo = Api.Utils.Constants.SPDX30ManifestInfo, ManifestJsonDirPath = manifestDirPath });
         }
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/SbomConsolidationWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/SbomConsolidationWorkflowTests.cs
@@ -1,8 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.Sbom.Api.Manifest.Configuration;
+using Microsoft.Sbom.Api.Utils;
+using Microsoft.Sbom.Common;
 using Microsoft.Sbom.Common.Config;
+using Microsoft.Sbom.Extensions.Entities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Serilog;
@@ -15,7 +20,17 @@ public class SbomConsolidationWorkflowTests
     private Mock<ILogger> loggerMock;
     private Mock<IConfiguration> configurationMock;
     private Mock<IWorkflow<SbomGenerationWorkflow>> sbomGenerationWorkflowMock;
+    private Mock<ISbomConfigFactory> sbomConfigFactoryMock;
+    private Mock<ISPDXFormatDetector> sPDXFormatDetectorMock;
+    private Mock<IFileSystemUtils> fileSystemUtilsMock;
+    private Mock<IMetadataBuilderFactory> metadataBuilderFactoryMock;
     private SbomConsolidationWorkflow testSubject;
+
+    private Dictionary<string, ArtifactInfo> artifactInfoMapStub = new Dictionary<string, ArtifactInfo>()
+    {
+        { "sbom-key-1", new ArtifactInfo() { } },
+        { "sbom-key-2", new ArtifactInfo() { ExternalManifestDir = "external-manifest-dir-2" } },
+    };
 
     [TestInitialize]
     public void BeforeEachTest()
@@ -23,11 +38,19 @@ public class SbomConsolidationWorkflowTests
         loggerMock = new Mock<ILogger>();  // Intentionally not using Strict to streamline setup
         configurationMock = new Mock<IConfiguration>(MockBehavior.Strict);
         sbomGenerationWorkflowMock = new Mock<IWorkflow<SbomGenerationWorkflow>>(MockBehavior.Strict);
+        sbomConfigFactoryMock = new Mock<ISbomConfigFactory>(MockBehavior.Strict);
+        sPDXFormatDetectorMock = new Mock<ISPDXFormatDetector>(MockBehavior.Strict);
+        fileSystemUtilsMock = new Mock<IFileSystemUtils>(MockBehavior.Strict);
+        metadataBuilderFactoryMock = new Mock<IMetadataBuilderFactory>(MockBehavior.Strict);
 
         testSubject = new SbomConsolidationWorkflow(
             loggerMock.Object,
             configurationMock.Object,
-            sbomGenerationWorkflowMock.Object);
+            sbomGenerationWorkflowMock.Object,
+            sbomConfigFactoryMock.Object,
+            sPDXFormatDetectorMock.Object,
+            fileSystemUtilsMock.Object,
+            metadataBuilderFactoryMock.Object);
     }
 
     [TestCleanup]
@@ -36,6 +59,50 @@ public class SbomConsolidationWorkflowTests
         loggerMock.VerifyAll();
         configurationMock.VerifyAll();
         sbomGenerationWorkflowMock.VerifyAll();
+        sbomConfigFactoryMock.VerifyAll();
+        sPDXFormatDetectorMock.VerifyAll();
+        fileSystemUtilsMock.VerifyAll();
+        metadataBuilderFactoryMock.VerifyAll();
+    }
+
+    [TestMethod]
+    public async Task RunAsync_ReturnsFalseOnNoArtifactInfoMapInput()
+    {
+        configurationMock
+            .Setup(m => m.ArtifactInfoMap)
+            .Returns(new ConfigurationSetting<Dictionary<string, ArtifactInfo>>(new Dictionary<string, ArtifactInfo>()))
+            .Verifiable();
+
+        var result = await testSubject.RunAsync();
+        Assert.IsFalse(result);
+    }
+
+    [TestMethod]
+    public async Task RunAsync_ReturnsFalseOnNoValidSpdxSbomsFound()
+    {
+        configurationMock
+            .Setup(m => m.ArtifactInfoMap)
+            .Returns(new ConfigurationSetting<Dictionary<string, ArtifactInfo>>(artifactInfoMapStub))
+            .Verifiable();
+        foreach (var (key, artifactInfo) in artifactInfoMapStub)
+        {
+            if (artifactInfo.ExternalManifestDir == null)
+            {
+                fileSystemUtilsMock
+                    .Setup(m => m.JoinPaths(key, Api.Utils.Constants.ManifestFolder))
+                    .Returns(key)
+                    .Verifiable();
+            }
+
+            IList<(string, ManifestInfo)> detectedSboms;
+            sPDXFormatDetectorMock
+                .Setup(m => m.TryGetSbomsWithVersion(artifactInfo.ExternalManifestDir ?? key, out detectedSboms))
+                .Returns(false)
+                .Verifiable();
+        }
+
+        var result = await testSubject.RunAsync();
+        Assert.IsFalse(result);
     }
 
     [TestMethod]
@@ -43,11 +110,50 @@ public class SbomConsolidationWorkflowTests
     [DataRow(false)]
     public async Task RunAsync_MinimalHappyPath_CallsGenerationWorkflow(bool expectedResult)
     {
+        SetUpSbomsToValidate();
+
         sbomGenerationWorkflowMock.Setup(x => x.RunAsync())
             .ReturnsAsync(expectedResult);
 
         var result = await testSubject.RunAsync();
 
         Assert.AreEqual(expectedResult, result);
+    }
+
+    private void SetUpSbomsToValidate()
+    {
+        configurationMock
+            .Setup(m => m.ArtifactInfoMap)
+            .Returns(new ConfigurationSetting<Dictionary<string, ArtifactInfo>>(artifactInfoMapStub))
+            .Verifiable();
+        foreach (var (key, artifactInfo) in artifactInfoMapStub)
+        {
+            if (artifactInfo.ExternalManifestDir == null)
+            {
+                fileSystemUtilsMock
+                    .Setup(m => m.JoinPaths(key, Api.Utils.Constants.ManifestFolder))
+                    .Returns(key)
+                    .Verifiable();
+            }
+
+            var manifestDirPath = artifactInfo.ExternalManifestDir ?? key;
+            IList<(string, ManifestInfo)> res = new List<(string, ManifestInfo)>()
+            {
+                (manifestDirPath, Api.Utils.Constants.SPDX22ManifestInfo),
+                (manifestDirPath, Api.Utils.Constants.SPDX30ManifestInfo)
+            };
+            sPDXFormatDetectorMock
+                .Setup(m => m.TryGetSbomsWithVersion(manifestDirPath, out res))
+                .Returns(true)
+                .Verifiable();
+            sbomConfigFactoryMock
+                .Setup(m => m.Get(Api.Utils.Constants.SPDX22ManifestInfo, manifestDirPath, metadataBuilderFactoryMock.Object))
+                .Returns(new SbomConfig(fileSystemUtilsMock.Object) { ManifestInfo = Api.Utils.Constants.SPDX22ManifestInfo, ManifestJsonDirPath = manifestDirPath })
+                .Verifiable();
+            sbomConfigFactoryMock
+                .Setup(m => m.Get(Api.Utils.Constants.SPDX30ManifestInfo, manifestDirPath, metadataBuilderFactoryMock.Object))
+                .Returns(new SbomConfig(fileSystemUtilsMock.Object) { ManifestInfo = Api.Utils.Constants.SPDX30ManifestInfo, ManifestJsonDirPath = manifestDirPath })
+                .Verifiable();
+        }
     }
 }


### PR DESCRIPTION
This PR adds some additional plumbing to the consolidate verb to parse the user provided ArtifactInfoMap and find all valid SBOMs that need to be validated/ consolidated. This PR has logic to account for a variety of flavors of SBOMs- spdx 2.2/3.0 and ADO/ CloudBuild