### PR TITLE
fix: Replace networkIsolationPolicy with disableNetworkIsolation flag

### DIFF
--- a/pipelines/sbom-tool-main-build.yaml
+++ b/pipelines/sbom-tool-main-build.yaml
@@ -31,8 +31,8 @@ variables:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
-    settings:
-      networkIsolationPolicy: Permissive
+    featureFlags:
+      disableNetworkIsolation: true
     sdl:
       sourceAnalysisPool:
         name: sbom-windows-build-pool


### PR DESCRIPTION
The 1ES Pipeline Templates updated the release tag to enforce stricter network isolation defaults, causing NuGet restore failures on Windows and Linux builds. Replace the deprecated networkIsolationPolicy: Permissive setting with featureFlags.disableNetworkIsolation: true, matching the approach already used in the release pipeline.