### PR TITLE
Upgrade Component Detection and Package URL

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     </PackageVersion>
   </ItemDefinitionGroup>
   <PropertyGroup>
-    <ComponentDetectionPackageVersion>6.3.0</ComponentDetectionPackageVersion>
+    <ComponentDetectionPackageVersion>7.0.18</ComponentDetectionPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.Build" Version="17.11.48" />
@@ -29,13 +29,13 @@
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageVersion Include="NuGet.Configuration" Version="7.0.1" />
-    <PackageVersion Include="NuGet.Frameworks" Version="7.0.1" />
-    <PackageVersion Include="NuGet.ProjectModel" Version="7.0.1" />
-    <PackageVersion Include="packageurl-dotnet" Version="1.1.0" />
+    <PackageVersion Include="NuGet.Configuration" Version="7.3.0" />
+    <PackageVersion Include="NuGet.Frameworks" Version="7.3.0" />
+    <PackageVersion Include="NuGet.ProjectModel" Version="7.3.0" />
+    <PackageVersion Include="packageurl-dotnet" Version="2.0.0-rc.3" />
     <PackageVersion Include="PowerArgs" Version="3.6.0" />
     <PackageVersion Include="Scrutor" Version="6.1.0" />
-    <PackageVersion Include="Serilog" Version="4.3.0" />
+    <PackageVersion Include="Serilog" Version="4.3.1" />
     <PackageVersion Include="Serilog.Extensions.Hosting" Version="8.0.0" />
     <PackageVersion Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
@@ -51,8 +51,8 @@
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <PackageVersion Include="System.Reactive" Version="6.0.1" />
     <PackageVersion Include="System.Runtime.Loader" Version="4.3.0" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.10" />
-    <PackageVersion Include="System.Threading.Channels" Version="9.0.10" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.13" />
+    <PackageVersion Include="System.Threading.Channels" Version="9.0.13" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="8.0.1" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
   </ItemGroup>

--- a/test/Microsoft.Sbom.Adapters.Tests/ComponentDetectionToSbomPackageAdapterTests.cs
+++ b/test/Microsoft.Sbom.Adapters.Tests/ComponentDetectionToSbomPackageAdapterTests.cs
@@ -565,7 +565,7 @@ public class ComponentDetectionToSBOMPackageAdapterTests
         Assert.IsTrue(packages.Any(p => p.PackageName == "Newtonsoft.Json"));
     }
 
-    private void AssertPackageUrlIsCorrect(PackageUrl.PackageURL expectedPackageUrl, string actualPackageUrl)
+    private void AssertPackageUrlIsCorrect(PackageUrl.PackageUrl expectedPackageUrl, string actualPackageUrl)
     {
         if (expectedPackageUrl is null)
         {


### PR DESCRIPTION
I have taken over ownership of the official .NET Package URL implementation ([RFC: Invite Jamie Magee as a maintainer](https://github.com/package-url/packageurl-dotnet/issues/33)).

Since the last release, `1.3.0`, 3 years ago the Package URL specification has reached 1.0 and become an ECMA standard: [ECMA-427](https://ecma-tc54.github.io/ECMA-427/)

Taking over the package, I updated the .NET implementation to conform with the 1.0 release of the specification, and validated with [the conformance tests](https://github.com/package-url/purl-spec/tree/main/tests).
