### PR TITLE
Include external doc refs in aggregated SBOMs

### DIFF
--- a/src/Microsoft.Sbom.Api/Executors/FileHasher.cs
+++ b/src/Microsoft.Sbom.Api/Executors/FileHasher.cs
@@ -47,10 +47,13 @@ public class FileHasher
                 {
                     configuration.HashAlgorithm.Value
                 },
-                ManifestToolActions.Aggregate => new AlgorithmName[]
-                {
-                    configuration.HashAlgorithm.Value
-                },
+                ManifestToolActions.Aggregate => sbomConfigs.GetManifestInfos()
+                    .Select(config => manifestGeneratorProvider
+                        .Get(config)
+                        .RequiredHashAlgorithms)
+                    .SelectMany(h => h)
+                    .Distinct()
+                    .ToArray(),
                 ManifestToolActions.Generate => sbomConfigs.GetManifestInfos()
                     .Select(config => manifestGeneratorProvider
                         .Get(config)

--- a/src/Microsoft.Sbom.Api/Providers/ExternalDocumentReferenceProviders/CGExternalDocumentReferenceProvider.cs
+++ b/src/Microsoft.Sbom.Api/Providers/ExternalDocumentReferenceProviders/CGExternalDocumentReferenceProvider.cs
@@ -48,7 +48,7 @@ public class CGExternalDocumentReferenceProvider : EntityToJsonProviderBase<Scan
 
     public override bool IsSupported(ProviderType providerType)
     {
-        if (providerType == ProviderType.ExternalDocumentReference)
+        if (providerType == ProviderType.ExternalDocumentReference && Configuration.ManifestToolAction == ManifestToolActions.Generate)
         {
             Log.Debug($"Using the {nameof(CGExternalDocumentReferenceProvider)} provider for the external documents workflow.");
             return true;

--- a/src/Microsoft.Sbom.Api/Workflows/SbomGenerationWorkflow.cs
+++ b/src/Microsoft.Sbom.Api/Workflows/SbomGenerationWorkflow.cs
@@ -192,11 +192,8 @@ public class SbomGenerationWorkflow : IWorkflow<SbomGenerationWorkflow>
         var packageGeneratorResult = await packageArrayGenerator.GenerateAsync(targetConfigs, elementsSpdxIdList);
         validErrors.AddRange(packageGeneratorResult.Errors);
 
-        if (configuration.ManifestToolAction == ManifestToolActions.Generate)
-        {
-            var externalDocumentReferenceGeneratorResult = await externalDocumentReferenceGenerator.GenerateAsync(targetConfigs, elementsSpdxIdList);
-            validErrors.AddRange(externalDocumentReferenceGeneratorResult.Errors);
-        }
+        var externalDocumentReferenceGeneratorResult = await externalDocumentReferenceGenerator.GenerateAsync(targetConfigs, elementsSpdxIdList);
+        validErrors.AddRange(externalDocumentReferenceGeneratorResult.Errors);
 
         var relationshipGeneratorResult = await relationshipsArrayGenerator.GenerateAsync(targetConfigs, elementsSpdxIdList);
         validErrors.AddRange(relationshipGeneratorResult.Errors);


### PR DESCRIPTION
This PR adds entries for component SBOMs to the externalDocumentRefs section of the resulting, aggregated SBOM in the aggregation workflow. This change also means that the component SBOM files are included in the files section of the aggregated SBOM. 