### PR TITLE
Add correct relationships to MergeableContent

### DIFF
--- a/src/Microsoft.Sbom.Common/Utils/CommonSPDXUtils.cs
+++ b/src/Microsoft.Sbom.Common/Utils/CommonSPDXUtils.cs
@@ -5,6 +5,7 @@ using System;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
+using Microsoft.Sbom.Contracts;
 
 namespace Microsoft.Sbom.Common.Utils;
 
@@ -22,6 +23,26 @@ public static class CommonSPDXUtils
     /// Returns the SPDX-compliant package ID.
     /// </summary>
     public static string GenerateSpdxPackageId(string id) => $"{Constants.SPDXRefPackage}-{GetStringHash(id)}";
+
+    /// <summary>
+    /// Returns the SPDX-compliant package ID from an SbomPackage object.
+    /// </summary>
+    public static string GenerateSpdxPackageId(SbomPackage packageInfo)
+    {
+        if (packageInfo is null)
+        {
+            throw new ArgumentNullException(nameof(packageInfo));
+        }
+
+        // Get package identity as package name and package version. If version is empty, just use package name
+        var packageIdentity = $"{packageInfo.Type}-{packageInfo.PackageName}";
+        if (!string.IsNullOrWhiteSpace(packageInfo.PackageVersion))
+        {
+            packageIdentity = string.Join("-", packageInfo.Type, packageInfo.PackageName, packageInfo.PackageVersion);
+        }
+
+        return GenerateSpdxPackageId(packageInfo.Id ?? packageIdentity);
+    }
 
     /// <summary>
     /// Returns the SPDX-compliant file ID.

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/MergeableContentProvider.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/MergeableContentProvider.cs
@@ -13,6 +13,7 @@ using Microsoft.Sbom.Extensions.Entities;
 using Microsoft.Sbom.JsonAsynchronousNodeKit;
 using Microsoft.Sbom.Parser;
 using Microsoft.Sbom.Parsers.Spdx22SbomParser.Entities;
+using Serilog;
 
 namespace Microsoft.Sbom.Parsers.Spdx22SbomParser;
 
@@ -24,10 +25,12 @@ public class MergeableContentProvider : IMergeableContentProvider
     private const string DependsOn = "DEPENDS_ON";
 
     private readonly IFileSystemUtils fileSystemUtils;
+    private readonly ILogger logger;
 
-    public MergeableContentProvider(IFileSystemUtils fileSystemUtils)
+    public MergeableContentProvider(IFileSystemUtils fileSystemUtils, ILogger logger)
     {
         this.fileSystemUtils = fileSystemUtils ?? throw new ArgumentNullException(nameof(fileSystemUtils));
+        this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     /// <summary>
@@ -47,6 +50,7 @@ public class MergeableContentProvider : IMergeableContentProvider
 
         if (!fileSystemUtils.FileExists(filePath))
         {
+            logger.Debug($"File '{filePath}' does not exist.");
             mergeableContent = null;
             return false;
         }
@@ -55,16 +59,19 @@ public class MergeableContentProvider : IMergeableContentProvider
 
         if (stream == null)
         {
+            logger.Debug($"Unable to open stream for file '{filePath}'.");
             mergeableContent = null;
             return false;
         }
 
         try
         {
+            logger.Debug($"Attempting to parse SPDX file at '{filePath}'.");
             return GetMergeableContent(stream, out mergeableContent);
         }
         catch (Exception)
         {
+            logger.Debug($"Failed to parse SPDX file at '{filePath}'. It may not be a valid SPDX 2.2 file.");
             mergeableContent = null;
             return false;
         }
@@ -89,10 +96,10 @@ public class MergeableContentProvider : IMergeableContentProvider
                 switch (result)
                 {
                     case PackagesResult packagesResult:
-                        packages = ProcessPackages(packagesResult.Packages.ToList());  // ToList() ensure correct parsing of the data
+                        packages = ProcessPackages(packagesResult.Packages.ToList());  // ToList() ensures correct parsing of the data
                         break;
                     case RelationshipsResult relationshipsResult:
-                        relationships = ProcessRelationships(relationshipsResult.Relationships.ToList());  // ToList() ensure correct parsing of the data
+                        relationships = ProcessRelationships(relationshipsResult.Relationships.ToList());  // ToList() ensures correct parsing of the data
                         break;
                     default:
                         break;
@@ -160,13 +167,21 @@ public class MergeableContentProvider : IMergeableContentProvider
     }
 
     /// <summary>
-    /// Build a mapping of fixed SPDXID values, then apply the mapping to the objects before returning the content.
+    /// Remaps the root package ID, updates relationships accordingly, then creates a new <see cref="MergeableContent"/> object.
     /// </summary>
-    private static MergeableContent CreateRemappedMergeableContent(IList<SbomPackage> packages, IList<SbomRelationship> relationships)
+    private MergeableContent CreateRemappedMergeableContent(IList<SbomPackage> packages, IList<SbomRelationship> relationships)
     {
-        // Build a map of special ID's--currently it's just the root package ID.
-        var spdxIdMapping = new Dictionary<string, string>();
+        var mappedRootPackageId = GetAdjustedRootPackageId(packages);
 
+        AdjustRootPackageRelationships(relationships, mappedRootPackageId);
+
+        logger.Debug($"MergeableContent includes {packages.Count} package(s) and {relationships.Count} relationship(s).");
+
+        return new MergeableContent(packages, relationships);
+    }
+
+    private string GetAdjustedRootPackageId(IList<SbomPackage> packages)
+    {
         foreach (var package in packages)
         {
             if (package.Id == Constants.RootPackageIdValue)
@@ -174,36 +189,35 @@ public class MergeableContentProvider : IMergeableContentProvider
                 package.Id = null;
                 var newSpdxId = CommonSPDXUtils.GenerateSpdxPackageId(package);
                 package.Id = newSpdxId;
-                spdxIdMapping.Add(Constants.RootPackageIdValue, newSpdxId);
-                break;
+                logger.Debug($"Remapped root package ID from '{Constants.RootPackageIdValue}' to '{newSpdxId}'");
+                return newSpdxId;
             }
         }
 
-        // Remap any relationships where the source element ID is remapped.
+        throw new InvalidDataException("No root package found in the SPDX document.");
+    }
+
+    private void AdjustRootPackageRelationships(IList<SbomRelationship> relationships, string mappedRootPackageId)
+    {
+        // Update relationships where the source is the root package.
         foreach (var relationship in relationships)
         {
-            if (spdxIdMapping.TryGetValue(relationship.SourceElementId, out var newSourceId))
+            if (relationship.SourceElementId == Constants.RootPackageIdValue)
             {
-                // Update the source element ID with the new SPDX ID.
-                relationship.SourceElementId = newSourceId;
+                // Update the source element ID to the remapped root package ID.
+                logger.Verbose($"Remapped root package dependency on '{relationship.TargetElementId}'");
+                relationship.SourceElementId = mappedRootPackageId;
             }
         }
 
-        // Finally, make the output root depend on the remapped root.
-        foreach (var mapping in spdxIdMapping)
+        // Make the output root depend on the remapped root.
+        var newRootRelationship = new SbomRelationship
         {
-            if (mapping.Key == Constants.RootPackageIdValue)
-            {
-                var relationship = new SbomRelationship
-                {
-                    SourceElementId = Constants.RootPackageIdValue,
-                    TargetElementId = mapping.Value,
-                    RelationshipType = DependsOn, // Force output consistency
-                };
-                relationships.Add(relationship);
-            }
-        }
-
-        return new MergeableContent(packages, relationships);
+            SourceElementId = Constants.RootPackageIdValue,
+            TargetElementId = mappedRootPackageId,
+            RelationshipType = DependsOn, // Force output consistency
+        };
+        relationships.Add(newRootRelationship);
+        logger.Debug($"Added new root relationship from '{Constants.RootPackageIdValue}' to '{mappedRootPackageId}'");
     }
 }

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/SPDXExtensions.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/SPDXExtensions.cs
@@ -69,19 +69,7 @@ public static class SPDXExtensions
             throw new ArgumentNullException(nameof(spdxPackage));
         }
 
-        if (packageInfo is null)
-        {
-            throw new ArgumentNullException(nameof(packageInfo));
-        }
-
-        // Get package identity as package name and package version. If version is empty, just use package name
-        var packageIdentity = $"{packageInfo.Type}-{packageInfo.PackageName}";
-        if (!string.IsNullOrWhiteSpace(packageInfo.PackageVersion))
-        {
-            packageIdentity = string.Join("-", packageInfo.Type, packageInfo.PackageName, packageInfo.PackageVersion);
-        }
-
-        spdxPackage.SpdxId = CommonSPDXUtils.GenerateSpdxPackageId(packageInfo.Id ?? packageIdentity);
+        spdxPackage.SpdxId = CommonSPDXUtils.GenerateSpdxPackageId(packageInfo);
         return spdxPackage.SpdxId;
     }
 

--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Utils/SPDXExtensions.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Utils/SPDXExtensions.cs
@@ -29,19 +29,7 @@ public static class SPDXExtensions
     /// <returns>Package ID that encapsulates unique info about a package.</returns>
     public static string AddSpdxId(this Package spdxPackage, SbomPackage packageInfo)
     {
-        if (packageInfo is null)
-        {
-            throw new ArgumentNullException(nameof(packageInfo));
-        }
-
-        // Get package identity as package name and package version. If version is empty, just use package name
-        var packageIdentity = $"{packageInfo.Type}-{packageInfo.PackageName}";
-        if (!string.IsNullOrWhiteSpace(packageInfo.PackageVersion))
-        {
-            packageIdentity = string.Join("-", packageInfo.Type, packageInfo.PackageName, packageInfo.PackageVersion);
-        }
-
-        spdxPackage.SpdxId = CommonSPDXUtils.GenerateSpdxPackageId(packageInfo.Id ?? packageIdentity);
+        spdxPackage.SpdxId = CommonSPDXUtils.GenerateSpdxPackageId(packageInfo);
         return spdxPackage.SpdxId;
     }
 

--- a/test/Microsoft.Sbom.Common.Tests/CommonSPDXUtilsTests.cs
+++ b/test/Microsoft.Sbom.Common.Tests/CommonSPDXUtilsTests.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Sbom.Parser;
 
 using System.Data;
 using Microsoft.Sbom.Common.Utils;
+using Microsoft.Sbom.Contracts;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 [TestClass]
@@ -29,6 +30,18 @@ public class CommonSPDXUtilsTests
     private const string TestExternalDoc1Hash1SpdxId = "DocumentRef-testExternalDoc1-sha1Value1";
     private const string TestExternalDoc2Hash2SpdxId = "DocumentRef-testExternalDoc2-sha1Value2";
 
+    private const string TestPackageVersion = "1.2.3";
+    private const string TestPackageType = "TestPackageType";
+
+    private const string ConstantPackageRoot = "SPDXRef-RootPackage";
+
+    private const string TestPackage1WithPackageSpdxId = "SPDXRef-Package-20D44930AAC47CD0742168EF1B379150FD6687B216B77D6206FACFF56F0FE17B";
+    private const string TestPackage1WithPackageAndVersionSpdxId = "SPDXRef-Package-58C5DD56550594F89AB94FBE3702CC8D0DCB06D5C781305938449FBF9E309196";
+    private const string TestPackage1WithPackageAndVersionAndTypeSpdxId = "SPDXRef-Package-E3FD92B139AF7424535396792FA2B2D70EB715EA83D24E497A6C716279227735";
+    private const string TestPackage1WithPackageAndTypeSpdxId = "SPDXRef-Package-F79E2B8CF0C894FA3991089088856FA215B7B196872B8AD653ADA4810F78F33C";
+    private const string TestPackage1WithIdSpdxId = "SPDXRef-Package-A8187CB9A95FFD35E50AC36CBADA2BE0958125B7EEDCF10F795995B633A2C564";
+    private const string ConstantPackageRootSpdxId = "SPDXRef-Package-27C5AE25932C81815EFD8B210DAA1A017B4A461AF82DE1405906163A2D5573BB";
+
     [DataRow(TestPackage1, TestPackage1SpdxId)]
     [DataRow(TestPackage2, TestPackage2SpdxId)]
     [TestMethod]
@@ -44,6 +57,27 @@ public class CommonSPDXUtilsTests
     public void GenerateSpdxFileIdTest(string file, string sha1Value, string expectedSpdxId)
     {
         var spdxId = CommonSPDXUtils.GenerateSpdxFileId(file, sha1Value);
+        Assert.AreEqual(expectedSpdxId, spdxId);
+    }
+
+    [TestMethod]
+    [DataRow(null, TestPackage1, null, null, TestPackage1WithPackageSpdxId)]
+    [DataRow(null, TestPackage1, TestPackageVersion, null, TestPackage1WithPackageAndVersionSpdxId)]
+    [DataRow(null, TestPackage1, TestPackageVersion, TestPackageType, TestPackage1WithPackageAndVersionAndTypeSpdxId)]
+    [DataRow(null, TestPackage1, null, TestPackageType, TestPackage1WithPackageAndTypeSpdxId)]
+    [DataRow(TestPackage1SpdxId, null, null, null, TestPackage1WithIdSpdxId)]
+    [DataRow(TestPackage1SpdxId, TestPackageType, TestPackageVersion, TestPackageType, TestPackage1WithIdSpdxId)]
+    [DataRow(ConstantPackageRoot, null, null, null, ConstantPackageRootSpdxId)]
+    public void GenerateSpdxFileId_Packages(string packageId, string packageName, string packageVersion, string type, string expectedSpdxId)
+    {
+        var packageInfo = new SbomPackage
+        {
+            Id = packageId,
+            PackageName = packageName,
+            PackageVersion = packageVersion,
+            Type = type,
+        };
+        var spdxId = CommonSPDXUtils.GenerateSpdxPackageId(packageInfo);
         Assert.AreEqual(expectedSpdxId, spdxId);
     }
 

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/MergeableContentProviderTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/MergeableContentProviderTests.cs
@@ -80,6 +80,6 @@ public class MergeableContentProviderTests
         Assert.IsNotNull(mergeableContent);
 
         Assert.AreEqual(267, mergeableContent.Packages.Count());
-        Assert.AreEqual(0, mergeableContent.Relationships.Count());
+        Assert.AreEqual(266, mergeableContent.Relationships.Count());
     }
 }

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/MergeableContentProviderTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/MergeableContentProviderTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Sbom.Common;
 using Microsoft.Sbom.Extensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using Serilog;
 
 namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests;
 
@@ -16,13 +17,15 @@ namespace Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests;
 public class MergeableContentProviderTests
 {
     private Mock<IFileSystemUtils> fileSystemUtilsMock;
+    private Mock<ILogger> loggerMock;
     private IMergeableContentProvider provider;
 
     [TestInitialize]
     public void BeforeEachTest()
     {
         fileSystemUtilsMock = new Mock<IFileSystemUtils>(MockBehavior.Strict);
-        provider = new MergeableContentProvider(fileSystemUtilsMock.Object);
+        loggerMock = new Mock<ILogger>(); // Intentionaly not using Strict behavior for logger
+        provider = new MergeableContentProvider(fileSystemUtilsMock.Object, loggerMock.Object);
     }
 
     [TestCleanup]


### PR DESCRIPTION
This PR does the following:
1. Add all DEPENDS_ON relationships to the `MergeableContent`
2. Within each source SBOM:
   - Assign a unique SPDX ID to the SBOM root package (the old code used the same ID for each root, meaning that if we were aggregating N sboms, then we'd have N packages with the same ID--they were the same because they were hashed from the same string of "SPDXRef-RootPackage"
   - Remap all DEPENDS_ON relationships that had a source of "SPDXRef-RootPackage" and point them to the unique SPDX ID we just assigned
   - Add a DEPENDS_ON relationship to connect the aggregated root to unique SPDX ID that we just assigned
3. Add logging to help record the activity. Things that occur once per source SBOM are logged at `Debug`, while things that occur more than once per source SBOM are logged at `Verbose`
4. Unit tests!

Redated sample of output logging:
```
##[debug]Attempting to parse SPDX file at 'C:\repos\CsvToJson\CsvToJson\bin\Debug\net8.0\_manifest\spdx_2.2\manifest.spdx.json'.
##[debug]Remapped root package ID from 'SPDXRef-RootPackage' to 'SPDXRef-Package-C8D4982D8356503F1912C637E4DFB7A53400AF98C08BA4732BB9F3CF70F628A9'
##[debug]Added new root relationship from 'SPDXRef-RootPackage' to 'SPDXRef-Package-C8D4982D8356503F1912C637E4DFB7A53400AF98C08BA4732BB9F3CF70F628A9'
##[debug]MergeableContent includes 3 package(s) and 1 relationship(s).
##[debug]Attempting to parse SPDX file at 'C:\scratch\SBOMTool-GitHub-Test\_manifest\spdx_2.2\manifest.spdx.json'.
##[debug]Remapped root package ID from 'SPDXRef-RootPackage' to 'SPDXRef-Package-6C3FCBFE8A8061781D6FA5DB922F6B292BEE13D2E107B3789F93C4343A48974D'
##[verbose]Remapped root package dependency on 'SPDXRef-Package-4CC76DE73D5AAB43B651EC777CEE740E936A6095E1DD28A99DCBB15C55909C50'
##[verbose]Remapped root package dependency on 'SPDXRef-Package-31A255ADCAF03261EC7411AE2C6E6FCC954C2A3A7919C3442AF4FA85159BA5EA'

(skipping about 260 verbose outputs)

##[verbose]Remapped root package dependency on 'SPDXRef-Package-59734D799ADDC55D5E50CD7B75B8C6344238FDE24BA85C53F2E4D4B58C3AEF98'
##[verbose]Remapped root package dependency on 'SPDXRef-Package-35FDBB7ACF69BB379B4E6C8CE96F08DADF1B593026AFDDABAC1AB6AFC96A5620'
##[debug]Added new root relationship from 'SPDXRef-RootPackage' to 'SPDXRef-Package-6C3FCBFE8A8061781D6FA5DB922F6B292BEE13D2E107B3789F93C4343A48974D'
##[debug]MergeableContent includes 266 package(s) and 266 relationship(s).
```