### PR TITLE
Refactor constructor for Generator class

### DIFF
--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Generator.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Generator.cs
@@ -41,12 +41,13 @@ public class Generator : IManifestGenerator
     public string ExternalDocumentRefArrayHeaderName => Constants.ExternalDocumentRefArrayHeaderName;
 
     // This constructor gets called by an internal consumer that does not use IConfiguration.
+    // In this repo, we use it in tests to pin the existing behavior via this constructor.
     public Generator()
     {
         actionIsAggregate = false;
     }
 
-    // This constructor gets used within this repo.
+    // This constructor gets used by the production code and by at least one test.
     public Generator(IConfiguration configuration)
     {
         ArgumentNullException.ThrowIfNull(configuration, nameof(configuration));

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/GeneratorTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/GeneratorTests.cs
@@ -23,6 +23,7 @@ public class GeneratorTests
     public void BeforeEachTest()
     {
         configurationMock = new Mock<IConfiguration>(MockBehavior.Strict);
+        configurationMock.SetupGet(m => m.ManifestToolAction).Returns(ManifestToolActions.Generate);
         generator = new Generator(configurationMock.Object);
     }
 
@@ -90,7 +91,9 @@ public class GeneratorTests
         const string packageId2 = Constants.RootPackageIdValue;
         const string packageId3 = ExpectedFormatSpdxId;
 
+        // Reset the generator to use the Aggregate action
         configurationMock.SetupGet(m => m.ManifestToolAction).Returns(ManifestToolActions.Aggregate);
+        generator = new Generator(configurationMock.Object);
 
         var packageInfo = new SbomPackage
         {
@@ -110,8 +113,6 @@ public class GeneratorTests
     [TestMethod]
     public void GenerateJsonDocument_Generating_DependsOnId_EqualsRootPackageId_ReturnsInputId()
     {
-        configurationMock.SetupGet(m => m.ManifestToolAction).Returns(ManifestToolActions.Generate);
-
         var packageInfo = new SbomPackage
         {
             PackageName = "TestPackage",
@@ -130,8 +131,6 @@ public class GeneratorTests
         const string packageId1 = "SomePackageId";
         const string packageId2 = "AnotherPackageId";
         const string packageId3 = ExpectedFormatSpdxId;
-
-        configurationMock.SetupGet(m => m.ManifestToolAction).Returns(ManifestToolActions.Generate);
 
         var packageInfo = new SbomPackage
         {

--- a/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/GeneratorTests.cs
+++ b/test/Microsoft.Sbom.Parsers.Spdx22SbomParser.Tests/Parser/GeneratorTests.cs
@@ -23,8 +23,7 @@ public class GeneratorTests
     public void BeforeEachTest()
     {
         configurationMock = new Mock<IConfiguration>(MockBehavior.Strict);
-        configurationMock.SetupGet(m => m.ManifestToolAction).Returns(ManifestToolActions.Generate);
-        generator = new Generator(configurationMock.Object);
+        generator = new Generator();
     }
 
     [TestCleanup]


### PR DESCRIPTION
#1139 added an `IConfiguration` object to the constructor of the `Generator` class. We have an internal consumer of this class, and that consumer does not have a readily available `IConfiguration` object to pass to the constructor. Rather than disrupt that consumer, it is preferable to allow a default constructor for the `Generator` class. Ultimately, `Generator` only needs to know how to handle existing SPDX ID's, so that's the only state that it stores. That state can now be set in any of three ways:
1. The default constructor (will retain the behavior that existed before #1139) 
2. A parameterized constructor that accepts a `bool`
3. A parameterized constructor that accepts an `IConfiguration`

Unit tests cover all scenarios with all applicable constructors. Because each test needs to use a specific constructor, the unit tests no longer use a fixture for the test subject.