### PR TITLE
Convert info message about invalid aggregation input to warn

### DIFF
--- a/src/Microsoft.Sbom.Api/Workflows/SbomAggregationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SbomAggregationWorkflow.cs
@@ -127,7 +127,7 @@ public class SbomAggregationWorkflow : IWorkflow<SbomAggregationWorkflow>
         var isValidSpdxFormat = spdxFormatDetector.TryGetSbomsWithVersion(manifestDirPath, out var detectedSboms);
         if (!isValidSpdxFormat)
         {
-            logger.Information($"No SBOMs located in {manifestDirPath} of a recognized SPDX format.");
+            logger.Warning($"No SBOMs located in {manifestDirPath} of a recognized SPDX format.");
             return null;
         }
 


### PR DESCRIPTION
This can be an indication that a user's config file is not properly formatted, so we don't want it to get lost in the logs.