### PR TITLE
Revert "Update pipeline to use shared service connection"

### DIFF
--- a/pipelines/sbom-tool-main-build.yaml
+++ b/pipelines/sbom-tool-main-build.yaml
@@ -64,7 +64,7 @@ extends:
           - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
             displayName: 'Sign dlls'
             inputs:
-              ConnectedServiceName: 'SBOM Tool CI ESRP-1ES'
+              ConnectedServiceName: 'SBOM Tool CI ESRP'
               AppRegistrationClientId: '51c11fce-97e9-4671-9176-0fc328a9dd17'
               AppRegistrationTenantId: '33e01921-4d64-4f8c-a055-5bdaffd5e33d'
               AuthAKVName: 'Sbom-Esrp-Secrets'
@@ -107,7 +107,7 @@ extends:
           - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
             displayName: 'Sign packages'
             inputs:
-              ConnectedServiceName: 'SBOM Tool CI ESRP-1ES'
+              ConnectedServiceName: 'SBOM Tool CI ESRP'
               AppRegistrationClientId: '51c11fce-97e9-4671-9176-0fc328a9dd17'
               AppRegistrationTenantId: '33e01921-4d64-4f8c-a055-5bdaffd5e33d'
               AuthAKVName: 'Sbom-Esrp-Secrets'
@@ -148,7 +148,7 @@ extends:
           - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
             displayName: 'Sign self-contained binaries'
             inputs:
-              ConnectedServiceName: 'SBOM Tool CI ESRP-1ES'
+              ConnectedServiceName: 'SBOM Tool CI ESRP'
               AppRegistrationClientId: '51c11fce-97e9-4671-9176-0fc328a9dd17'
               AppRegistrationTenantId: '33e01921-4d64-4f8c-a055-5bdaffd5e33d'
               AuthAKVName: 'Sbom-Esrp-Secrets'


### PR DESCRIPTION
Reverts microsoft/sbom-tool#1262 . This pipeline cannot use the updated Service connection since it is in a different ADO org. Rather than using the cloned SC with branch protection checks in a different ADO org, I've enabled the branch protection check on the original SC.