### PR TITLE
Add COSE paths to SbomConfig

### DIFF
--- a/src/Microsoft.Sbom.Api/Manifest/BaseManifestConfigHandler.cs
+++ b/src/Microsoft.Sbom.Api/Manifest/BaseManifestConfigHandler.cs
@@ -46,6 +46,10 @@ public abstract class BaseManifestConfigHandler : IManifestConfigHandler
 
     protected string BsiFilePath => fileSystemUtils.JoinPaths(SbomDirPath, Constants.BsiFileName);
 
+    protected string BsiCoseFilePath => fileSystemUtils.JoinPaths(SbomDirPath, Constants.BsiCoseFileName);
+
+    protected string ManifestCoseFilePath => fileSystemUtils.JoinPaths(SbomDirPath, Constants.ManifestCoseFileName);
+
     protected IMetadataBuilder MetadataBuilder => metadataBuilderFactory.Get(ManifestInfo);
 
     protected ISbomConfig CreateSbomConfig()
@@ -57,6 +61,8 @@ public abstract class BaseManifestConfigHandler : IManifestConfigHandler
             ManifestJsonFilePath = SbomFilePath,
             CatalogFilePath = CatalogFilePath,
             BsiFilePath = BsiFilePath,
+            BsiCoseFilePath = BsiCoseFilePath,
+            ManifestCoseFilePath = ManifestCoseFilePath,
             ManifestJsonFileSha256FilePath = ManifestJsonSha256FilePath,
             MetadataBuilder = MetadataBuilder,
             Recorder = new SbomPackageDetailsRecorder()

--- a/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfig.cs
+++ b/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfig.cs
@@ -51,6 +51,16 @@ public class SbomConfig : ISbomConfig, IDisposable, IAsyncDisposable
     public string BsiFilePath { get; set; }
 
     /// <summary>
+    /// Gets or sets the absolute path of the build session information COSE file.
+    /// </summary>
+    public string BsiCoseFilePath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the absolute path of the manifest COSE file.
+    /// </summary>
+    public string ManifestCoseFilePath { get; set; }
+
+    /// <summary>
     /// Gets or sets derived manifestInfo or from configurations.
     /// </summary>
     public ManifestInfo ManifestInfo { get; set; }

--- a/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfigFactory.cs
+++ b/src/Microsoft.Sbom.Api/Manifest/Configuration/SbomConfigFactory.cs
@@ -26,6 +26,8 @@ public class SbomConfigFactory : ISbomConfigFactory
         string manifestFileSha256HashPath,
         string catalogFilePath,
         string bsiFilePath,
+        string bsiCoseFilePath,
+        string manifestCoseFilePath,
         ISbomPackageDetailsRecorder recorder,
         IMetadataBuilder metadataBuilder)
     {
@@ -35,6 +37,8 @@ public class SbomConfigFactory : ISbomConfigFactory
             ManifestJsonDirPath = manifestDirPath,
             ManifestJsonFilePath = manifestFilePath,
             BsiFilePath = bsiFilePath,
+            BsiCoseFilePath = bsiCoseFilePath,
+            ManifestCoseFilePath = manifestCoseFilePath,
             CatalogFilePath = catalogFilePath,
             ManifestJsonFileSha256FilePath = manifestFileSha256HashPath,
             MetadataBuilder = metadataBuilder,
@@ -52,6 +56,8 @@ public class SbomConfigFactory : ISbomConfigFactory
         var shaFilePath = $"{sbomFilePath}.sha256";
         var catFilePath = fileSystemUtils.JoinPaths(sbomDirPath, Constants.CatalogFileName);
         var bsiFilePath = fileSystemUtils.JoinPaths(sbomDirPath, Constants.BsiFileName);
+        var bsiCoseFilePath = fileSystemUtils.JoinPaths(sbomDirPath, Constants.BsiCoseFileName);
+        var manifestCoseFilePath = fileSystemUtils.JoinPaths(sbomDirPath, Constants.ManifestCoseFileName);
         if (!fileSystemUtils.FileExists(shaFilePath) && !fileSystemUtils.FileExists(catFilePath) && !fileSystemUtils.FileExists(bsiFilePath))
         {
             // This is likely a CloudBuild SBOM, adjust paths accordingly
@@ -66,6 +72,8 @@ public class SbomConfigFactory : ISbomConfigFactory
             shaFilePath,
             catFilePath,
             bsiFilePath,
+            bsiCoseFilePath,
+            manifestCoseFilePath,
             new SbomPackageDetailsRecorder(),
             metadataBuilderFactory.Get(manifestInfo));
     }

--- a/src/Microsoft.Sbom.Api/Utils/Constants.cs
+++ b/src/Microsoft.Sbom.Api/Utils/Constants.cs
@@ -70,6 +70,8 @@ public static class Constants
     public const string DefaultRootElement = "SPDXRef-Document";
     public const string CatalogFileName = "manifest.cat";
     public const string BsiFileName = "bsi.json";
+    public const string BsiCoseFileName = "bsi.cose";
+    public const string ManifestCoseFileName = "manifest.spdx.cose";
     public const string DeleteManifestDirBoolVariableName = "DeleteManifestDirIfPresent";
     public const string RootPackageIdValue = "SPDXRef-RootPackage";
 

--- a/src/Microsoft.Sbom.Common/ISbomConfigFactory.cs
+++ b/src/Microsoft.Sbom.Common/ISbomConfigFactory.cs
@@ -21,6 +21,8 @@ public interface ISbomConfigFactory
         string manifestFileSha256HashPath,
         string catalogFilePath,
         string bsiFilePath,
+        string bsiCoseFilePath,
+        string manifestCoseFilePath,
         ISbomPackageDetailsRecorder recorder,
         IMetadataBuilder metadataBuilder);
 

--- a/src/Microsoft.Sbom.Extensions/ISbomConfig.cs
+++ b/src/Microsoft.Sbom.Extensions/ISbomConfig.cs
@@ -38,6 +38,16 @@ public interface ISbomConfig : IDisposable, IAsyncDisposable
     public string BsiFilePath { get; set; }
 
     /// <summary>
+    /// Gets or sets the absolute path of the build session information COSE file.
+    /// </summary>
+    public string BsiCoseFilePath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the absolute path of the manifest COSE file.
+    /// </summary>
+    public string ManifestCoseFilePath { get; set; }
+
+    /// <summary>
     /// Gets or sets derived manifestInfo or from configurations.
     /// </summary>
     public ManifestInfo ManifestInfo { get; set; }

--- a/test/Microsoft.Sbom.Api.Tests/Manifest/Configuration/SbomConfigFactoryTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/Manifest/Configuration/SbomConfigFactoryTests.cs
@@ -24,6 +24,8 @@ public class SbomConfigFactoryTests
     private string cbCatFilePathStub = "cloud-build-cat-file-path";
     private string bsiFilePathStub = "bsi-file-path";
     private string cbBsiFilePathStub = "cloud-build-bsi-file-path";
+    private string bsiCoseFilePathStub = "bsi-cose-file-path";
+    private string manifestCoseFilePathStub = "manifest-cose-file-path";
     private ManifestInfo manifestInfoStub = Api.Utils.Constants.SPDX30ManifestInfo;
     private string manifestInfoStringStub = "spdx_3.0";
     private string manifestFileNameStub = "manifest.spdx.json";
@@ -86,6 +88,12 @@ public class SbomConfigFactoryTests
             .Setup(m => m.JoinPaths(spdxDirPathStub, Api.Utils.Constants.BsiFileName))
             .Returns(bsiFilePathStub);
         fileSystemUtilsMock
+            .Setup(m => m.JoinPaths(spdxDirPathStub, Api.Utils.Constants.BsiCoseFileName))
+            .Returns(bsiCoseFilePathStub);
+        fileSystemUtilsMock
+            .Setup(m => m.JoinPaths(spdxDirPathStub, Api.Utils.Constants.ManifestCoseFileName))
+            .Returns(manifestCoseFilePathStub);
+        fileSystemUtilsMock
             .Setup(m => m.FileExists($"{sbomFilePathStub}.sha256"))
             .Returns(true);
         metadataBuilderFactoryMock.Setup(m => m.Get(manifestInfoStub)).Returns(metadataBuilderStub);
@@ -114,6 +122,12 @@ public class SbomConfigFactoryTests
         fileSystemUtilsMock
             .Setup(m => m.JoinPaths(spdxDirPathStub, Api.Utils.Constants.BsiFileName))
             .Returns(bsiFilePathStub);
+        fileSystemUtilsMock
+            .Setup(m => m.JoinPaths(spdxDirPathStub, Api.Utils.Constants.BsiCoseFileName))
+            .Returns(bsiCoseFilePathStub);
+        fileSystemUtilsMock
+            .Setup(m => m.JoinPaths(spdxDirPathStub, Api.Utils.Constants.ManifestCoseFileName))
+            .Returns(manifestCoseFilePathStub);
         fileSystemUtilsMock
             .Setup(m => m.FileExists($"{sbomFilePathStub}.sha256"))
             .Returns(false);

--- a/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
+++ b/test/Microsoft.Sbom.Api.Tests/VersionSpecificPins/Version_4_0/InterfaceConcretionTests.cs
@@ -220,6 +220,8 @@ public class InterfaceConcretionTests
         public string ManifestJsonFileSha256FilePath { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public string CatalogFilePath { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public string BsiFilePath { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public string BsiCoseFilePath { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public string ManifestCoseFilePath { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public ManifestInfo ManifestInfo { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public IMetadataBuilder MetadataBuilder { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 


### PR DESCRIPTION
This PR adds the COSE signed file paths to the SbomConfig interface (and implementation) so we can create COSE validators based on these filepaths.