### PR TITLE
Exclude samples folder from externaldocreferences

### DIFF
--- a/pipelines/build-test-tool-template.yaml
+++ b/pipelines/build-test-tool-template.yaml
@@ -43,3 +43,6 @@ steps:
     condition: eq(variables['Agent.OS'], 'Windows_NT')
     inputs:
       summaryFileLocation: '$(Agent.TempDirectory)/coverage.cobertura.xml'
+
+  - powershell: 'Remove-Item -Path $(Build.SourcesDirectory)/samples -Recurse -Force'
+    displayName: 'Remove Samples to avoid treating them as external doc references'


### PR DESCRIPTION
When we build the manifests for release, they are treating the SPDX files in the `./samples` folder as external document references, which is causing some downstream pain. To prevent this, we just delete the `./samples` folder after building and running our tests. I've run this in a [test build](https://dev.azure.com/mseng/AzureDevOps/_build/results?buildId=30266343&view=results) and confirmed that the manifests we produce are no longer including the samples up as external document references.