### PR TITLE
Ignore SHA1 codeQL warnings

### DIFF
--- a/src/Microsoft.Sbom.Contracts/Contracts/Enums/AlgorithmName.cs
+++ b/src/Microsoft.Sbom.Contracts/Contracts/Enums/AlgorithmName.cs
@@ -114,5 +114,5 @@ public class AlgorithmName : IEquatable<AlgorithmName>
     /// Gets equivalent to <see cref="HashAlgorithmName.MD5"/>.
     /// </summary>
     [SuppressMessage("Security", "CA5351:Do Not Use Broken Cryptographic Algorithms", Justification = "Used by conda package manager.")]
-    public static AlgorithmName MD5 => new AlgorithmName(nameof(MD5), stream => System.Security.Cryptography.MD5.Create().ComputeHash(stream));
+    public static AlgorithmName MD5 => new AlgorithmName(nameof(MD5), stream => System.Security.Cryptography.MD5.Create().ComputeHash(stream)); // CodeQL [SM02196] Used by conda package manager.
 }

--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/SPDXExtensions.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/SPDXExtensions.cs
@@ -94,7 +94,7 @@ public static class SPDXExtensions
 
         if (checksums is null || !checksums.Any(c => c.Algorithm == AlgorithmName.SHA1))
         {
-            throw new MissingHashValueException($"The file {fileName} is missing the {HashAlgorithmName.SHA1} hash value.");
+            throw new MissingHashValueException($"The file {fileName} is missing the {HashAlgorithmName.SHA1} hash value."); // CodeQL [SM02196] Sha1 is required per the SPDX spec.
         }
 
         // Get the SHA1 for this file.

--- a/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Utils/SPDXExtensions.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx30SbomParser/Utils/SPDXExtensions.cs
@@ -42,7 +42,7 @@ public static class SPDXExtensions
 
         if (fileInfo.Checksum is null || !fileInfo.Checksum.Any(c => c.Algorithm == AlgorithmName.SHA1))
         {
-            throw new MissingHashValueException($"The file {fileInfo.Path} is missing the {HashAlgorithmName.SHA1} hash value.");
+            throw new MissingHashValueException($"The file {fileInfo.Path} is missing the {HashAlgorithmName.SHA1} hash value."); // CodeQL [SM02196] Sha1 is required per the SPDX spec.
         }
 
         // Get the SHA1 for this file.


### PR DESCRIPTION
Following up on https://github.com/microsoft/sbom-tool/pull/1138, fixing some issues missed in that PR