### PR TITLE
Fix parser bug & add tests

### DIFF
--- a/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/SPDXToSbomFormatConverterExtensions.cs
+++ b/src/Microsoft.Sbom.Parsers.Spdx22SbomParser/Utils/SPDXToSbomFormatConverterExtensions.cs
@@ -102,7 +102,7 @@ public static class SPDXToSbomFormatConverterExtensions
     /// <param name="externalReference"></param>
     internal static string ToPurl(this IList<ExternalReference> externalReference)
     {
-        var packageManagerReference = externalReference?.Where(e => e.ReferenceCategory.Replace("_", "-", System.StringComparison.Ordinal) == "PACKAGE-MANAGER")?.First();
+        var packageManagerReference = externalReference?.Where(e => e.ReferenceCategory.Replace("_", "-", System.StringComparison.Ordinal) == "PACKAGE-MANAGER")?.FirstOrDefault();
         return packageManagerReference?.Locator;
     }
 


### PR DESCRIPTION
Upon updating to a new version of Syft, a user found found a bug in our handling of the external refs property in the packages section. 

In the case that an SBOM contains an external refs property that is empty, like so:

```
"packages": [
        {
           ...
            "externalRefs": []
        }
    ]
```

...or, when the user provides an external refs property of the packages section that only contains elements where Reference Category != "PACKAGE_MANAGER", like so:

```
"packages": [
        {
               ...
                "externalRefs": [
                    {
                        "referenceCategory": "SECURITY",
                        "referenceLocator": "cpe:2.3:a:antlr4_runtime_standard:antlr4_runtime_standard_.net:4.13.1:*:*:*:*:*:*:*",
                        "referenceType": "cpe23Type"
                    },
                    {
                        "referenceCategory": "SECURITY",
                        "referenceLocator": "cpe:2.3:a:antlr4_runtime_standard:antlr4_runtime_standard:4.13.1:*:*:*:*:*:*:*",
                        "referenceType": "cpe23Type"
                    },
                ]  
            }
    ]
```

...then we get this error:
Exception: System.InvalidOperationException: Sequence contains no elements

This PR fixes the bug and adds tests to ensure all such versions of external refs are handled properly. 
