### PR TITLE
Bump to dotnet 8.0.121 to resolve CG alert

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "8.0.121",
     "rollForward": "latestMajor"
   }
 }


### PR DESCRIPTION
Resolves a [CG alert](https://dev.azure.com/mseng/AzureDevOps/_componentGovernance/845/alert/333826?typeId=289624) with version 8.0.100 of dotnet. 