### PR TITLE
Restore writing of root dependencies

### DIFF
--- a/src/Microsoft.Sbom.Api/Executors/PackageInfoJsonWriter.cs
+++ b/src/Microsoft.Sbom.Api/Executors/PackageInfoJsonWriter.cs
@@ -19,11 +19,11 @@ namespace Microsoft.Sbom.Api.Executors;
 /// </summary>
 public class PackageInfoJsonWriter
 {
-    private readonly ManifestGeneratorProvider manifestGeneratorProvider;
+    private readonly IManifestGeneratorProvider manifestGeneratorProvider;
     private readonly ILogger log;
 
     public PackageInfoJsonWriter(
-        ManifestGeneratorProvider manifestGeneratorProvider,
+        IManifestGeneratorProvider manifestGeneratorProvider,
         ILogger log)
     {
         if (manifestGeneratorProvider is null)
@@ -54,7 +54,7 @@ public class PackageInfoJsonWriter
         return (result, errors);
     }
 
-    private async Task GenerateJson(
+    internal async Task GenerateJson(
         IList<ISbomConfig> packagesArraySupportingConfigs,
         SbomPackage packageInfo,
         Channel<JsonDocWithSerializer> result,

--- a/src/Microsoft.Sbom.Api/Executors/PackageInfoJsonWriter.cs
+++ b/src/Microsoft.Sbom.Api/Executors/PackageInfoJsonWriter.cs
@@ -67,12 +67,20 @@ public class PackageInfoJsonWriter
                 var generationResult =
                     manifestGeneratorProvider.Get(sbomConfig.ManifestInfo).GenerateJsonDocument(packageInfo);
 
+                var recordedAnyDependencies = false;
+
                 if (generationResult?.ResultMetadata?.DependOn != null)
                 {
                     foreach (var dependency in generationResult?.ResultMetadata?.DependOn)
                     {
                         sbomConfig.Recorder.RecordPackageId(generationResult?.ResultMetadata?.EntityId, dependency);
+                        recordedAnyDependencies = true;
                     }
+                }
+
+                if (!recordedAnyDependencies)
+                {
+                    sbomConfig.Recorder.RecordPackageId(generationResult?.ResultMetadata?.EntityId, null);
                 }
 
                 await result.Writer.WriteAsync((generationResult?.Document, sbomConfig.JsonSerializer));

--- a/src/Microsoft.Sbom.Api/Manifest/IManifestGeneratorProvider.cs
+++ b/src/Microsoft.Sbom.Api/Manifest/IManifestGeneratorProvider.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Microsoft.Sbom.Extensions;
+using Microsoft.Sbom.Extensions.Entities;
+
+namespace Microsoft.Sbom.Api.Manifest;
+
+public interface IManifestGeneratorProvider
+{
+    public IManifestGenerator Get(ManifestInfo manifestInfo);
+
+    public IEnumerable<ManifestInfo> GetSupportedManifestInfos();
+
+    public ManifestGeneratorProvider Init();
+}

--- a/src/Microsoft.Sbom.Api/Manifest/ManifestGeneratorProvider.cs
+++ b/src/Microsoft.Sbom.Api/Manifest/ManifestGeneratorProvider.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Sbom.Api.Manifest;
 /// Factory class that returns the correct implementation of the <see cref="IManifestGenerator"/>
 /// at runtime based on the 'ManifestInfo' parameter.
 /// </summary>
-public class ManifestGeneratorProvider
+public class ManifestGeneratorProvider : IManifestGeneratorProvider
 {
     private readonly IEnumerable<IManifestGenerator> manifestGenerators;
     private readonly IDictionary<string, IManifestGenerator> manifestMap = new Dictionary<string, IManifestGenerator>(StringComparer.OrdinalIgnoreCase);

--- a/src/Microsoft.Sbom.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Sbom.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -87,6 +87,7 @@ public static class ServiceCollectionExtensions
             .AddTransient<IHashCodeGenerator, HashCodeGenerator>()
             .AddTransient<IManifestPathConverter, SbomToolManifestPathConverter>()
             .AddTransient<ManifestGeneratorProvider>()
+            .AddTransient<IManifestGeneratorProvider, ManifestGeneratorProvider>()
             .AddTransient<HashValidator>()
             .AddTransient<ValidationResultGenerator>()
             .AddTransient<IOutputWriter, FileOutputWriter>()

--- a/test/Microsoft.Sbom.Api.Tests/Executors/PackageInfoJsonWriterTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Executors/PackageInfoJsonWriterTests.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Linq;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Microsoft.Sbom.Api.Entities;
+using Microsoft.Sbom.Api.Executors;
+using Microsoft.Sbom.Api.Manifest;
+using Microsoft.Sbom.Api.Utils;
+using Microsoft.Sbom.Contracts;
+using Microsoft.Sbom.Extensions;
+using Microsoft.Sbom.Extensions.Entities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Serilog;
+
+namespace Microsoft.Sbom.Api.Tests.Executors;
+
+[TestClass]
+public class PackageInfoJsonWriterTests
+{
+    private const string TestEntityId = "TestEntityId";
+
+    private Mock<IManifestGenerator> manifestGeneratorMock;
+    private Mock<IManifestGeneratorProvider> manifestGeneratorProviderMock;
+    private Mock<ILogger> loggerMock;
+    private Mock<ISbomConfig> sbomConfigMock;
+    private Mock<ISbomPackageDetailsRecorder> sbomPackageDetailsRecorderMock;
+    private Mock<IManifestToolJsonSerializer> manifestToolJsonSerializerMock;
+    private PackageInfoJsonWriter testSubject;
+    private GenerationResult generationResult;
+
+    [TestInitialize]
+    public void BeforeEach()
+    {
+        manifestGeneratorMock = new Mock<IManifestGenerator>();
+        manifestGeneratorProviderMock = new Mock<IManifestGeneratorProvider>();
+        loggerMock = new Mock<ILogger>();
+        sbomPackageDetailsRecorderMock = new Mock<ISbomPackageDetailsRecorder>(MockBehavior.Strict);
+        manifestToolJsonSerializerMock = new Mock<IManifestToolJsonSerializer>();
+        testSubject = new PackageInfoJsonWriter(manifestGeneratorProviderMock.Object, loggerMock.Object);
+
+        sbomConfigMock = new Mock<ISbomConfig>(MockBehavior.Strict);
+        sbomConfigMock.SetupGet(x => x.ManifestInfo).Returns(Constants.TestManifestInfo);
+        sbomConfigMock.SetupGet(x => x.Recorder).Returns(sbomPackageDetailsRecorderMock.Object);
+        sbomConfigMock.SetupGet(x => x.JsonSerializer).Returns(manifestToolJsonSerializerMock.Object);
+
+        generationResult = new GenerationResult
+        {
+            ResultMetadata = new ResultMetadata
+            {
+                EntityId = TestEntityId,
+            },
+        };
+
+        manifestGeneratorProviderMock
+            .Setup(x => x.Get(It.IsAny<ManifestInfo>()))
+            .Returns(manifestGeneratorMock.Object);
+
+        manifestGeneratorMock
+            .Setup(x => x.GenerateJsonDocument(It.IsAny<SbomPackage>()))
+            .Returns(generationResult);
+    }
+
+    [TestCleanup]
+    public void AfterEach()
+    {
+        manifestGeneratorMock.VerifyAll();
+        manifestGeneratorProviderMock.VerifyAll();
+        manifestToolJsonSerializerMock.VerifyAll();
+        loggerMock.VerifyAll();
+        sbomPackageDetailsRecorderMock.VerifyAll();
+        sbomConfigMock.VerifyAll();
+    }
+
+    [TestMethod]
+    [DataRow(null, true)]
+    [DataRow(new string[0], true)]
+    [DataRow(new[] { "a", "b", "c" }, false)]
+    public async Task GenerateJson_RecordsExpectedDependencies(string[] testCase, bool expectNullDependency)
+    {
+        var sbomConfigs = new[] { sbomConfigMock.Object };
+        var packageInfo = new SbomPackage
+        {
+            PackageName = "TestPackage",
+            PackageVersion = "1.0.0",
+            PackageUrl = "pkg:example/testpackage@1.0.0"
+        };
+        var resultChannel = Channel.CreateUnbounded<JsonDocWithSerializer>();
+        var errorsChannel = Channel.CreateUnbounded<FileValidationResult>();
+
+        if (testCase is not null)
+        {
+            generationResult.ResultMetadata.DependOn = testCase.ToList();
+            foreach (var test in testCase)
+            {
+                sbomPackageDetailsRecorderMock.Setup(m => m.RecordPackageId(TestEntityId, test));
+            }
+        }
+
+        if (expectNullDependency)
+        {
+            sbomPackageDetailsRecorderMock.Setup(m => m.RecordPackageId(TestEntityId, null));
+        }
+
+        await testSubject.GenerateJson(sbomConfigs, packageInfo, resultChannel, errorsChannel);
+    }
+}


### PR DESCRIPTION
PR #1101 added support for multiple transitive dependencies, but it had an unintended side effect: We stopped writing the dependencies from the root package. Put into more concrete terms, we lost all `DEPENDS_ON` relationships from `SPDXRef-RootPackage` to other packages, like the one shown here (which happens to be for `MinVer` version 6.0.0

```json
    {
      "relationshipType": "DEPENDS_ON",
      "relatedSpdxElement": "SPDXRef-Package-38ECF1208220BC62360A75A5B25CB21CF68DCDA163069DFEC12FC2D8234F046E",
      "spdxElementId": "SPDXRef-RootPackage"
    },
```

Prior to #1101, if a package was a dependency only of the root package, the code would call `ISbomPackageDetailsRecorder.RecordPackageId()` with the second parameter set to `null`, which was the source of the dependencies from the root package. #1101 called `ISbomPackageDetailsRecorder.RecordPackageId()` for each known dependency, but dropped the case where no upstream dependency existed. This PR adds code to call `ISbomPackageDetailsRecorder.RecordPackageId()` with the second parameter set to `null` if no dependencies were found.

This PR also adds unit tests for `PackageInfoJsonWriter.GenerateJson`, which required the addition of the `IManifestGeneratorProvider` to decouple the classes. The DI code currently maps both `ManifestGeneratorProvider` and `IManifestGeneratorProvider` to `ManifestGeneratorProvider`. This could definitely be cleaned up, but it significantly increases the scope of the change and feels like it belongs in a separate PR.