### PR TITLE
Update pipeline to use shared service connection

### DIFF
--- a/pipelines/sbom-tool-main-build.yaml
+++ b/pipelines/sbom-tool-main-build.yaml
@@ -64,7 +64,7 @@ extends:
           - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
             displayName: 'Sign dlls'
             inputs:
-              ConnectedServiceName: 'SBOM Tool CI ESRP'
+              ConnectedServiceName: 'SBOM Tool CI ESRP-1ES'
               AppRegistrationClientId: '51c11fce-97e9-4671-9176-0fc328a9dd17'
               AppRegistrationTenantId: '33e01921-4d64-4f8c-a055-5bdaffd5e33d'
               AuthAKVName: 'Sbom-Esrp-Secrets'
@@ -107,7 +107,7 @@ extends:
           - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
             displayName: 'Sign packages'
             inputs:
-              ConnectedServiceName: 'SBOM Tool CI ESRP'
+              ConnectedServiceName: 'SBOM Tool CI ESRP-1ES'
               AppRegistrationClientId: '51c11fce-97e9-4671-9176-0fc328a9dd17'
               AppRegistrationTenantId: '33e01921-4d64-4f8c-a055-5bdaffd5e33d'
               AuthAKVName: 'Sbom-Esrp-Secrets'
@@ -148,7 +148,7 @@ extends:
           - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
             displayName: 'Sign self-contained binaries'
             inputs:
-              ConnectedServiceName: 'SBOM Tool CI ESRP'
+              ConnectedServiceName: 'SBOM Tool CI ESRP-1ES'
               AppRegistrationClientId: '51c11fce-97e9-4671-9176-0fc328a9dd17'
               AppRegistrationTenantId: '33e01921-4d64-4f8c-a055-5bdaffd5e33d'
               AuthAKVName: 'Sbom-Esrp-Secrets'


### PR DESCRIPTION
Recently, security enforcements have caused us to have to enable branch control on service connections.  Branch control is not required for classic pipelines, but is required for YAML pipelines. Therefore I created a cloned SC with branch protection enabled that can be used for the YAML pipelines.