### PR TITLE
Fix ObjectDisposedException in GenerateSbom Task under MSBuild Server

### DIFF
--- a/src/Microsoft.Sbom.Extensions.DependencyInjection/Microsoft.Sbom.Extensions.DependencyInjection.csproj
+++ b/src/Microsoft.Sbom.Extensions.DependencyInjection/Microsoft.Sbom.Extensions.DependencyInjection.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="Serilog.Sinks.Console" />
     <PackageReference Include="Serilog.Sinks.File" />
     <PackageReference Include="Serilog.Sinks.Map" />
+    <PackageReference Include="Spectre.Console.Cli" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Sbom.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Sbom.Extensions.DependencyInjection/ServiceCollectionExtensions.cs
@@ -39,6 +39,7 @@ using Serilog.Core;
 using Serilog.Events;
 using Serilog.Extensions.Logging;
 using Serilog.Filters;
+using Spectre.Console;
 using Constants = Microsoft.Sbom.Api.Utils.Constants;
 using ILogger = Serilog.ILogger;
 
@@ -180,6 +181,7 @@ public static class ServiceCollectionExtensions
 
                 return manifestData;
             })
+            .AddSingleton(_ => CreateAnsiConsole())
             .AddComponentDetection()
             .ConfigureLoggingProviders()
             .AddHttpClient<LicenseInformationService>();
@@ -205,6 +207,30 @@ public static class ServiceCollectionExtensions
         });
 
         return services;
+    }
+
+    private static IAnsiConsole CreateAnsiConsole()
+    {
+        // Microsoft.ComponentDetection.Orchestrator's DetectorProcessingService takes an optional
+        // IAnsiConsole constructor parameter and falls back to the process-wide static
+        // AnsiConsole.Console singleton whenever DI doesn't supply one. That static singleton is
+        // created lazily on first use and permanently captures whichever TextWriter happened to be
+        // bound to Console.Out at that moment. Under a long-lived, reused process -- e.g. MSBuild
+        // Server, or any host that runs GenerateSbom in-process more than once -- the writer
+        // captured during the first invocation can be disposed once that build completes, and the
+        // static console then throws ObjectDisposedException the next time ComponentDetection tries
+        // to write to it (see https://github.com/dotnet/msbuild/issues/14691).
+        //
+        // Registering our own IAnsiConsole here -- scoped to this service collection/host instance
+        // rather than the process -- ensures ComponentDetection never touches the shared static
+        // console or the live Console.Out binding. The output is intentionally discarded via
+        // TextWriter.Null: the detection-times table should only be written to the log file, not the
+        // console (see the "DetectionTimeLine" filter in CreateLogger below), so there's nothing to
+        // gain by wiring this console up to the real standard output.
+        return AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Out = new AnsiConsoleOutput(TextWriter.Null),
+        });
     }
 
     private static ILogger CreateLogger(LogEventLevel logLevel)

--- a/test/Microsoft.Sbom.Extensions.DependencyInjection.Tests/Microsoft.Sbom.Extensions.DependencyInjection.Tests.csproj
+++ b/test/Microsoft.Sbom.Extensions.DependencyInjection.Tests/Microsoft.Sbom.Extensions.DependencyInjection.Tests.csproj
@@ -11,8 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Serilog" />
     <PackageReference Include="Serilog.Sinks.Console" />
+    <PackageReference Include="Spectre.Console.Cli" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Sbom.Extensions.DependencyInjection.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/Microsoft.Sbom.Extensions.DependencyInjection.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Serilog.Events;
+using Spectre.Console;
+
+namespace Microsoft.Sbom.Extensions.DependencyInjection.Tests;
+
+// Regression coverage for https://github.com/dotnet/msbuild/issues/14691: AddSbomTool must
+// register its own IAnsiConsole so ComponentDetection never falls back to the static, process-wide
+// AnsiConsole.Console singleton, which lazily captures Console.Out and can outlive it under
+// MSBuild Server reuse.
+[TestClass]
+[DoNotParallelize]
+public class ServiceCollectionExtensionsTests
+{
+    [TestMethod]
+    public void AddSbomTool_RegistersLocalAnsiConsole_DistinctFromProcessWideSingleton()
+    {
+        var services = new ServiceCollection();
+        services.AddSbomTool(LogEventLevel.Fatal);
+        using var provider = services.BuildServiceProvider();
+
+        var resolved = provider.GetRequiredService<IAnsiConsole>();
+
+        Assert.IsNotNull(resolved);
+        Assert.AreNotSame(AnsiConsole.Console, resolved, "AddSbomTool must not rely on the process-wide AnsiConsole.Console singleton.");
+    }
+
+    [TestMethod]
+    public void AddSbomTool_ResolvesIndependentAnsiConsole_AfterPriorConsoleOutIsDisposed()
+    {
+        var originalOut = Console.Out;
+        IAnsiConsole firstInvocationConsole;
+        IAnsiConsole secondInvocationConsole;
+
+        try
+        {
+            // Build #1: bind Console.Out, resolve IAnsiConsole from a fresh DI container, write to
+            // it, then dispose the writer -- mirroring MSBuild Server disposing its
+            // RedirectConsoleWriter after the build completes.
+            using (var firstInvocationWriter = new StringWriter())
+            {
+                Console.SetOut(firstInvocationWriter);
+
+                var firstServices = new ServiceCollection();
+                firstServices.AddSbomTool(LogEventLevel.Fatal);
+                using var firstProvider = firstServices.BuildServiceProvider();
+                firstInvocationConsole = firstProvider.GetRequiredService<IAnsiConsole>();
+
+                Assert.IsNotNull(firstInvocationConsole);
+                firstInvocationConsole.WriteLine("build #1 output");
+            }
+
+            // Build #2 reuses the process with Console.Out rebound to a new writer. The fresh DI
+            // container's IAnsiConsole must write without throwing ObjectDisposedException against
+            // build #1's now-disposed writer.
+            using var secondInvocationWriter = new StringWriter();
+            Console.SetOut(secondInvocationWriter);
+
+            var secondServices = new ServiceCollection();
+            secondServices.AddSbomTool(LogEventLevel.Fatal);
+            using var secondProvider = secondServices.BuildServiceProvider();
+            secondInvocationConsole = secondProvider.GetRequiredService<IAnsiConsole>();
+
+            Assert.IsNotNull(secondInvocationConsole);
+            secondInvocationConsole.WriteLine("build #2 output");
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+
+        Assert.AreNotSame(firstInvocationConsole, secondInvocationConsole, "Each AddSbomTool()-built provider must resolve its own IAnsiConsole instance.");
+    }
+}

--- a/test/Microsoft.Sbom.Targets.Tests/AbstractGenerateSbomTaskTests.cs
+++ b/test/Microsoft.Sbom.Targets.Tests/AbstractGenerateSbomTaskTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
@@ -383,6 +384,91 @@ public abstract class AbstractGenerateSbomTaskTests
         // Assert
         Assert.IsTrue(result);
         this.GeneratedSbomValidator.AssertSbomIsValid(this.ManifestPath, TestBuildDropPath, PackageName, PackageVersion, PackageSupplier, NamespaceBaseUri, buildComponentPath: sourceDirectory);
+    }
+
+    // Regression test for https://github.com/dotnet/msbuild/issues/14691: under MSBuild Server
+    // reuse, ComponentDetection previously fell back to the static AnsiConsole.Console singleton,
+    // which captured build #1's Console.Out and threw ObjectDisposedException once that writer
+    // was disposed and build #2 ran in the same process.
+    [TestMethod]
+    [DoNotParallelize]
+    public void Sbom_Is_Successfully_Generated_Across_Repeated_Invocations_After_ConsoleOut_Disposed()
+    {
+        var sourceDirectory = Path.Combine(TestBuildDropPath, "..", "..", "..");
+        var originalOut = Console.Out;
+
+        // Manifest output lives outside TestBuildDropPath/sourceDirectory so invocation-1's
+        // manifest files are never picked up by invocation-2's file/component scan.
+        var firstManifestDirPath = Path.Combine(Path.GetTempPath(), "sbom-e2e-" + Guid.NewGuid().ToString("N"));
+        var secondManifestDirPath = Path.Combine(Path.GetTempPath(), "sbom-e2e-" + Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            Directory.CreateDirectory(firstManifestDirPath);
+            using (var firstConsoleOut = new StringWriter())
+            {
+                Console.SetOut(firstConsoleOut);
+
+                var firstTask = new GenerateSbom
+                {
+                    BuildDropPath = TestBuildDropPath,
+                    BuildComponentPath = sourceDirectory,
+                    ManifestDirPath = firstManifestDirPath,
+                    PackageSupplier = PackageSupplier,
+                    PackageName = PackageName,
+                    PackageVersion = PackageVersion,
+                    NamespaceBaseUri = NamespaceBaseUri,
+                    BuildEngine = this.BuildEngine.Object,
+                    ManifestInfo = this.SbomSpecification,
+#if NET472
+                    SbomToolPath = SbomToolPath,
+#endif
+                };
+
+                Assert.IsTrue(firstTask.Execute());
+                var firstManifestPath = Path.Combine(firstManifestDirPath, "_manifest", this.SbomSpecificationDirectoryName, "manifest.spdx.json");
+                this.GeneratedSbomValidator.AssertSbomHasPackageData(firstManifestPath, PackageName, PackageVersion, PackageSupplier);
+            }
+
+            // firstConsoleOut is now disposed; a naive fallback to AnsiConsole.Console would still
+            // hold it and throw ObjectDisposedException on the next write attempt below.
+            Directory.CreateDirectory(secondManifestDirPath);
+            using var secondConsoleOut = new StringWriter();
+            Console.SetOut(secondConsoleOut);
+
+            var secondTask = new GenerateSbom
+            {
+                BuildDropPath = TestBuildDropPath,
+                BuildComponentPath = sourceDirectory,
+                ManifestDirPath = secondManifestDirPath,
+                PackageSupplier = PackageSupplier,
+                PackageName = PackageName,
+                PackageVersion = PackageVersion,
+                NamespaceBaseUri = NamespaceBaseUri,
+                BuildEngine = this.BuildEngine.Object,
+                ManifestInfo = this.SbomSpecification,
+#if NET472
+                SbomToolPath = SbomToolPath,
+#endif
+            };
+
+            Assert.IsTrue(secondTask.Execute());
+            var secondManifestPath = Path.Combine(secondManifestDirPath, "_manifest", this.SbomSpecificationDirectoryName, "manifest.spdx.json");
+            this.GeneratedSbomValidator.AssertSbomHasPackageData(secondManifestPath, PackageName, PackageVersion, PackageSupplier);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            if (Directory.Exists(firstManifestDirPath))
+            {
+                Directory.Delete(firstManifestDirPath, true);
+            }
+
+            if (Directory.Exists(secondManifestDirPath))
+            {
+                Directory.Delete(secondManifestDirPath, true);
+            }
+        }
     }
 
     [TestMethod]

--- a/test/Microsoft.Sbom.Targets.Tests/Utility/GeneratedSbomValidator.cs
+++ b/test/Microsoft.Sbom.Targets.Tests/Utility/GeneratedSbomValidator.cs
@@ -103,6 +103,46 @@ internal class GeneratedSbomValidator
         }
     }
 
+    /// <summary>
+    /// Lightweight validation used by tests that invoke GenerateSbom repeatedly against a shared
+    /// BuildDropPath. Unlike <see cref="AssertSbomIsValid"/>, this does not hash-compare every file
+    /// under BuildDropPath (fragile when BuildDropPath is shared across invocations/tests); it only
+    /// confirms the manifest is parseable and that component/package detection produced real data.
+    /// </summary>
+    internal void AssertSbomHasPackageData(string manifestPath, string expectedPackageName, string expectedPackageVersion, string expectedPackageSupplier)
+    {
+        Assert.IsTrue(File.Exists(manifestPath));
+
+        var manifestContent = File.ReadAllText(manifestPath);
+        var manifest = JsonConvert.DeserializeObject<dynamic>(manifestContent);
+
+        if (this.sbomSpecification.Equals(SPDX22Specification))
+        {
+            var filesValue = manifest["files"];
+            Assert.IsNotNull(filesValue);
+            Assert.IsTrue(filesValue.Count > 0, "Expected at least one file entry in the manifest.");
+
+            var packagesValue = manifest["packages"];
+            Assert.IsNotNull(packagesValue);
+            Assert.IsTrue(packagesValue.Count > 1, $"Expected component detection to report more than 1 package but found {packagesValue.Count}.");
+
+            var nameValue = manifest["name"];
+            Assert.AreEqual($"{expectedPackageName} {expectedPackageVersion}", (string)nameValue);
+
+            var creatorsValue = manifest["creationInfo"]["creators"];
+            Assert.IsTrue(creatorsValue.Count > 0);
+            Assert.IsTrue(((string)creatorsValue[0]).Contains(expectedPackageSupplier));
+        }
+        else if (this.sbomSpecification.Equals(SPDX30Specification))
+        {
+            Console.Write("SPDX 3.0 specified, validation is handled through parser and validation already.");
+        }
+        else
+        {
+            Assert.Fail("An unexpected SBOM specification was used. Please specify a valid SPDX version. Current supported versions are 2.2 and 3.0.");
+        }
+    }
+
     private IDictionary<string, IDictionary<string, string>> GetBuildDropFileHashes(string buildDropPath)
     {
         var filesHashes = new Dictionary<string, IDictionary<string, string>>();


### PR DESCRIPTION
## Summary

Fixes an `ObjectDisposedException` in `Microsoft.Sbom.Targets.GenerateSbom` when running under a reused MSBuild Server process (e.g., MSBuild Server node reuse across multiple builds in the same VS/CLI session).

Root cause, upstream context, and fix rationale are tracked in dotnet/msbuild#14691.

Fixes https://github.com/microsoft/sbom-tool/issues/712

### Root cause

`GenerateSbom` builds a fresh DI container on every task invocation via `AddSbomTool()`, which calls ComponentDetection's `AddComponentDetection()`. ComponentDetection's `DetectorProcessingService` does not receive an explicit `Spectre.Console.IAnsiConsole` from the DI container, so it falls back to the process-wide static `AnsiConsole.Console` singleton, which is bound to whatever `Console.Out` was current the first time it was touched in the process.

This is a cardinal sin of MSBuild Tasks - they _should not_ rely on ambient/environmental state. They should only interact with the build environment through the APIs/mechanisms provided by the IBuildEngineX APIs or the new TaskEnvironment contextual parameter.

Under MSBuild Server reuse, build 1 sets up a `RedirectConsoleWriter` around `Console.Out` and disposes it when build 1 finishes. Build 2 reuses the same process; ComponentDetection still holds the (now-disposed) writer via the static `AnsiConsole.Console` singleton, and any call into `DetectorProcessingService.LogTabularOutput` (which renders the "Detection Summary" table via Spectre) throws `ObjectDisposedException`, producing empty/failed SBOM generation on the second and subsequent invocations in the same process.

### Fix

`AddSbomTool()` now registers a local, non-static `IAnsiConsole` in the service collection *before* calling `AddComponentDetection()`, so ComponentDetection resolves this instance instead of falling back to the static singleton. The console is created via `AnsiConsole.Create(new AnsiConsoleSettings { Out = new AnsiConsoleOutput(TextWriter.Null) })` — a fresh, per-invocation instance backed by `TextWriter.Null` rather than the process's `Console.Out`.

This is intentional and low-risk: the only thing ComponentDetection renders through `IAnsiConsole` is a decorative "Detection Summary" table (gated by `!settings.NoSummary`) in `DetectorProcessingService.LogTabularOutput`. The same data is already independently emitted through `ILogger`, and `ServiceCollectionExtensions.CreateLogger()` in this repo already excludes that verbose per-detector timing/summary data from the console sink on purpose (it's meant for the log file only). Discarding the Spectre summary table via `TextWriter.Null` therefore has **no effect on the actual SBOM manifest, detected packages/files, or logged output** — only on a summary table that was already suppressed from the console in this tool's logging configuration.

### Testing

- New unit tests in `Microsoft.Sbom.Extensions.DependencyInjection.Tests` assert that `AddSbomTool()` resolves an `IAnsiConsole` from the container that is **not** the static `AnsiConsole.Console` singleton, across repeated container builds.
- New end-to-end regression tests in `Microsoft.Sbom.Targets.Tests` invoke `GenerateSbom` twice in-process, replacing and disposing `Console.Out` between invocations (simulating MSBuild Server's build-boundary `RedirectConsoleWriter` disposal). Both invocations succeed and produce a valid manifest with non-empty package data, on both `net8.0` and `net472`. Before the fix, the second invocation throws `ObjectDisposedException`.
- Full solution build passes (`dotnet build` and `dotnet test` on the affected projects).

### Files changed

- `src/Microsoft.Sbom.Extensions.DependencyInjection/ServiceCollectionExtensions.cs` — register invocation-local `IAnsiConsole` before `AddComponentDetection()`.
- `src/Microsoft.Sbom.Extensions.DependencyInjection/Microsoft.Sbom.Extensions.DependencyInjection.csproj` — explicit `Spectre.Console` package reference (central package management).
- `test/Microsoft.Sbom.Extensions.DependencyInjection.Tests/ServiceCollectionExtensionsTests.cs` — new DI resolution regression tests.
- `test/Microsoft.Sbom.Targets.Tests/AbstractGenerateSbomTaskTests.cs` — new repeated in-process invocation regression test.
- `test/Microsoft.Sbom.Targets.Tests/GeneratedSbomValidator.cs` — new lightweight package-data validator assertion used by the regression test.

Closes/relates to dotnet/msbuild#14691.