### PR TITLE
Follow try standard

### DIFF
--- a/src/Microsoft.Sbom.Api/Utils/SPDXFormatDetector.cs
+++ b/src/Microsoft.Sbom.Api/Utils/SPDXFormatDetector.cs
@@ -36,7 +36,8 @@ public class SPDXFormatDetector : ISPDXFormatDetector
     public bool TryGetSbomsWithVersion(string manifestDirPath, out IList<(string sbomFilePath, ManifestInfo manifestInfo)> detectedSboms)
     {
         detectedSboms = new List<(string, ManifestInfo)>();
-        foreach (var mi in supportedManifestInfos.Keys) {
+        foreach (var mi in supportedManifestInfos.Keys)
+        {
             var filePath = sbomConfigFactory.GetSbomFilePath(manifestDirPath, mi);
             if (fileSystemUtils.FileExists(filePath) && fileSystemUtils.GetFileSize(filePath) > 0)
             {
@@ -48,7 +49,13 @@ public class SPDXFormatDetector : ISPDXFormatDetector
             }
         }
 
-        return detectedSboms.Any();
+        if (detectedSboms.Any())
+        {
+            return true;
+        }
+
+        detectedSboms = null;
+        return false;
     }
 
     public bool TryDetectFormat(string filePath, out ManifestInfo detectedManifestInfo)

--- a/test/Microsoft.Sbom.Api.Tests/Utils/SPDXFormatDetectorTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Utils/SPDXFormatDetectorTests.cs
@@ -149,8 +149,7 @@ public class SPDXFormatDetectorTests
 
         var result = testSubject.TryGetSbomsWithVersion(DirPathStub, out var detectedSboms);
         Assert.IsFalse(result);
-        Assert.IsNotNull(detectedSboms);
-        Assert.IsFalse(detectedSboms.Any());
+        Assert.IsNull(detectedSboms);
     }
 
     [TestMethod]
@@ -179,8 +178,7 @@ public class SPDXFormatDetectorTests
 
         var result = testSubject.TryGetSbomsWithVersion(DirPathStub, out var detectedSboms);
         Assert.IsFalse(result);
-        Assert.IsNotNull(detectedSboms);
-        Assert.IsFalse(detectedSboms.Any());
+        Assert.IsNull(detectedSboms);
     }
 
     [TestMethod]


### PR DESCRIPTION
I can't pin down documentation on this, but all of .NET `Try*` methods that use an `out` parameter follow the same pattern:
1. If the method returns true, the `out` parameter is not `null`
2. If the method returns false, the `out` parameter is `null`

I happened to notice that the `TryGetSbomsWithVersion` method in `SPDXFormatDetector` was not following this pattern on failure--instead of setting `detectedSboms` to `null`, it was setting it to an empty list. This PR just sets `detectedSboms` to `null` on failure and updates the unit tests accordingly. The calling code didn't need any modification, since it was already checking the return value before using `detectedSboms`
