### PR TITLE
Generated a consolidated SBOM

### DIFF
--- a/src/Microsoft.Sbom.Api/Manifest/BaseManifestConfigHandler.cs
+++ b/src/Microsoft.Sbom.Api/Manifest/BaseManifestConfigHandler.cs
@@ -69,7 +69,8 @@ public abstract class BaseManifestConfigHandler : IManifestConfigHandler
 
         // For generation the default behavior is to return the SPDX 2.2 SBOM.
         // Only override if the -mi argument is specified.
-        if (configuration.ManifestToolAction == ManifestToolActions.Generate)
+        if (configuration.ManifestToolAction == ManifestToolActions.Generate ||
+            configuration.ManifestToolAction == ManifestToolActions.Consolidate)
         {
             if (configuration.ManifestInfo?.Value != null
                 && !Constants.SupportedSpdxManifests.Any(configuration.ManifestInfo.Value.Contains))

--- a/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfigProvider.cs
+++ b/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfigProvider.cs
@@ -211,6 +211,11 @@ public class SbomConfigProvider : ISbomConfigProvider
         throw new Exception("Unable to find any provider to generate the namespace.");
     }
 
+    public void ClearCache()
+    {
+        configsDictionary = null;
+    }
+
     public void Dispose()
     {
         Dispose(disposing: true);

--- a/src/Microsoft.Sbom.Api/Workflows/SbomConsolidationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SbomConsolidationWorkflow.cs
@@ -21,6 +21,8 @@ namespace Microsoft.Sbom.Api.Workflows;
 
 public class SbomConsolidationWorkflow : IWorkflow<SbomConsolidationWorkflow>
 {
+    public const string WorkingDirPrefix = "sbom-consolidation-";
+
     private readonly ILogger logger;
     private readonly IConfiguration configuration;
     private readonly ISbomConfigFactory sbomConfigFactory;
@@ -96,23 +98,19 @@ public class SbomConsolidationWorkflow : IWorkflow<SbomConsolidationWorkflow>
             logger.Information($"Running consolidation on the following SBOMs:\n{string.Join('\n', consolidationSources.Select(s => s.SbomConfig.ManifestJsonFilePath))}");
         }
 
-        workingDir = fileSystemUtils.CreateTempSubDirectory();
+        workingDir = fileSystemUtils.CreateTempSubDirectory(WorkingDirPrefix);
 
         try
         {
             return await ValidateSourceSbomsAsync(consolidationSources) && await GenerateConsolidatedSbom(consolidationSources);
         }
-#if DEBUG
         catch (Exception)
         {
+#if DEBUG
             // This is here to help debug issues during active development. It will be removed before release.
             System.Diagnostics.Debugger.Break();
-            throw;
-        }
 #endif
-        finally
-        {
-            fileSystemUtils.DeleteDir(workingDir, true);
+            throw;
         }
     }
 

--- a/src/Microsoft.Sbom.Api/Workflows/SbomConsolidationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SbomConsolidationWorkflow.cs
@@ -10,6 +10,7 @@ using Microsoft.Sbom.Api.Utils;
 using Microsoft.Sbom.Api.Workflows.Helpers;
 using Microsoft.Sbom.Common;
 using Microsoft.Sbom.Common.Config;
+using Microsoft.Sbom.Contracts;
 using Microsoft.Sbom.Extensions;
 using Microsoft.Sbom.Extensions.Entities;
 using Serilog;
@@ -167,13 +168,13 @@ public class SbomConsolidationWorkflow : IWorkflow<SbomConsolidationWorkflow>
             return false;
         }
 
-        SetConfigurationForConsolidation();
+        SetConfigurationForConsolidation(mergeableContents);
 
         // TODO : How do we pass mergeableContents into the generation workflow?
         return await sbomGenerationWorkflow.RunAsync().ConfigureAwait(false);
     }
 
-    private void SetConfigurationForConsolidation()
+    private void SetConfigurationForConsolidation(IEnumerable<MergeableContent> mergeableContents)
     {
         var buildDropPath = Path.Combine(workingDir, "consolidated-build-drop");
         fileSystemUtils.CreateDirectory(buildDropPath);
@@ -181,6 +182,7 @@ public class SbomConsolidationWorkflow : IWorkflow<SbomConsolidationWorkflow>
         configuration.ManifestInfo = new ConfigurationSetting<IList<ManifestInfo>>(new List<ManifestInfo> { Constants.SPDX22ManifestInfo });
         configuration.BuildDropPath = new ConfigurationSetting<string>(buildDropPath);
         configuration.BuildComponentPath = new ConfigurationSetting<string>(buildDropPath);
+        configuration.PackagesList = new ConfigurationSetting<IEnumerable<SbomPackage>>(mergeableContents.ToMergedPackages());
     }
 
     private bool TryGetMergeableContent(IEnumerable<ConsolidationSource> consolidationSources, out IEnumerable<MergeableContent> mergeableContents)

--- a/src/Microsoft.Sbom.Common/FileSystemUtils.cs
+++ b/src/Microsoft.Sbom.Common/FileSystemUtils.cs
@@ -29,7 +29,7 @@ public abstract class FileSystemUtils : IFileSystemUtils
     public string GetSbomToolTempPath() => SbomToolTempPath;
 
     /// <inheritdoc />
-    public string CreateTempSubDirectory() => Directory.CreateTempSubdirectory().FullName;
+    public string CreateTempSubDirectory(string prefix = default) => Directory.CreateTempSubdirectory(prefix).FullName;
 
     /// <inheritdoc />
     public IEnumerable<string> GetDirectories(string path, bool followSymlinks = true) => followSymlinks switch

--- a/src/Microsoft.Sbom.Common/IFileSystemUtils.cs
+++ b/src/Microsoft.Sbom.Common/IFileSystemUtils.cs
@@ -203,6 +203,7 @@ public interface IFileSystemUtils
     /// <summary>
     /// Returns the path to a temp dir
     /// </summary>
+    /// <param name="prefix">Optional prefix for the temp directory name.</param>
     /// <returns>Path to a temp dir</returns>
-    public string CreateTempSubDirectory();
+    public string CreateTempSubDirectory(string prefix = default);
 }

--- a/src/Microsoft.Sbom.Extensions/ISbomConfigProvider.cs
+++ b/src/Microsoft.Sbom.Extensions/ISbomConfigProvider.cs
@@ -49,4 +49,9 @@ public interface ISbomConfigProvider : IDisposable, IAsyncDisposable, IInternalM
     /// </summary>
     /// <param name="action">The action to perform on the config.</param>
     public void ApplyToEachConfig(Action<ISbomConfig> action);
+
+    /// <summary>
+    /// Clear the cache. Use sparingly, as it will cause perf issues if abused.
+    /// </summary>
+    public void ClearCache();
 }

--- a/src/Microsoft.Sbom.Extensions/MergeableContentExtensions.cs
+++ b/src/Microsoft.Sbom.Extensions/MergeableContentExtensions.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Sbom.Contracts;
+
+namespace Microsoft.Sbom.Extensions;
+
+public static class MergeableContentExtensions
+{
+    public static IEnumerable<SbomPackage> ToMergedPackages(this IEnumerable<MergeableContent> contents)
+    {
+        if (contents == null)
+        {
+            throw new ArgumentNullException(nameof(contents));
+        }
+
+        return contents.SelectMany(c => c.Packages).Distinct();
+    }
+}

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/SbomConsolidationWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/SbomConsolidationWorkflowTests.cs
@@ -295,8 +295,7 @@ public class SbomConsolidationWorkflowTests
         configurationMock.SetupSet(m => m.OutputPath = It.IsAny<ConfigurationSetting<string>>());
         configurationMock.SetupSet(m => m.ValidateSignature = It.IsAny<ConfigurationSetting<bool>>());
 
-        fileSystemUtilsMock.Setup(m => m.CreateTempSubDirectory()).Returns(TempDirPath);
-        fileSystemUtilsMock.Setup(m => m.DeleteDir(TempDirPath, true));
+        fileSystemUtilsMock.Setup(m => m.CreateTempSubDirectory(SbomConsolidationWorkflow.WorkingDirPrefix)).Returns(TempDirPath);
         fileSystemUtilsMock.Setup(m => m.JoinPaths(TempDirPath, It.IsAny<string>())).Returns(TempDirPath);
     }
 

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/SbomConsolidationWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/SbomConsolidationWorkflowTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Sbom.Api.Manifest.Configuration;
 using Microsoft.Sbom.Api.Utils;
@@ -209,8 +210,8 @@ public class SbomConsolidationWorkflowTests
     {
         SetUpSbomsToValidate();
         SetUpMinimalValidation();
-        sbomGenerationWorkflowMock.Setup(x => x.RunAsync())
-            .ReturnsAsync(expectedResult);
+        SetupMinimalGenerationMocks(expectedResult);
+
         mergeableContent22ProviderMock.Setup(x => x.TryGetContent(PathToSpdx22ManifestForArtifactKey1, out It.Ref<MergeableContent>.IsAny))
             .Returns(true);
         mergeableContent22ProviderMock.Setup(x => x.TryGetContent(PathToSpdx22ManifestForArtifactKey2, out It.Ref<MergeableContent>.IsAny))
@@ -288,6 +289,15 @@ public class SbomConsolidationWorkflowTests
         configurationMock.SetupSet(m => m.OutputPath = It.IsAny<ConfigurationSetting<string>>());
         fileSystemUtilsMock.Setup(m => m.CreateTempSubDirectory()).Returns(TempDirPath);
         fileSystemUtilsMock.Setup(m => m.JoinPaths(TempDirPath, It.IsAny<string>())).Returns(TempDirPath);
-        fileSystemUtilsMock.Setup(m => m.DeleteDir(TempDirPath, false));
+        fileSystemUtilsMock.Setup(m => m.DeleteDir(TempDirPath, true));
+    }
+
+    private void SetupMinimalGenerationMocks(bool expectedResult)
+    {
+        fileSystemUtilsMock.Setup(m => m.CreateDirectory(Path.Join(TempDirPath, "consolidated-build-drop"))).Returns<DirectoryInfo>(null);
+        configurationMock.SetupSet(m => m.ManifestInfo = It.IsAny<ConfigurationSetting<IList<ManifestInfo>>>());
+        configurationMock.SetupSet(m => m.BuildComponentPath = It.IsAny<ConfigurationSetting<string>>());
+        configurationMock.SetupSet(m => m.BuildDropPath = It.IsAny<ConfigurationSetting<string>>());
+        sbomGenerationWorkflowMock.Setup(x => x.RunAsync()).ReturnsAsync(expectedResult);
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/SbomConsolidationWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/SbomConsolidationWorkflowTests.cs
@@ -185,16 +185,7 @@ public class SbomConsolidationWorkflowTests
     public async Task RunAsync_MixOfValidAndInvalidInputSboms()
     {
         SetUpSbomsToValidate();
-
-        configurationMock.Setup(m => m.OutputPath).Returns(new ConfigurationSetting<string>());
-        configurationMock.Setup(m => m.ValidateSignature).Returns(new ConfigurationSetting<bool>(true));
-        configurationMock.Setup(m => m.BuildDropPath).Returns(new ConfigurationSetting<string>(ArtifactKey1));
-        configurationMock.SetupSet(m => m.ValidateSignature = It.IsAny<ConfigurationSetting<bool>>());
-        configurationMock.SetupSet(m => m.IgnoreMissing = It.IsAny<ConfigurationSetting<bool>>());
-        configurationMock.SetupSet(m => m.BuildDropPath = It.IsAny<ConfigurationSetting<string>>());
-        configurationMock.SetupSet(m => m.OutputPath = It.IsAny<ConfigurationSetting<string>>());
-        fileSystemUtilsMock.Setup(m => m.CreateTempSubDirectory()).Returns(TempDirPath);
-        fileSystemUtilsMock.Setup(m => m.JoinPaths(TempDirPath, It.IsAny<string>())).Returns(TempDirPath);
+        SetupMinimalValidationMocks();
 
         sbomValidationWorkflowFactoryMock
             .Setup(x => x.Get(It.IsAny<IConfiguration>(), It.Is<SbomConfig>(c => c.ManifestJsonDirPath.Equals(ArtifactKey1)), It.IsAny<string>()))
@@ -278,6 +269,16 @@ public class SbomConsolidationWorkflowTests
 
     private void SetUpMinimalValidation(bool workflowResult = true)
     {
+        SetupMinimalValidationMocks();
+
+        sbomValidationWorkflowFactoryMock
+            .Setup(x => x.Get(It.IsAny<IConfiguration>(), It.IsAny<SbomConfig>(), It.IsAny<string>()))
+            .Returns(sbomValidationWorkflowMock.Object);
+        sbomValidationWorkflowMock.Setup(x => x.RunAsync()).ReturnsAsync(workflowResult);
+    }
+
+    private void SetupMinimalValidationMocks()
+    {
         configurationMock.Setup(m => m.OutputPath).Returns(new ConfigurationSetting<string>());
         configurationMock.Setup(m => m.ValidateSignature).Returns(new ConfigurationSetting<bool>(true));
         configurationMock.Setup(m => m.BuildDropPath).Returns(new ConfigurationSetting<string>());
@@ -287,10 +288,6 @@ public class SbomConsolidationWorkflowTests
         configurationMock.SetupSet(m => m.OutputPath = It.IsAny<ConfigurationSetting<string>>());
         fileSystemUtilsMock.Setup(m => m.CreateTempSubDirectory()).Returns(TempDirPath);
         fileSystemUtilsMock.Setup(m => m.JoinPaths(TempDirPath, It.IsAny<string>())).Returns(TempDirPath);
-
-        sbomValidationWorkflowFactoryMock
-            .Setup(x => x.Get(It.IsAny<IConfiguration>(), It.IsAny<SbomConfig>(), It.IsAny<string>()))
-            .Returns(sbomValidationWorkflowMock.Object);
-        sbomValidationWorkflowMock.Setup(x => x.RunAsync()).ReturnsAsync(workflowResult);
+        fileSystemUtilsMock.Setup(m => m.DeleteDir(TempDirPath, false));
     }
 }


### PR DESCRIPTION
This PR creates the full end-to-end experience with consolidation, using real SBOM as the basis for the local testing. It needs more unit tests and maybe some E2E tests, but this connects the pieces. Here are the key issues that it addresses:

1. The first issue was that we needed to get the correct set of packages, instead of the ones from the component-detection code. To do this, we set the `IConfiguration.PackagesList` property. This causes [SbomPackagesProvider](https://github.com/microsoft/sbom-tool/blob/main/src/Microsoft.Sbom.Api/Providers/PackagesProviders/SbomPackagesProvider.cs#L34-L46) to replace [CGScannedPackagesProvider](https://github.com/microsoft/sbom-tool/blob/main/src/Microsoft.Sbom.Api/Providers/PackagesProviders/CGScannedPackagesProvider.cs#L43-L56) as the source of the `packages` section of the generated SBOM.
2. The second issue was that the validation of packages with the _manifest folder contained in the drop were failing during consolidation. This was because the validation code uses the `ManifestDirPath` property to automatically ignore the contents of this folder, meaning that it needs to be set for each SBOM that we validate. We now set, then restore the property around each validation workflow. The code that sets the property is duplicated, but there was no obvious to avoid this, short of creating a new class, which seemed like overkill for the amount of code involved. It's easy to refactor if needed.
3. The third issue was that the consolidate SBOM was being written to the wrong location. Instead of going to the location specified by the `ManifestDirPath`, it was overwriting one of the input SBOMs. This took a while to figure out, but ultimately it boils down to the fact that the `SbomConfigProvider` was written with the assumption that `ManifestDirPath` was constant throughout the app's lifetime. The value set during validation was saved, then reused during generation. There are multiple ways we could address this, but I elected to add a `ISbomConfigProvider` that clears the cache between validation and generation. I also considered changing the `ISbomConfigProvider from a Singleton to a Transient, but I wanted to minimize the potential side effects. The new method only gets called by the consolidation workflow, so the side effects are constrained.

The rest of the changes are mainly about unit tests (including some refactoring of setting up the mocks) and adding an extension class for managing the `MergeableContent`. I also added code to clean up our temp directory after exiting. We can tweak that as needed.