### PR TITLE
Do not require outputPath in consolidate config file

### DIFF
--- a/src/Microsoft.Sbom.Api/Workflows/SbomConsolidationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SbomConsolidationWorkflow.cs
@@ -105,7 +105,6 @@ public class SbomConsolidationWorkflow : IWorkflow<SbomConsolidationWorkflow>
         foreach (var source in consolidationSources)
         {
             var identifier = Math.Abs(string.GetHashCode(source.SbomConfig.ManifestJsonFilePath)).ToString();
-            var defaultOutputPath = configuration.OutputPath.Value;
             var workflowResult = false;
             try
             {
@@ -126,7 +125,7 @@ public class SbomConsolidationWorkflow : IWorkflow<SbomConsolidationWorkflow>
             finally
             {
                 configuration.BuildDropPath.Value = null;
-                configuration.OutputPath.Value = defaultOutputPath;
+                configuration.OutputPath.Value = null;
 
                 result = workflowResult && result;
             }

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/SbomConsolidationWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/SbomConsolidationWorkflowTests.cs
@@ -148,7 +148,7 @@ public class SbomConsolidationWorkflowTests
     {
         SetUpSbomsToValidate();
 
-        configurationMock.Setup(m => m.OutputPath).Returns(new ConfigurationSetting<string>("test-out-path"));
+        configurationMock.Setup(m => m.OutputPath).Returns(new ConfigurationSetting<string>());
         configurationMock.Setup(m => m.ValidateSignature).Returns(new ConfigurationSetting<bool>(true));
         configurationMock.Setup(m => m.BuildDropPath).Returns(new ConfigurationSetting<string>(ArtifactKey1));
         configurationMock.SetupSet(m => m.ValidateSignature = It.IsAny<ConfigurationSetting<bool>>());
@@ -240,7 +240,7 @@ public class SbomConsolidationWorkflowTests
 
     private void SetUpMinimalValidation(bool workflowResult = true)
     {
-        configurationMock.Setup(m => m.OutputPath).Returns(new ConfigurationSetting<string>("test-out-path"));
+        configurationMock.Setup(m => m.OutputPath).Returns(new ConfigurationSetting<string>());
         configurationMock.Setup(m => m.ValidateSignature).Returns(new ConfigurationSetting<bool>(true));
         configurationMock.Setup(m => m.BuildDropPath).Returns(new ConfigurationSetting<string>());
         configurationMock.SetupSet(m => m.ValidateSignature = It.IsAny<ConfigurationSetting<bool>>());


### PR DESCRIPTION
Fixes a bug in the consolidation code in which we expected the `OutputPath` param to always be specified in the consolidate config file. 