### PR TITLE
Pass set of validated SBOMs to consolidation

### DIFF
--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/ConsolidationSource.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/ConsolidationSource.cs
@@ -24,4 +24,9 @@ internal class ConsolidationSource
         SbomConfig = sbomConfig ?? throw new ArgumentNullException(nameof(sbomConfig));
         SbomPath = sbomPath ?? throw new ArgumentNullException(nameof(sbomPath));
     }
+
+    public override string ToString()
+    {
+        return $"ConsolidationSource: {ArtifactInfo}, ManifestInfo: {SbomConfig.ManifestInfo}, SbomPath: {SbomPath}";
+    }
 }

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/ConsolidationSource.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/ConsolidationSource.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Sbom.Common.Config;
+using Microsoft.Sbom.Extensions;
+
+namespace Microsoft.Sbom.Api.Workflows.Helpers;
+
+/// <summary>
+/// A class that lets us track information about the source artifact that feeds into a consolidated SBOM.
+/// </summary>
+internal class ConsolidationSource
+{
+    public ArtifactInfo ArtifactInfo { get; }
+
+    public ISbomConfig SbomConfig { get; }
+
+    public string SbomPath { get; }
+
+    public ConsolidationSource(ArtifactInfo artifactInfo, ISbomConfig sbomConfig, string sbomPath)
+    {
+        ArtifactInfo = artifactInfo ?? throw new ArgumentNullException(nameof(artifactInfo));
+        SbomConfig = sbomConfig ?? throw new ArgumentNullException(nameof(sbomConfig));
+        SbomPath = sbomPath ?? throw new ArgumentNullException(nameof(sbomPath));
+    }
+}

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/ConsolidationSource.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/ConsolidationSource.cs
@@ -16,17 +16,14 @@ internal class ConsolidationSource
 
     public ISbomConfig SbomConfig { get; }
 
-    public string SbomPath { get; }
-
-    public ConsolidationSource(ArtifactInfo artifactInfo, ISbomConfig sbomConfig, string sbomPath)
+    public ConsolidationSource(ArtifactInfo artifactInfo, ISbomConfig sbomConfig)
     {
         ArtifactInfo = artifactInfo ?? throw new ArgumentNullException(nameof(artifactInfo));
         SbomConfig = sbomConfig ?? throw new ArgumentNullException(nameof(sbomConfig));
-        SbomPath = sbomPath ?? throw new ArgumentNullException(nameof(sbomPath));
     }
 
     public override string ToString()
     {
-        return $"ConsolidationSource: {ArtifactInfo}, ManifestInfo: {SbomConfig.ManifestInfo}, SbomPath: {SbomPath}";
+        return $"ConsolidationSource: {ArtifactInfo}, ManifestInfo: {SbomConfig.ManifestInfo}";
     }
 }

--- a/src/Microsoft.Sbom.Api/Workflows/SbomConsolidationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SbomConsolidationWorkflow.cs
@@ -127,7 +127,7 @@ public class SbomConsolidationWorkflow : IWorkflow<SbomConsolidationWorkflow>
             var sbomPath = sourceSbom.SbomPath;
             if (!contentProviders.TryGetValue(sbomConfig.ManifestInfo, out var contentProvider))
             {
-                logger.Error("No content provider found for manifest info: {ManifestInfo}", sbomConfig);
+                logger.Error("No content provider found for manifest info: {ManifestInfo}", sbomConfig.ManifestInfo);
                 return false;
             }
 

--- a/src/Microsoft.Sbom.Api/Workflows/SbomConsolidationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SbomConsolidationWorkflow.cs
@@ -22,7 +22,7 @@ public class SbomConsolidationWorkflow : IWorkflow<SbomConsolidationWorkflow>
     private readonly ILogger logger;
     private readonly IConfiguration configuration;
     private readonly ISbomConfigFactory sbomConfigFactory;
-    private readonly ISPDXFormatDetector sPDXFormatDetector;
+    private readonly ISPDXFormatDetector spdxFormatDetector;
     private readonly IFileSystemUtils fileSystemUtils;
     private readonly IMetadataBuilderFactory metadataBuilderFactory;
     private readonly IWorkflow<SbomGenerationWorkflow> sbomGenerationWorkflow;
@@ -35,7 +35,7 @@ public class SbomConsolidationWorkflow : IWorkflow<SbomConsolidationWorkflow>
         IConfiguration configuration,
         IWorkflow<SbomGenerationWorkflow> sbomGenerationWorkflow,
         ISbomConfigFactory sbomConfigFactory,
-        ISPDXFormatDetector sPDXFormatDetector,
+        ISPDXFormatDetector spdxFormatDetector,
         IFileSystemUtils fileSystemUtils,
         IMetadataBuilderFactory metadataBuilderFactory,
         IEnumerable<IMergeableContentProvider> mergeableContentProviders)
@@ -43,7 +43,7 @@ public class SbomConsolidationWorkflow : IWorkflow<SbomConsolidationWorkflow>
         this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
         this.configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         this.sbomConfigFactory = sbomConfigFactory ?? throw new ArgumentNullException(nameof(sbomConfigFactory));
-        this.sPDXFormatDetector = sPDXFormatDetector ?? throw new ArgumentNullException(nameof(sPDXFormatDetector));
+        this.spdxFormatDetector = spdxFormatDetector ?? throw new ArgumentNullException(nameof(spdxFormatDetector));
         this.fileSystemUtils = fileSystemUtils ?? throw new ArgumentNullException(nameof(fileSystemUtils));
         this.metadataBuilderFactory = metadataBuilderFactory ?? throw new ArgumentNullException(nameof(metadataBuilderFactory));
         this.sbomGenerationWorkflow = sbomGenerationWorkflow ?? throw new ArgumentNullException(nameof(sbomGenerationWorkflow));
@@ -85,7 +85,7 @@ public class SbomConsolidationWorkflow : IWorkflow<SbomConsolidationWorkflow>
     private IEnumerable<ConsolidationSource> GetSbomsToConsolidate(string artifactPath, ArtifactInfo info)
     {
         var manifestDirPath = info?.ExternalManifestDir ?? fileSystemUtils.JoinPaths(artifactPath, Constants.ManifestFolder);
-        var isValidSpdxFormat = sPDXFormatDetector.TryGetSbomsWithVersion(manifestDirPath, out var detectedSboms);
+        var isValidSpdxFormat = spdxFormatDetector.TryGetSbomsWithVersion(manifestDirPath, out var detectedSboms);
         if (!isValidSpdxFormat)
         {
             logger.Information($"No SBOMs located in {manifestDirPath} of a recognized SPDX format.");

--- a/src/Microsoft.Sbom.Api/Workflows/SbomConsolidationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SbomConsolidationWorkflow.cs
@@ -92,7 +92,7 @@ public class SbomConsolidationWorkflow : IWorkflow<SbomConsolidationWorkflow>
             return null;
         }
 
-        return detectedSboms.Select((sbom) => new ConsolidationSource(info, sbomConfigFactory.Get(sbom.manifestInfo, manifestDirPath, metadataBuilderFactory), sbom.sbomFilePath));
+        return detectedSboms.Select((sbom) => new ConsolidationSource(info, sbomConfigFactory.Get(sbom.manifestInfo, manifestDirPath, metadataBuilderFactory)));
     }
 
     private async Task<bool> ValidateSourceSbomsAsync(IEnumerable<ConsolidationSource> consolidationSources)
@@ -124,7 +124,7 @@ public class SbomConsolidationWorkflow : IWorkflow<SbomConsolidationWorkflow>
         foreach (var consolidationSource in consolidationSources)
         {
             var sbomConfig = consolidationSource.SbomConfig;
-            var sbomPath = consolidationSource.SbomPath;
+            var sbomPath = consolidationSource.SbomConfig.ManifestJsonFilePath;
             if (!contentProviders.TryGetValue(sbomConfig.ManifestInfo, out var contentProvider))
             {
                 logger.Error("No content provider found for manifest info: {ManifestInfo}", sbomConfig.ManifestInfo);

--- a/src/Microsoft.Sbom.Api/Workflows/SbomConsolidationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SbomConsolidationWorkflow.cs
@@ -121,10 +121,10 @@ public class SbomConsolidationWorkflow : IWorkflow<SbomConsolidationWorkflow>
         var contents = new List<MergeableContent>();
 
         // Incorporate the source SBOMs in the consolidated SBOM generation workflow.
-        foreach (var sourceSbom in consolidationSources)
+        foreach (var consolidationSource in consolidationSources)
         {
-            var sbomConfig = sourceSbom.SbomConfig;
-            var sbomPath = sourceSbom.SbomPath;
+            var sbomConfig = consolidationSource.SbomConfig;
+            var sbomPath = consolidationSource.SbomPath;
             if (!contentProviders.TryGetValue(sbomConfig.ManifestInfo, out var contentProvider))
             {
                 logger.Error("No content provider found for manifest info: {ManifestInfo}", sbomConfig.ManifestInfo);

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/SbomConsolidationWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/SbomConsolidationWorkflowTests.cs
@@ -23,6 +23,12 @@ public class SbomConsolidationWorkflowTests
     private const string ArtifactKey1 = "sbom-key-1";
     private const string ArtifactKey2 = "sbom-key-2";
     private const string ExternalManifestDir2 = "external-manifest-dir-2";
+    private const string RelativePathToSpdx22Manifest = "/spdx_2.2/manifest.json";
+    private const string RelativePathToSpdx30Manifest = "/spdx_3.0/manifest.json";
+    private const string PathToSpdx22ManifestForArtifactKey1 = ArtifactKey1 + RelativePathToSpdx22Manifest;
+    private const string PathToSpdx30ManifestForArtifactKey1 = ArtifactKey1 + RelativePathToSpdx30Manifest;
+    private const string PathToSpdx22ManifestForArtifactKey2 = ExternalManifestDir2 + RelativePathToSpdx22Manifest;
+    private const string PathToSpdx30ManifestForArtifactKey2 = ExternalManifestDir2 + RelativePathToSpdx30Manifest;
 
     private Mock<ILogger> loggerMock;
     private Mock<IConfiguration> configurationMock;
@@ -128,13 +134,13 @@ public class SbomConsolidationWorkflowTests
         SetUpSbomsToValidate();
         sbomGenerationWorkflowMock.Setup(x => x.RunAsync())
             .ReturnsAsync(expectedResult);
-        mergeableContent22ProviderMock.Setup(x => x.TryGetContent(ArtifactKey1, out It.Ref<MergeableContent>.IsAny))
+        mergeableContent22ProviderMock.Setup(x => x.TryGetContent(PathToSpdx22ManifestForArtifactKey1, out It.Ref<MergeableContent>.IsAny))
             .Returns(true);
-        mergeableContent22ProviderMock.Setup(x => x.TryGetContent(ExternalManifestDir2, out It.Ref<MergeableContent>.IsAny))
+        mergeableContent22ProviderMock.Setup(x => x.TryGetContent(PathToSpdx22ManifestForArtifactKey2, out It.Ref<MergeableContent>.IsAny))
             .Returns(true);
-        mergeableContent30ProviderMock.Setup(x => x.TryGetContent(ArtifactKey1, out It.Ref<MergeableContent>.IsAny))
+        mergeableContent30ProviderMock.Setup(x => x.TryGetContent(PathToSpdx30ManifestForArtifactKey1, out It.Ref<MergeableContent>.IsAny))
             .Returns(true);
-        mergeableContent30ProviderMock.Setup(x => x.TryGetContent(ExternalManifestDir2, out It.Ref<MergeableContent>.IsAny))
+        mergeableContent30ProviderMock.Setup(x => x.TryGetContent(PathToSpdx30ManifestForArtifactKey2, out It.Ref<MergeableContent>.IsAny))
             .Returns(true);
 
         var result = await testSubject.RunAsync();
@@ -167,10 +173,20 @@ public class SbomConsolidationWorkflowTests
                 .Returns(true);
             sbomConfigFactoryMock
                 .Setup(m => m.Get(Constants.SPDX22ManifestInfo, manifestDirPath, metadataBuilderFactoryMock.Object))
-                .Returns(new SbomConfig(fileSystemUtilsMock.Object) { ManifestInfo = Constants.SPDX22ManifestInfo, ManifestJsonDirPath = manifestDirPath });
+                .Returns(new SbomConfig(fileSystemUtilsMock.Object)
+                {
+                    ManifestInfo = Constants.SPDX22ManifestInfo,
+                    ManifestJsonDirPath = manifestDirPath,
+                    ManifestJsonFilePath = $"{manifestDirPath}{RelativePathToSpdx22Manifest}",
+                });
             sbomConfigFactoryMock
                 .Setup(m => m.Get(Constants.SPDX30ManifestInfo, manifestDirPath, metadataBuilderFactoryMock.Object))
-                .Returns(new SbomConfig(fileSystemUtilsMock.Object) { ManifestInfo = Constants.SPDX30ManifestInfo, ManifestJsonDirPath = manifestDirPath });
+                .Returns(new SbomConfig(fileSystemUtilsMock.Object)
+                {
+                    ManifestInfo = Constants.SPDX30ManifestInfo,
+                    ManifestJsonDirPath = manifestDirPath,
+                    ManifestJsonFilePath = $"{manifestDirPath}{RelativePathToSpdx30Manifest}",
+                });
         }
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/SbomConsolidationWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/SbomConsolidationWorkflowTests.cs
@@ -30,7 +30,7 @@ public class SbomConsolidationWorkflowTests
     private Mock<IMergeableContentProvider> mergeableContent22ProviderMock;
     private Mock<IMergeableContentProvider> mergeableContent30ProviderMock;
     private Mock<ISbomConfigFactory> sbomConfigFactoryMock;
-    private Mock<ISPDXFormatDetector> sPDXFormatDetectorMock;
+    private Mock<ISPDXFormatDetector> spdxFormatDetectorMock;
     private Mock<IFileSystemUtils> fileSystemUtilsMock;
     private Mock<IMetadataBuilderFactory> metadataBuilderFactoryMock;
     private SbomConsolidationWorkflow testSubject;
@@ -48,7 +48,7 @@ public class SbomConsolidationWorkflowTests
         configurationMock = new Mock<IConfiguration>(MockBehavior.Strict);
         sbomGenerationWorkflowMock = new Mock<IWorkflow<SbomGenerationWorkflow>>(MockBehavior.Strict);
         sbomConfigFactoryMock = new Mock<ISbomConfigFactory>(MockBehavior.Strict);
-        sPDXFormatDetectorMock = new Mock<ISPDXFormatDetector>(MockBehavior.Strict);
+        spdxFormatDetectorMock = new Mock<ISPDXFormatDetector>(MockBehavior.Strict);
         fileSystemUtilsMock = new Mock<IFileSystemUtils>(MockBehavior.Strict);
         metadataBuilderFactoryMock = new Mock<IMetadataBuilderFactory>(MockBehavior.Strict);
         mergeableContent22ProviderMock = new Mock<IMergeableContentProvider>(MockBehavior.Strict);
@@ -64,7 +64,7 @@ public class SbomConsolidationWorkflowTests
             configurationMock.Object,
             sbomGenerationWorkflowMock.Object,
             sbomConfigFactoryMock.Object,
-            sPDXFormatDetectorMock.Object,
+            spdxFormatDetectorMock.Object,
             fileSystemUtilsMock.Object,
             metadataBuilderFactoryMock.Object,
             new[] { mergeableContent22ProviderMock.Object, mergeableContent30ProviderMock.Object });
@@ -77,7 +77,7 @@ public class SbomConsolidationWorkflowTests
         configurationMock.VerifyAll();
         sbomGenerationWorkflowMock.VerifyAll();
         sbomConfigFactoryMock.VerifyAll();
-        sPDXFormatDetectorMock.VerifyAll();
+        spdxFormatDetectorMock.VerifyAll();
         fileSystemUtilsMock.VerifyAll();
         metadataBuilderFactoryMock.VerifyAll();
         mergeableContent22ProviderMock.VerifyAll();
@@ -111,7 +111,7 @@ public class SbomConsolidationWorkflowTests
             }
 
             IList<(string, ManifestInfo)> detectedSboms;
-            sPDXFormatDetectorMock
+            spdxFormatDetectorMock
                 .Setup(m => m.TryGetSbomsWithVersion(artifactInfo.ExternalManifestDir ?? key, out detectedSboms))
                 .Returns(false);
         }
@@ -162,7 +162,7 @@ public class SbomConsolidationWorkflowTests
                 (manifestDirPath, Constants.SPDX22ManifestInfo),
                 (manifestDirPath, Constants.SPDX30ManifestInfo)
             };
-            sPDXFormatDetectorMock
+            spdxFormatDetectorMock
                 .Setup(m => m.TryGetSbomsWithVersion(manifestDirPath, out res))
                 .Returns(true);
             sbomConfigFactoryMock


### PR DESCRIPTION
#1117 included a temporary property that was just for testing purposes. This PR is about removing that temporary property.

1. Remove `SbomConsolidationWorkflow.SourceSbomsTemp`
2. The SBOM detection code had the sbomPath, but wasn't passing it back to where the consolidation code could access it. I could have added another field to the `Tuple`, but it felt cleaner to replace the `Tuple` with a new class--this is the `ConsolidationSource` class
3. Add a couple of mocks to replace the test that was setting the temporary property
4. Rename `sbomsToValidate` to `consolidationSources`, since the same data will flow to both validation and consolidation
5. Use some const strings in the unit tests
6. Casing consistency: We had a couple of variables whose names began with `sPDXFormatDetector`. Change them to begin with `spdxFormatDetector`
