### PR TITLE
Update readme to reflect new contribution policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,15 +153,8 @@ By default, telemetry will output to your output file path and will be a JSON bl
 
 ## Contributing
 
-Please follow the steps [here](docs/building-from-source.md) to clone and build this repository from source.
-
-This project welcomes contributions and suggestions.  Most contributions require you to agree to a
-Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit <https://cla.opensource.microsoft.com>.
-
-When you submit a pull request, a CLA bot will automatically determine whether you need to provide
-a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
-provided by the bot. You will only need to do this once across all repos using our CLA.
+This project does not accept open-source contributions due to the sensitive, regulatory nature of SBOMs. If you are external to Microsoft and need modifications to the tool, you are welcome to fork and maintain a version of the tool.
+If you are internal, please contact SBOM Support to discuss your scenario.
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or


### PR DESCRIPTION
sbom-tool will no longer accept external contributions; update readme accordingly.