### PR TITLE
Ignore SHA1 codeQL warnings

### DIFF
--- a/src/Microsoft.Sbom.Api/Hashing/Algorithms/Sha1HashAlgorithm.cs
+++ b/src/Microsoft.Sbom.Api/Hashing/Algorithms/Sha1HashAlgorithm.cs
@@ -12,5 +12,5 @@ namespace Microsoft.Sbom.Api.Hashing.Algorithms;
 #pragma warning disable CA5350 // Suppress Do Not Use Weak Cryptographic Algorithms as we use SHA1 intentionally
 public class Sha1HashAlgorithm : IHashAlgorithm
 {
-    public byte[] ComputeHash(Stream stream) => SHA1.Create().ComputeHash(stream);
+    public byte[] ComputeHash(Stream stream) => SHA1.Create().ComputeHash(stream); // CodeQL [SM02196] Sha1 is required per the SPDX spec.
 }

--- a/src/Microsoft.Sbom.Contracts/Contracts/Enums/AlgorithmName.cs
+++ b/src/Microsoft.Sbom.Contracts/Contracts/Enums/AlgorithmName.cs
@@ -97,7 +97,7 @@ public class AlgorithmName : IEquatable<AlgorithmName>
     /// Gets equivalent to <see cref="HashAlgorithmName.SHA1"/>.
     /// </summary>
 #pragma warning disable CA5350 // Suppress Do Not Use Weak Cryptographic Algorithms as we use SHA1 intentionally
-    public static AlgorithmName SHA1 => new AlgorithmName(nameof(SHA1), stream => System.Security.Cryptography.SHA1.Create().ComputeHash(stream));
+    public static AlgorithmName SHA1 => new AlgorithmName(nameof(SHA1), stream => System.Security.Cryptography.SHA1.Create().ComputeHash(stream)); // CodeQL [SM02196] Sha1 is required per the SPDX spec.
 #pragma warning restore CA5350
 
     /// <summary>

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Generator.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Generator.cs
@@ -338,7 +338,7 @@ public class Generator : IManifestGenerator
 
         var packageChecksumString = string.Concat(sha1Checksums.OrderBy(s => s));
 #pragma warning disable CA5350 // Suppress Do Not Use Weak Cryptographic Algorithms as we use SHA1 intentionally
-        var sha1Hasher = SHA1.Create();
+        var sha1Hasher = SHA1.Create(); // CodeQL [SM02196] Sha1 is required per the SPDX spec.
 #pragma warning restore CA5350
         var hashByteArray = sha1Hasher.ComputeHash(Encoding.Default.GetBytes(packageChecksumString));
 

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/SPDXExtensions.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/SPDXExtensions.cs
@@ -123,7 +123,7 @@ public static class SPDXExtensions
 
         if (checksums is null || !checksums.Any(c => c.Algorithm == AlgorithmName.SHA1))
         {
-            throw new MissingHashValueException($"The external reference {name} is missing the {HashAlgorithmName.SHA1} hash value.");
+            throw new MissingHashValueException($"The external reference {name} is missing the {HashAlgorithmName.SHA1} hash value."); // CodeQL [SM02196] Sha1 is required per the SPDX spec.
         }
 
         // Get the SHA1 for this file.

--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Generator.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Generator.cs
@@ -654,7 +654,7 @@ public class Generator : IManifestGenerator
 
         var packageChecksumString = string.Concat(sha1Checksums.OrderBy(s => s));
 #pragma warning disable CA5350 // Suppress Do Not Use Weak Cryptographic Algorithms as we use SHA1 intentionally
-        var sha1Hasher = SHA1.Create();
+        var sha1Hasher = SHA1.Create(); // CodeQL [SM02196] Sha1 is required per the SPDX spec.
 #pragma warning restore CA5350
         var hashByteArray = sha1Hasher.ComputeHash(Encoding.Default.GetBytes(packageChecksumString));
 

--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Utils/SPDXExtensions.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Utils/SPDXExtensions.cs
@@ -72,7 +72,7 @@ public static class SPDXExtensions
         var sha1checksums = checksums.Where(c => c.Algorithm == AlgorithmName.SHA1);
         if (checksums is null || !sha1checksums.Any())
         {
-            throw new MissingHashValueException($"The external reference {name} is missing the {HashAlgorithmName.SHA1} hash value.");
+            throw new MissingHashValueException($"The external reference {name} is missing the {HashAlgorithmName.SHA1} hash value."); // CodeQL [SM02196] Sha1 is required per the SPDX spec.
         }
 
         // Get the SHA1 for this file.


### PR DESCRIPTION
Dismiss code QL warnings about usage of SHA1 because it is required per the SPDX 2.2/3.0 specs