### PR TITLE
Temporarily make NI policy permissive

### DIFF
--- a/pipelines/sbom-tool-main-build.yaml
+++ b/pipelines/sbom-tool-main-build.yaml
@@ -31,6 +31,8 @@ variables:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
+    settings:
+      networkIsolationPolicy: Permissive
     sdl:
       sourceAnalysisPool:
         name: sbom-windows-build-pool


### PR DESCRIPTION
The auto-onboarded Network Isolation policy denies access to public websites like nuget.org. This blocks us from successfully building our SBOM tool pipeline and releasing the sbom-tool. Therefore we are temporarily using the permissive policy in order to release, after which we will fix the NI policy.