### PR TITLE
Upgrade Component Detection packages from 6.0.0 to 6.2.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,17 +23,17 @@
     <PackageVersion Include="Microsoft.ComponentDetection.Detectors" Version="$(ComponentDetectionPackageVersion)" />
     <PackageVersion Include="Microsoft.ComponentDetection.Orchestrator" Version="$(ComponentDetectionPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.10" />
     <PackageVersion Include="Microsoft.IO.Redist" Version="6.1.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageVersion Include="NuGet.Configuration" Version="6.14.0" />
-    <PackageVersion Include="NuGet.Frameworks" Version="6.14.0" />
-    <PackageVersion Include="NuGet.ProjectModel" Version="6.11.1" />
+    <PackageVersion Include="NuGet.Configuration" Version="7.0.0" />
+    <PackageVersion Include="NuGet.Frameworks" Version="7.0.0" />
+    <PackageVersion Include="NuGet.ProjectModel" Version="7.0.0" />
     <PackageVersion Include="packageurl-dotnet" Version="1.1.0" />
     <PackageVersion Include="PowerArgs" Version="3.6.0" />
     <PackageVersion Include="Scrutor" Version="6.1.0" />
@@ -43,7 +43,7 @@
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageVersion Include="Serilog.Sinks.Map" Version="2.0.0" />
-    <PackageVersion Include="Spectre.Console.Cli" Version="0.49.1" />
+    <PackageVersion Include="Spectre.Console.Cli" Version="0.53.0" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
     <PackageVersion Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
@@ -53,9 +53,9 @@
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <PackageVersion Include="System.Reactive" Version="6.0.1" />
     <PackageVersion Include="System.Runtime.Loader" Version="4.3.0" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.9" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.10" />
     <PackageVersion Include="System.Threading.Channels" Version="9.0.10" />
-    <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="8.0.1" />
+    <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="9.0.0" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Sbom.Adapters/Microsoft.Sbom.Adapters.csproj
+++ b/src/Microsoft.Sbom.Adapters/Microsoft.Sbom.Adapters.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" VersionOverride="9.0.9" />
+    <PackageReference Include="System.Text.Json" />
     <ProjectReference Include="..\Microsoft.Sbom.Common\Microsoft.Sbom.Common.csproj" />
     <ProjectReference Include="..\Microsoft.Sbom.Contracts\Microsoft.Sbom.Contracts.csproj" />
   </ItemGroup>

--- a/src/Microsoft.Sbom.Api/Microsoft.Sbom.Api.csproj
+++ b/src/Microsoft.Sbom.Api/Microsoft.Sbom.Api.csproj
@@ -47,7 +47,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="NuGet.Frameworks" VersionOverride="6.14.0" />
+      <PackageReference Include="NuGet.Frameworks" />
       <ProjectReference Include="..\Microsoft.Sbom.Adapters\Microsoft.Sbom.Adapters.csproj" />
       <ProjectReference Include="..\Microsoft.Sbom.Common\Microsoft.Sbom.Common.csproj" />
       <ProjectReference Include="..\Microsoft.Sbom.Contracts\Microsoft.Sbom.Contracts.csproj" />

--- a/src/Microsoft.Sbom.Common/Microsoft.Sbom.Common.csproj
+++ b/src/Microsoft.Sbom.Common/Microsoft.Sbom.Common.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" VersionOverride="9.0.9" />
+    <PackageReference Include="System.Text.Json" />
     <ProjectReference Include="..\Microsoft.Sbom.Extensions\Microsoft.Sbom.Extensions.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This release includes quite a few changes, but the most relevant ones are:
- [Add support for application-level component support in containers (#1529)][1]
- [Update Syft from 1.16.0 to 1.37.0 (#1527)][2]

See:
- https://github.com/microsoft/component-detection/releases/tag/v6.1.0
- https://github.com/microsoft/component-detection/releases/tag/v6.1.1
- https://github.com/microsoft/component-detection/releases/tag/v6.2.0

[1]: https://github.com/microsoft/component-detection/pull/1529
[2]: https://github.com/microsoft/component-detection/pull/1527