### PR TITLE
Add aggregation telemetry

### DIFF
--- a/src/Microsoft.Sbom.Api/Output/Telemetry/Entities/AggregationSourceTelemetry.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/Entities/AggregationSourceTelemetry.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Sbom.Api.Output.Telemetry.Entities;
+
+/// <summary>
+/// Defines the telemetry we produce for each AggregationSource object
+/// </summary>
+public class AggregationSourceTelemetry
+{
+    public int PackageCount { get; set; }
+
+    public int RelationShipCount { get; set; }
+}

--- a/src/Microsoft.Sbom.Api/Output/Telemetry/Entities/AggregationSourceTelemetry.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/Entities/AggregationSourceTelemetry.cs
@@ -10,5 +10,5 @@ public class AggregationSourceTelemetry
 {
     public int PackageCount { get; set; }
 
-    public int RelationShipCount { get; set; }
+    public int RelationshipCount { get; set; }
 }

--- a/src/Microsoft.Sbom.Api/Output/Telemetry/Entities/SbomTelemetry.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/Entities/SbomTelemetry.cs
@@ -80,4 +80,9 @@ public class SbomTelemetry
     /// Gets or sets additional properties, like signature validation results, etc.
     /// </summary>
     public Dictionary<string, string> AdditionalResults { get; set; }
+
+    /// <summary>
+    /// Contains telemetry about each AggregationSource used in aggregation. The key is the identifier of the AggregationSource.
+    /// </summary>
+    public Dictionary<string, AggregationSourceTelemetry> AggregationSourceTelemetry { get; set; }
 }

--- a/src/Microsoft.Sbom.Api/Output/Telemetry/IRecorder.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/IRecorder.cs
@@ -97,7 +97,7 @@ public interface IRecorder
     public IList<FileValidationResult> Errors { get; }
 
     /// <summary>
-    /// Capture telemetry for an AggregationSource.
+    /// Record telemetry for an AggregationSource.
     /// </summary>
-    public void AddAggregationSourceTelemetry(string identifier, int packageCount, int relationshipCount);
+    public void RecordAggregationSource(string identifier, int packageCount, int relationshipCount);
 }

--- a/src/Microsoft.Sbom.Api/Output/Telemetry/IRecorder.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/IRecorder.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Sbom.Api.Entities;
+using Microsoft.Sbom.Api.Output.Telemetry.Entities;
 using Microsoft.Sbom.Extensions.Entities;
 
 namespace Microsoft.Sbom.Api.Output.Telemetry;
@@ -95,4 +96,9 @@ public interface IRecorder
     public void AddResult(string propertyName, string value);
 
     public IList<FileValidationResult> Errors { get; }
+
+    /// <summary>
+    /// Capture telemetry for an AggregationSource.
+    /// </summary>
+    public void AddAggregationSourceTelemety(string identifier, AggregationSourceTelemetry telemetry);
 }

--- a/src/Microsoft.Sbom.Api/Output/Telemetry/IRecorder.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/IRecorder.cs
@@ -100,5 +100,5 @@ public interface IRecorder
     /// <summary>
     /// Capture telemetry for an AggregationSource.
     /// </summary>
-    public void AddAggregationSourceTelemety(string identifier, AggregationSourceTelemetry telemetry);
+    public void AddAggregationSourceTelemetry(string identifier, AggregationSourceTelemetry telemetry);
 }

--- a/src/Microsoft.Sbom.Api/Output/Telemetry/IRecorder.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/IRecorder.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Sbom.Api.Entities;
-using Microsoft.Sbom.Api.Output.Telemetry.Entities;
 using Microsoft.Sbom.Extensions.Entities;
 
 namespace Microsoft.Sbom.Api.Output.Telemetry;
@@ -100,5 +99,5 @@ public interface IRecorder
     /// <summary>
     /// Capture telemetry for an AggregationSource.
     /// </summary>
-    public void AddAggregationSourceTelemetry(string identifier, AggregationSourceTelemetry telemetry);
+    public void AddAggregationSourceTelemetry(string identifier, int packageCount, int relationshipCount);
 }

--- a/src/Microsoft.Sbom.Api/Output/Telemetry/TelemetryRecorder.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/TelemetryRecorder.cs
@@ -361,7 +361,7 @@ public class TelemetryRecorder : IRecorder
     /// <inheritdoc/>
     /// </summary>
     /// <param name="identifier"></param>
-    public void AddAggregationSourceTelemety(string identifier, AggregationSourceTelemetry telemetry)
+    public void AddAggregationSourceTelemetry(string identifier, AggregationSourceTelemetry telemetry)
     {
         aggregationSourceTelemetry.Add(identifier, telemetry);
     }

--- a/src/Microsoft.Sbom.Api/Output/Telemetry/TelemetryRecorder.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/TelemetryRecorder.cs
@@ -361,8 +361,12 @@ public class TelemetryRecorder : IRecorder
     /// <inheritdoc/>
     /// </summary>
     /// <param name="identifier"></param>
-    public void AddAggregationSourceTelemetry(string identifier, AggregationSourceTelemetry telemetry)
+    public void AddAggregationSourceTelemetry(string identifier, int packageCount, int relationshipCount)
     {
-        aggregationSourceTelemetry.Add(identifier, telemetry);
+        aggregationSourceTelemetry.Add(identifier, new AggregationSourceTelemetry
+        {
+            PackageCount = packageCount,
+            RelationShipCount = relationshipCount
+        });
     }
 }

--- a/src/Microsoft.Sbom.Api/Output/Telemetry/TelemetryRecorder.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/TelemetryRecorder.cs
@@ -362,7 +362,7 @@ public class TelemetryRecorder : IRecorder
     /// <inheritdoc/>
     /// </summary>
     /// <param name="identifier"></param>
-    public void AddAggregationSourceTelemetry(string identifier, int packageCount, int relationshipCount)
+    public void RecordAggregationSource(string identifier, int packageCount, int relationshipCount)
     {
         aggregationSourceTelemetry.Add(identifier, new AggregationSourceTelemetry
         {

--- a/src/Microsoft.Sbom.Api/Output/Telemetry/TelemetryRecorder.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/TelemetryRecorder.cs
@@ -36,6 +36,7 @@ public class TelemetryRecorder : IRecorder
     private readonly IList<Exception> apiExceptions = new List<Exception>();
     private readonly IList<Exception> metadataExceptions = new List<Exception>();
     private readonly Dictionary<string, string> additionalResults = new Dictionary<string, string>();
+    private readonly IDictionary<string, AggregationSourceTelemetry> aggregationSourceTelemetry = new Dictionary<string, AggregationSourceTelemetry>();
     private IList<FileValidationResult> errors = new List<FileValidationResult>();
     private Result result = Result.Success;
 
@@ -354,5 +355,14 @@ public class TelemetryRecorder : IRecorder
     public void AddResult(string propertyName, string propertyValue)
     {
         this.additionalResults[propertyName] = propertyValue;
+    }
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    /// <param name="identifier"></param>
+    public void AddAggregationSourceTelemety(string identifier, AggregationSourceTelemetry telemetry)
+    {
+        aggregationSourceTelemetry.Add(identifier, telemetry);
     }
 }

--- a/src/Microsoft.Sbom.Api/Output/Telemetry/TelemetryRecorder.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/TelemetryRecorder.cs
@@ -36,7 +36,7 @@ public class TelemetryRecorder : IRecorder
     private readonly IList<Exception> apiExceptions = new List<Exception>();
     private readonly IList<Exception> metadataExceptions = new List<Exception>();
     private readonly Dictionary<string, string> additionalResults = new Dictionary<string, string>();
-    private readonly IDictionary<string, AggregationSourceTelemetry> aggregationSourceTelemetry = new Dictionary<string, AggregationSourceTelemetry>();
+    private readonly Dictionary<string, AggregationSourceTelemetry> aggregationSourceTelemetry = new Dictionary<string, AggregationSourceTelemetry>();
     private IList<FileValidationResult> errors = new List<FileValidationResult>();
     private Result result = Result.Success;
 
@@ -327,6 +327,7 @@ public class TelemetryRecorder : IRecorder
                 TotalLicensesDetected = this.totalNumberOfLicenses,
                 PackageDetailsEntries = this.packageDetailsEntries,
                 AdditionalResults = this.additionalResults,
+                AggregationSourceTelemetry = aggregationSourceTelemetry,
             };
 
             // Log to logger.

--- a/src/Microsoft.Sbom.Api/Output/Telemetry/TelemetryRecorder.cs
+++ b/src/Microsoft.Sbom.Api/Output/Telemetry/TelemetryRecorder.cs
@@ -366,7 +366,7 @@ public class TelemetryRecorder : IRecorder
         aggregationSourceTelemetry.Add(identifier, new AggregationSourceTelemetry
         {
             PackageCount = packageCount,
-            RelationShipCount = relationshipCount
+            RelationshipCount = relationshipCount
         });
     }
 }

--- a/src/Microsoft.Sbom.Api/Utils/Events.cs
+++ b/src/Microsoft.Sbom.Api/Utils/Events.cs
@@ -12,6 +12,7 @@ internal static class Events
     internal const string RelationshipsGeneration = "Relationships generation time";
     internal const string MetadataBuilder = "Metadata build time for {0} format";
     internal const string ExternalDocumentReferenceGeneration = "External document reference generation time";
+    internal const string SbomAggregationWorkflow = "Total aggregation time";
 
     internal const string SbomValidationWorkflow = "Total validation time";
 }

--- a/src/Microsoft.Sbom.Api/Workflows/Helpers/AggregationSource.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/Helpers/AggregationSource.cs
@@ -18,11 +18,14 @@ internal class AggregationSource
 
     public string BuildDropPath { get; }
 
+    public string Identifier { get; }
+
     public AggregationSource(ArtifactInfo artifactInfo, ISbomConfig sbomConfig, string buildDropPath)
     {
         ArtifactInfo = artifactInfo ?? throw new ArgumentNullException(nameof(artifactInfo));
         SbomConfig = sbomConfig ?? throw new ArgumentNullException(nameof(sbomConfig));
         BuildDropPath = string.IsNullOrEmpty(buildDropPath) ? throw new ArgumentNullException(nameof(buildDropPath)) : buildDropPath;
+        Identifier = Math.Abs(string.GetHashCode(sbomConfig.ManifestJsonFilePath)).ToString();
     }
 
     public override string ToString()

--- a/src/Microsoft.Sbom.Api/Workflows/SbomAggregationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SbomAggregationWorkflow.cs
@@ -243,7 +243,7 @@ public class SbomAggregationWorkflow : IWorkflow<SbomAggregationWorkflow>
                 return false;
             }
 
-            recorder.AddAggregationSourceTelemetry(aggregationSource.Identifier, mergeableContent.Packages.Count(), mergeableContent.Relationships.Count());
+            recorder.RecordAggregationSource(aggregationSource.Identifier, mergeableContent.Packages.Count(), mergeableContent.Relationships.Count());
 
             contents.Add(mergeableContent);
         }

--- a/src/Microsoft.Sbom.Api/Workflows/SbomAggregationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SbomAggregationWorkflow.cs
@@ -132,7 +132,7 @@ public class SbomAggregationWorkflow : IWorkflow<SbomAggregationWorkflow>
         var result = true;
         foreach (var source in aggregationSources)
         {
-            var identifier = Math.Abs(string.GetHashCode(source.SbomConfig.ManifestJsonFilePath)).ToString();
+            var identifier = source.Identifier;
             var workflowResult = false;
             var originalManifestDirPath = configuration.ManifestDirPath;
             try

--- a/src/Microsoft.Sbom.Api/Workflows/SbomAggregationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SbomAggregationWorkflow.cs
@@ -243,6 +243,8 @@ public class SbomAggregationWorkflow : IWorkflow<SbomAggregationWorkflow>
                 return false;
             }
 
+            recorder.AddAggregationSourceTelemetry(aggregationSource.Identifier, mergeableContent.Packages.Count(), mergeableContent.Relationships.Count());
+
             contents.Add(mergeableContent);
         }
 

--- a/src/Microsoft.Sbom.Api/Workflows/SbomAggregationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SbomAggregationWorkflow.cs
@@ -112,10 +112,6 @@ public class SbomAggregationWorkflow : IWorkflow<SbomAggregationWorkflow>
             }
             catch (Exception e)
             {
-#if DEBUG
-                // This is here to help debug issues during active development. It will be removed before release.
-                System.Diagnostics.Debugger.Break();
-#endif
                 recorder.RecordException(e);
                 logger.Error("Encountered an error while generating the manifest.");
                 logger.Error($"Error details: {e.Message}");

--- a/src/Microsoft.Sbom.Api/Workflows/SbomGenerationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SbomGenerationWorkflow.cs
@@ -170,7 +170,7 @@ public class SbomGenerationWorkflow : IWorkflow<SbomGenerationWorkflow>
                     recorder.RecordTotalErrors(validErrors.ToList());
                 }
 
-               // Delete the generated _manifest folder if generation failed.
+                // Delete the generated _manifest folder if generation failed.
                 if (deleteSbomDir || validErrors.Any())
                 {
                     DeleteManifestFolder(sbomDir);

--- a/test/Microsoft.Sbom.Api.Tests/Output/Telemetry/TelemetryRecorderTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Output/Telemetry/TelemetryRecorderTests.cs
@@ -4,6 +4,7 @@ namespace Microsoft.Sbom.Api.Output.Telemetry.Tests;
 
 using System.Collections.Generic;
 using Microsoft.Sbom.Api.Output.Telemetry;
+using Microsoft.Sbom.Api.Output.Telemetry.Entities;
 using Microsoft.Sbom.Common;
 using Microsoft.Sbom.Common.Config;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -44,5 +45,26 @@ public class TelemetryRecorderTests
         telemetryRecorder.AddResult(testKey, testValue2);
         Assert.AreEqual(testValue2, additionalResults[testKey]);
         Assert.AreNotEqual(testValue1, additionalResults[testKey]);
+    }
+
+    [TestMethod]
+    public void AddAggregationSourceTelemetryTest()
+    {
+        const string testKey = "TestKey";
+
+        var telemetryRecorder = new TelemetryRecorder(fileSystemUtilsMock.Object, configMock.Object, loggerMock.Object);
+        var aggregationSourceTelemetry = new AggregationSourceTelemetry
+        {
+            PackageCount = 5,
+            RelationShipCount = 10
+        };
+
+        telemetryRecorder.AddAggregationSourceTelemety(testKey, aggregationSourceTelemetry);
+
+        var telemetryField = typeof(TelemetryRecorder).GetField("aggregationSourceTelemetry", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var telemetryResults = (Dictionary<string, AggregationSourceTelemetry>)telemetryField.GetValue(telemetryRecorder);
+
+        Assert.AreEqual(1, telemetryResults.Count);
+        Assert.AreSame(aggregationSourceTelemetry, telemetryResults[testKey]);
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/Output/Telemetry/TelemetryRecorderTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Output/Telemetry/TelemetryRecorderTests.cs
@@ -56,7 +56,7 @@ public class TelemetryRecorderTests
 
         var telemetryRecorder = new TelemetryRecorder(fileSystemUtilsMock.Object, configMock.Object, loggerMock.Object);
 
-        telemetryRecorder.AddAggregationSourceTelemetry(testKey, testPackageCount, testRelationshipCount);
+        telemetryRecorder.RecordAggregationSource(testKey, testPackageCount, testRelationshipCount);
 
         var telemetryField = typeof(TelemetryRecorder).GetField("aggregationSourceTelemetry", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
         var telemetryResults = (Dictionary<string, AggregationSourceTelemetry>)telemetryField.GetValue(telemetryRecorder);

--- a/test/Microsoft.Sbom.Api.Tests/Output/Telemetry/TelemetryRecorderTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Output/Telemetry/TelemetryRecorderTests.cs
@@ -63,6 +63,6 @@ public class TelemetryRecorderTests
 
         Assert.AreEqual(1, telemetryResults.Count);
         Assert.AreEqual(testPackageCount, telemetryResults[testKey].PackageCount);
-        Assert.AreEqual(testRelationshipCount, telemetryResults[testKey].RelationShipCount);
+        Assert.AreEqual(testRelationshipCount, telemetryResults[testKey].RelationshipCount);
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/Output/Telemetry/TelemetryRecorderTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Output/Telemetry/TelemetryRecorderTests.cs
@@ -59,7 +59,7 @@ public class TelemetryRecorderTests
             RelationShipCount = 10
         };
 
-        telemetryRecorder.AddAggregationSourceTelemety(testKey, aggregationSourceTelemetry);
+        telemetryRecorder.AddAggregationSourceTelemetry(testKey, aggregationSourceTelemetry);
 
         var telemetryField = typeof(TelemetryRecorder).GetField("aggregationSourceTelemetry", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
         var telemetryResults = (Dictionary<string, AggregationSourceTelemetry>)telemetryField.GetValue(telemetryRecorder);

--- a/test/Microsoft.Sbom.Api.Tests/Output/Telemetry/TelemetryRecorderTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Output/Telemetry/TelemetryRecorderTests.cs
@@ -51,20 +51,18 @@ public class TelemetryRecorderTests
     public void AddAggregationSourceTelemetryTest()
     {
         const string testKey = "TestKey";
+        const int testPackageCount = 5;
+        const int testRelationshipCount = 10;
 
         var telemetryRecorder = new TelemetryRecorder(fileSystemUtilsMock.Object, configMock.Object, loggerMock.Object);
-        var aggregationSourceTelemetry = new AggregationSourceTelemetry
-        {
-            PackageCount = 5,
-            RelationShipCount = 10
-        };
 
-        telemetryRecorder.AddAggregationSourceTelemetry(testKey, aggregationSourceTelemetry);
+        telemetryRecorder.AddAggregationSourceTelemetry(testKey, testPackageCount, testRelationshipCount);
 
         var telemetryField = typeof(TelemetryRecorder).GetField("aggregationSourceTelemetry", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
         var telemetryResults = (Dictionary<string, AggregationSourceTelemetry>)telemetryField.GetValue(telemetryRecorder);
 
         Assert.AreEqual(1, telemetryResults.Count);
-        Assert.AreSame(aggregationSourceTelemetry, telemetryResults[testKey]);
+        Assert.AreEqual(testPackageCount, telemetryResults[testKey].PackageCount);
+        Assert.AreEqual(testRelationshipCount, telemetryResults[testKey].RelationShipCount);
     }
 }

--- a/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
@@ -128,7 +128,7 @@ public class InterfaceConcretionTests
     {
         public IList<FileValidationResult> Errors => throw new NotImplementedException();
 
-        public void AddAggregationSourceTelemetry(string identifier, Output.Telemetry.Entities.AggregationSourceTelemetry telemetry) => throw new NotImplementedException();
+        public void AddAggregationSourceTelemetry(string identifier, int packageCount, int relationshipCount) => throw new NotImplementedException();
         public void AddResult(string propertyName, string value) => throw new NotImplementedException();
         public void AddToTotalCountOfLicenses(int count) => throw new NotImplementedException();
         public void AddToTotalNumberOfPackageDetailsEntries(int count) => throw new NotImplementedException();

--- a/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
@@ -128,6 +128,7 @@ public class InterfaceConcretionTests
     {
         public IList<FileValidationResult> Errors => throw new NotImplementedException();
 
+        public void AddAggregationSourceTelemety(string identifier, Output.Telemetry.Entities.AggregationSourceTelemetry telemetry) => throw new NotImplementedException();
         public void AddResult(string propertyName, string value) => throw new NotImplementedException();
         public void AddToTotalCountOfLicenses(int count) => throw new NotImplementedException();
         public void AddToTotalNumberOfPackageDetailsEntries(int count) => throw new NotImplementedException();

--- a/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
@@ -128,7 +128,7 @@ public class InterfaceConcretionTests
     {
         public IList<FileValidationResult> Errors => throw new NotImplementedException();
 
-        public void AddAggregationSourceTelemety(string identifier, Output.Telemetry.Entities.AggregationSourceTelemetry telemetry) => throw new NotImplementedException();
+        public void AddAggregationSourceTelemetry(string identifier, Output.Telemetry.Entities.AggregationSourceTelemetry telemetry) => throw new NotImplementedException();
         public void AddResult(string propertyName, string value) => throw new NotImplementedException();
         public void AddToTotalCountOfLicenses(int count) => throw new NotImplementedException();
         public void AddToTotalNumberOfPackageDetailsEntries(int count) => throw new NotImplementedException();

--- a/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
@@ -128,11 +128,11 @@ public class InterfaceConcretionTests
     {
         public IList<FileValidationResult> Errors => throw new NotImplementedException();
 
-        public void RecordAggregationSource(string identifier, int packageCount, int relationshipCount) => throw new NotImplementedException();
         public void AddResult(string propertyName, string value) => throw new NotImplementedException();
         public void AddToTotalCountOfLicenses(int count) => throw new NotImplementedException();
         public void AddToTotalNumberOfPackageDetailsEntries(int count) => throw new NotImplementedException();
         public Task FinalizeAndLogTelemetryAsync() => throw new NotImplementedException();
+        public void RecordAggregationSource(string identifier, int packageCount, int relationshipCount) => throw new NotImplementedException();
         public void RecordAPIException(Exception exception) => throw new NotImplementedException();
         public void RecordException(Exception exception) => throw new NotImplementedException();
         public void RecordMetadataException(Exception exception) => throw new NotImplementedException();

--- a/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
@@ -128,7 +128,7 @@ public class InterfaceConcretionTests
     {
         public IList<FileValidationResult> Errors => throw new NotImplementedException();
 
-        public void AddAggregationSourceTelemetry(string identifier, int packageCount, int relationshipCount) => throw new NotImplementedException();
+        public void RecordAggregationSource(string identifier, int packageCount, int relationshipCount) => throw new NotImplementedException();
         public void AddResult(string propertyName, string value) => throw new NotImplementedException();
         public void AddToTotalCountOfLicenses(int count) => throw new NotImplementedException();
         public void AddToTotalNumberOfPackageDetailsEntries(int count) => throw new NotImplementedException();

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/SbomAggregationWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/SbomAggregationWorkflowTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Sbom.Api.Manifest.Configuration;
 using Microsoft.Sbom.Api.Output.Telemetry;
@@ -222,18 +223,32 @@ public class SbomAggregationWorkflowTests
         SetUpSbomsToValidate();
         SetUpMinimalValidation();
         SetupMinimalGenerationMocks(expectedResult);
-
-        mergeableContent22ProviderMock.Setup(x => x.TryGetContent(PathToSpdx22ManifestForArtifactKey1, out It.Ref<MergeableContent>.IsAny))
-            .Returns(true);
-        mergeableContent22ProviderMock.Setup(x => x.TryGetContent(PathToSpdx22ManifestForArtifactKey2, out It.Ref<MergeableContent>.IsAny))
-            .Returns(true);
-        mergeableContent30ProviderMock.Setup(x => x.TryGetContent(PathToSpdx30ManifestForArtifactKey1, out It.Ref<MergeableContent>.IsAny))
-            .Returns(true);
-        mergeableContent30ProviderMock.Setup(x => x.TryGetContent(PathToSpdx30ManifestForArtifactKey2, out It.Ref<MergeableContent>.IsAny))
-            .Returns(true);
+        SetupMinimalMergeableContentProviderMocks();
 
         var result = await testSubject.RunAsync();
         Assert.AreEqual(expectedResult, result);
+    }
+
+    private void SetupMinimalMergeableContentProviderMocks()
+    {
+        var minimalMergeableContent = new MergeableContent(
+            new List<SbomPackage> { new SbomPackage() }, Enumerable.Empty<SbomRelationship>());
+
+        mergeableContent22ProviderMock
+            .Setup(m => m.TryGetContent(PathToSpdx22ManifestForArtifactKey1, out minimalMergeableContent))
+            .Returns(true);
+        mergeableContent22ProviderMock
+            .Setup(m => m.TryGetContent(PathToSpdx22ManifestForArtifactKey2, out minimalMergeableContent))
+            .Returns(true);
+        mergeableContent30ProviderMock
+            .Setup(m => m.TryGetContent(PathToSpdx30ManifestForArtifactKey1, out minimalMergeableContent))
+            .Returns(true);
+        mergeableContent30ProviderMock
+            .Setup(m => m.TryGetContent(PathToSpdx30ManifestForArtifactKey2, out minimalMergeableContent))
+            .Returns(true);
+
+        recorderMock.Setup(m => m.AddAggregationSourceTelemetry(
+            It.IsAny<string>(), 1 /* package count */, 0 /* relationship count */));
     }
 
     private void SetUpSbomsToValidate()

--- a/test/Microsoft.Sbom.Api.Tests/Workflows/SbomAggregationWorkflowTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Workflows/SbomAggregationWorkflowTests.cs
@@ -247,7 +247,7 @@ public class SbomAggregationWorkflowTests
             .Setup(m => m.TryGetContent(PathToSpdx30ManifestForArtifactKey2, out minimalMergeableContent))
             .Returns(true);
 
-        recorderMock.Setup(m => m.AddAggregationSourceTelemetry(
+        recorderMock.Setup(m => m.RecordAggregationSource(
             It.IsAny<string>(), 1 /* package count */, 0 /* relationship count */));
     }
 


### PR DESCRIPTION
This PR adds the package count and relationship count for each `AggregationSource` to the telemetry stream. Steps to this point:

1. Adds `Events.SbomAggregationWorkflow` so we can record this as a discrete event
2. Adds `AggregationSource.Identifier` and uses it for validation logs. We'll also use it for reporting package information in telemetry
3. Add a top-level exception handler to `SbomAggregationWorkflow.RunAsync` so that we can catch and log the exceptions
4. Adds a small refactor to the code that calls the various `GenerateAsync` methods, so that aggregation calls only the generators that need to be called. Aggregating relationships will occur in a later feature.
5. Add `IRecorder.RecordAggregationSource` and its implementation to capture the data
6. Call `IRecorder.RecordAggregationSource` from the workflow

When all the pieces land, we get the following added to the telemetry stream:
```
AggregationSourceTelemetry = {
  ["1832146932"]=AggregationSourceTelemetry {PackageCount=266, RelationshipCount=0},
  ["1810187031"]=AggregationSourceTelemetry {PackageCount=3, RelationshipCount=0}
}
```

I'd love to remove the "AggregationSourceTelemetry" prefix on each item, but so far I haven't found a way to make that happen.